### PR TITLE
Add Tests and Clean up TodoController

### DIFF
--- a/hs_err_pid26680.log
+++ b/hs_err_pid26680.log
@@ -1,0 +1,775 @@
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (malloc) failed to allocate 2129296 bytes. Error detail: Chunk::new
+# Possible reasons:
+#   The system is out of physical RAM or swap space
+#   This process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap
+# Possible solutions:
+#   Reduce memory load on the system
+#   Increase physical memory or swap space
+#   Check if swap backing store is full
+#   Decrease Java heap size (-Xmx/-Xms)
+#   Decrease number of Java threads
+#   Decrease Java thread stack sizes (-Xss)
+#   Set larger code cache with -XX:ReservedCodeCacheSize=
+#   JVM is running with Unscaled Compressed Oops mode in which the Java heap is
+#     placed in the first 4GB address space. The Java Heap base address is the
+#     maximum limit for the native heap growth. Please use -XX:HeapBaseMinAddress
+#     to set the Java Heap base and to place the Java Heap above 4GB virtual address.
+# This output file may be truncated or incomplete.
+#
+#  Out of Memory Error (arena.cpp:168), pid=26680, tid=11748
+#
+# JRE version: OpenJDK Runtime Environment Temurin-21.0.9+10 (21.0.9+10) (build 21.0.9+10-LTS)
+# Java VM: OpenJDK 64-Bit Server VM Temurin-21.0.9+10 (21.0.9+10-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, parallel gc, windows-amd64)
+# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: --add-modules=ALL-SYSTEM --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Djava.import.generatesMetadataFilesAtProjectRoot=false -DDetectVMInstallationsJob.disabled=true -Dfile.encoding=utf8 -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable -javaagent:c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\lombok\lombok-1.18.39-4050.jar -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=c:\Users\prcri\AppData\Roaming\Code\User\workspaceStorage\9bac68a4509a4c6ff0f03304305a388a\redhat.java -Daether.dependencyCollector.impl=bf c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\server\plugins\org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar -configuration c:\Users\prcri\AppData\Roaming\Code\User\globalStorage\redhat.java\1.51.0\config_win -data c:\Users\prcri\AppData\Roaming\Code\User\workspaceStorage\9bac68a4509a4c6ff0f03304305a388a\redhat.java\jdt_ws --pipe=\\.\pipe\lsp-3076be3d7f3b703a6f480eed6a94ad77-sock
+
+Host: AMD Ryzen 5 7535HS with Radeon Graphics        , 12 cores, 7G,  Windows 11 , 64 bit Build 26100 (10.0.26100.7623)
+Time: Wed Jan 28 10:42:17 2026 Central Standard Time elapsed time: 14.602111 seconds (0d 0h 0m 14s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x0000013a1b799e80):  JavaThread "C2 CompilerThread0" daemon [_thread_in_native, id=11748, stack(0x0000000241500000,0x0000000241600000) (1024K)]
+
+
+Current CompileTask:
+C2:14603 3897       4       org.lombokweb.asm.ClassReader::readMethod (1070 bytes)
+
+Stack: [0x0000000241500000,0x0000000241600000]
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [jvm.dll+0x6d6e29]
+V  [jvm.dll+0x8b4b76]
+V  [jvm.dll+0x8b712e]
+V  [jvm.dll+0x8b7813]
+V  [jvm.dll+0x283d86]
+V  [jvm.dll+0xc66ed]
+V  [jvm.dll+0xc6c31]
+V  [jvm.dll+0x3be501]
+V  [jvm.dll+0x1e3d59]
+V  [jvm.dll+0x24c0f3]
+V  [jvm.dll+0x24b580]
+V  [jvm.dll+0x1cb13e]
+V  [jvm.dll+0x25b29d]
+V  [jvm.dll+0x25982a]
+V  [jvm.dll+0x3f7ea6]
+V  [jvm.dll+0x85e9ad]
+V  [jvm.dll+0x6d565d]
+C  [ucrtbase.dll+0x37b0]
+C  [KERNEL32.DLL+0x2e8d7]
+C  [ntdll.dll+0x8c53c]
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x0000013a207fa370, length=26, elements={
+0x00000139c0054360, 0x0000013a1b7744b0, 0x00000139d86dc1c0, 0x0000013a1b777910,
+0x0000013a1b778560, 0x0000013a1b77eda0, 0x0000013a1b785e20, 0x0000013a1b799e80,
+0x0000013a1b79e480, 0x0000013a1b916f80, 0x0000013a1ba7a720, 0x0000013a205c7710,
+0x0000013a205ba790, 0x0000013a204afeb0, 0x0000013a20576a20, 0x0000013a20cfbaf0,
+0x0000013a20b2f1d0, 0x0000013a20a7c8d0, 0x0000013a20a7c240, 0x0000013a20a7d5f0,
+0x0000013a20a7dc80, 0x0000013a20a7f030, 0x0000013a20a7bbb0, 0x0000013a20a7e310,
+0x0000013a20a7e9a0, 0x0000013a22f7f500
+}
+
+Java Threads: ( => current thread )
+  0x00000139c0054360 JavaThread "main"                              [_thread_in_Java, id=23764, stack(0x0000000240b00000,0x0000000240c00000) (1024K)]
+  0x0000013a1b7744b0 JavaThread "Reference Handler"          daemon [_thread_blocked, id=37012, stack(0x0000000240f00000,0x0000000241000000) (1024K)]
+  0x00000139d86dc1c0 JavaThread "Finalizer"                  daemon [_thread_blocked, id=29592, stack(0x0000000241000000,0x0000000241100000) (1024K)]
+  0x0000013a1b777910 JavaThread "Signal Dispatcher"          daemon [_thread_blocked, id=37748, stack(0x0000000241100000,0x0000000241200000) (1024K)]
+  0x0000013a1b778560 JavaThread "Attach Listener"            daemon [_thread_blocked, id=29956, stack(0x0000000241200000,0x0000000241300000) (1024K)]
+  0x0000013a1b77eda0 JavaThread "Service Thread"             daemon [_thread_blocked, id=30632, stack(0x0000000241300000,0x0000000241400000) (1024K)]
+  0x0000013a1b785e20 JavaThread "Monitor Deflation Thread"   daemon [_thread_blocked, id=19984, stack(0x0000000241400000,0x0000000241500000) (1024K)]
+=>0x0000013a1b799e80 JavaThread "C2 CompilerThread0"         daemon [_thread_in_native, id=11748, stack(0x0000000241500000,0x0000000241600000) (1024K)]
+  0x0000013a1b79e480 JavaThread "C1 CompilerThread0"         daemon [_thread_in_native, id=38448, stack(0x0000000241600000,0x0000000241700000) (1024K)]
+  0x0000013a1b916f80 JavaThread "Common-Cleaner"             daemon [_thread_blocked, id=28156, stack(0x0000000241700000,0x0000000241800000) (1024K)]
+  0x0000013a1ba7a720 JavaThread "Notification Thread"        daemon [_thread_blocked, id=31548, stack(0x0000000241800000,0x0000000241900000) (1024K)]
+  0x0000013a205c7710 JavaThread "Active Thread: Equinox Container: 35edb800-6080-4d9a-acc1-7d494f23a175"        [_thread_blocked, id=31864, stack(0x0000000241f00000,0x0000000242000000) (1024K)]
+  0x0000013a205ba790 JavaThread "Refresh Thread: Equinox Container: 35edb800-6080-4d9a-acc1-7d494f23a175" daemon [_thread_blocked, id=11696, stack(0x0000000242100000,0x0000000242200000) (1024K)]
+  0x0000013a204afeb0 JavaThread "Framework Event Dispatcher: Equinox Container: 35edb800-6080-4d9a-acc1-7d494f23a175" daemon [_thread_blocked, id=11296, stack(0x0000000242200000,0x0000000242300000) (1024K)]
+  0x0000013a20576a20 JavaThread "Start Level: Equinox Container: 35edb800-6080-4d9a-acc1-7d494f23a175" daemon [_thread_blocked, id=1028, stack(0x0000000242300000,0x0000000242400000) (1024K)]
+  0x0000013a20cfbaf0 JavaThread "Bundle File Closer"         daemon [_thread_blocked, id=35904, stack(0x0000000242600000,0x0000000242700000) (1024K)]
+  0x0000013a20b2f1d0 JavaThread "SCR Component Actor"        daemon [_thread_blocked, id=35064, stack(0x0000000242700000,0x0000000242800000) (1024K)]
+  0x0000013a20a7c8d0 JavaThread "Worker-JM"                         [_thread_blocked, id=36988, stack(0x0000000242800000,0x0000000242900000) (1024K)]
+  0x0000013a20a7c240 JavaThread "JNA Cleaner"                daemon [_thread_blocked, id=31060, stack(0x0000000242900000,0x0000000242a00000) (1024K)]
+  0x0000013a20a7d5f0 JavaThread "Worker-0: Repository registry initialization"        [_thread_blocked, id=10104, stack(0x0000000242a00000,0x0000000242b00000) (1024K)]
+  0x0000013a20a7dc80 JavaThread "Worker-1: Updating Maven Dependencies"        [_thread_in_vm, id=3464, stack(0x0000000242b00000,0x0000000242c00000) (1024K)]
+  0x0000013a20a7f030 JavaThread "Worker-2: Initialize After Load"        [_thread_in_native, id=38148, stack(0x0000000242c00000,0x0000000242d00000) (1024K)]
+  0x0000013a20a7bbb0 JavaThread "Worker-3: Loading available Gradle versions"        [_thread_in_native, id=37796, stack(0x0000000242d00000,0x0000000242e00000) (1024K)]
+  0x0000013a20a7e310 JavaThread "Java indexing"              daemon [_thread_blocked, id=37716, stack(0x0000000242e00000,0x0000000242f00000) (1024K)]
+  0x0000013a20a7e9a0 JavaThread "Worker-4"                          [_thread_blocked, id=35712, stack(0x0000000243100000,0x0000000243200000) (1024K)]
+  0x0000013a22f7f500 JavaThread "Worker-5"                          [_thread_blocked, id=4836, stack(0x0000000243200000,0x0000000243300000) (1024K)]
+Total: 26
+
+Other Threads:
+  0x00000139d86c3b30 VMThread "VM Thread"                           [id=37080, stack(0x0000000240e00000,0x0000000240f00000) (1024K)]
+  0x00000139d85bca00 WatcherThread "VM Periodic Task Thread"        [id=12000, stack(0x0000000240d00000,0x0000000240e00000) (1024K)]
+  0x00000139c00739d0 WorkerThread "GC Thread#0"                     [id=27284, stack(0x0000000240c00000,0x0000000240d00000) (1024K)]
+  0x0000013a202c4310 WorkerThread "GC Thread#1"                     [id=32912, stack(0x0000000241900000,0x0000000241a00000) (1024K)]
+  0x0000013a202c46b0 WorkerThread "GC Thread#2"                     [id=21204, stack(0x0000000241a00000,0x0000000241b00000) (1024K)]
+  0x0000013a202c4a50 WorkerThread "GC Thread#3"                     [id=30704, stack(0x0000000241b00000,0x0000000241c00000) (1024K)]
+  0x0000013a202c4df0 WorkerThread "GC Thread#4"                     [id=34608, stack(0x0000000241c00000,0x0000000241d00000) (1024K)]
+  0x0000013a2029c5d0 WorkerThread "GC Thread#5"                     [id=12976, stack(0x0000000241d00000,0x0000000241e00000) (1024K)]
+  0x0000013a2029c970 WorkerThread "GC Thread#6"                     [id=27852, stack(0x0000000241e00000,0x0000000241f00000) (1024K)]
+  0x0000013a204c51b0 WorkerThread "GC Thread#7"                     [id=24188, stack(0x0000000242000000,0x0000000242100000) (1024K)]
+  0x0000013a20590c90 WorkerThread "GC Thread#8"                     [id=38292, stack(0x0000000242400000,0x0000000242500000) (1024K)]
+  0x0000013a2058fa70 WorkerThread "GC Thread#9"                     [id=36572, stack(0x0000000242500000,0x0000000242600000) (1024K)]
+Total: 12
+
+Threads with active compile tasks:
+C2 CompilerThread0  14725 3897       4       org.lombokweb.asm.ClassReader::readMethod (1070 bytes)
+Total: 1
+
+VM state: not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread:  ([mutex/lock_event])
+[0x00007ffc5d56d570] Threads_lock - owner thread: 0x00000139d86c3b30
+[0x00007ffc5d56d670] Heap_lock - owner thread: 0x0000013a20a7bbb0
+
+Heap address: 0x0000000080000000, size: 2048 MB, Compressed Oops mode: 32-bit
+
+CDS archive(s) mapped at: [0x00000139d9000000-0x00000139d9ba0000-0x00000139d9ba0000), size 12189696, SharedBaseAddress: 0x00000139d9000000, ArchiveRelocationMode: 1.
+Compressed class space mapped at: 0x00000139da000000-0x0000013a1a000000, reserved size: 1073741824
+Narrow klass base: 0x00000139d9000000, Narrow klass shift: 0, Narrow klass range: 0x100000000
+
+GC Precious Log:
+ CardTable entry size: 512
+ CPUs: 12 total, 12 available
+ Memory: 7381M
+ Large Page Support: Disabled
+ NUMA Support: Disabled
+ Compressed Oops: Enabled (32-bit)
+ Alignments: Space 512K, Generation 512K, Heap 2M
+ Heap Min Capacity: 100M
+ Heap Initial Capacity: 100M
+ Heap Max Capacity: 2G
+ Pre-touch: Disabled
+ Parallel Workers: 10
+
+Heap:
+ PSYoungGen      total 24576K, used 1278K [0x00000000d5580000, 0x00000000d7180000, 0x0000000100000000)
+  eden space 22016K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6b00000)
+  from space 2560K, 49% used [0x00000000d6c80000,0x00000000d6dbfa90,0x00000000d6f00000)
+  to   space 2048K, 0% used [0x00000000d6f80000,0x00000000d6f80000,0x00000000d7180000)
+ ParOldGen       total 68608K, used 18221K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 26% used [0x0000000080000000,0x00000000811cb6e8,0x0000000084300000)
+ Metaspace       used 34746K, committed 35840K, reserved 1114112K
+  class space    used 3601K, committed 4096K, reserved 1048576K
+
+Card table byte_map: [0x00000139d3a20000,0x00000139d3e30000] _byte_map_base: 0x00000139d3620000
+
+Marking Bits: (ParMarkBitMap*) 0x00007ffc5d572460
+ Begin Bits: [0x00000139d40e0000, 0x00000139d60e0000)
+ End Bits:   [0x00000139d60e0000, 0x00000139d80e0000)
+
+Polling page: 0x00000139bfa50000
+
+Metaspace:
+
+Usage:
+  Non-class:     30.42 MB used.
+      Class:      3.52 MB used.
+       Both:     33.93 MB used.
+
+Virtual space:
+  Non-class space:       64.00 MB reserved,      31.00 MB ( 48%) committed,  1 nodes.
+      Class space:        1.00 GB reserved,       4.00 MB ( <1%) committed,  1 nodes.
+             Both:        1.06 GB reserved,      35.00 MB (  3%) committed. 
+
+Chunk freelists:
+   Non-Class:  416.00 KB
+       Class:  11.87 MB
+        Both:  12.27 MB
+
+MaxMetaspaceSize: unlimited
+CompressedClassSpaceSize: 1.00 GB
+Initial GC threshold: 21.00 MB
+Current GC threshold: 35.00 MB
+CDS: on
+ - commit_granule_bytes: 65536.
+ - commit_granule_words: 8192.
+ - virtual_space_node_default_size: 8388608.
+ - enlarge_chunks_in_place: 1.
+ - use_allocation_guard: 0.
+
+
+Internal statistics:
+
+num_allocs_failed_limit: 8.
+num_arena_births: 766.
+num_arena_deaths: 14.
+num_vsnodes_births: 2.
+num_vsnodes_deaths: 0.
+num_space_committed: 560.
+num_space_uncommitted: 0.
+num_chunks_returned_to_freelist: 22.
+num_chunks_taken_from_freelist: 2255.
+num_chunk_merges: 10.
+num_chunk_splits: 1413.
+num_chunks_enlarged: 825.
+num_inconsistent_stats: 0.
+
+CodeHeap 'non-profiled nmethods': size=120000Kb used=1771Kb max_used=1771Kb free=118228Kb
+ bounds [0x00000139cc310000, 0x00000139cc580000, 0x00000139d3840000]
+CodeHeap 'profiled nmethods': size=120000Kb used=9660Kb max_used=9660Kb free=110339Kb
+ bounds [0x00000139c4840000, 0x00000139c51b0000, 0x00000139cbd70000]
+CodeHeap 'non-nmethods': size=5760Kb used=1352Kb max_used=1352Kb free=4407Kb
+ bounds [0x00000139cbd70000, 0x00000139cbfe0000, 0x00000139cc310000]
+CodeCache: size=245760Kb, used=12783Kb, max_used=12783Kb, free=232974Kb
+ total_blobs=5229, nmethods=4580, adapters=555, full_count=0
+Compilation: enabled, stopped_count=0, restarted_count=0
+
+Compilation events (20 events):
+Event: 13.577 Thread 0x0000013a1b79e480 4523       2       aQute.bnd.header.OSGiHeader$$Lambda/0x00000139da128800::apply (16 bytes)
+Event: 13.577 Thread 0x0000013a1b79e480 nmethod 4523 0x00000139c5177990 code [0x00000139c5177b40, 0x00000139c5177cd8]
+Event: 13.577 Thread 0x0000013a1b79e480 4524       2       org.eclipse.core.runtime.ServiceCaller$ReferenceAndService::bundleChanged (32 bytes)
+Event: 13.577 Thread 0x0000013a1b79e480 nmethod 4524 0x00000139c5177d90 code [0x00000139c5177f80, 0x00000139c5178388]
+Event: 13.578 Thread 0x0000013a1b79e480 4525       2       java.util.logging.Logger::isLoggable (27 bytes)
+Event: 13.578 Thread 0x0000013a1b79e480 nmethod 4525 0x00000139c5178710 code [0x00000139c51788c0, 0x00000139c5178a20]
+Event: 13.578 Thread 0x0000013a1b79e480 4526       2       java.util.EnumSet::noneOf (63 bytes)
+Event: 13.578 Thread 0x0000013a1b79e480 nmethod 4526 0x00000139c5178b10 code [0x00000139c5178d40, 0x00000139c51792b0]
+Event: 13.578 Thread 0x0000013a1b79e480 4528 %     3       org.objectweb.asm.ClassReader::readUtf @ 18 (161 bytes)
+Event: 13.579 Thread 0x0000013a1b79e480 nmethod 4528% 0x00000139c5179610 code [0x00000139c5179800, 0x00000139c5179cf8]
+Event: 13.579 Thread 0x0000013a1b79e480 4529       2       java.util.zip.ZipFile$Source::initCEN (612 bytes)
+Event: 13.580 Thread 0x0000013a1b79e480 nmethod 4529 0x00000139c5179f90 code [0x00000139c517a340, 0x00000139c517bb98]
+Event: 13.580 Thread 0x0000013a1b79e480 4534       2       java.util.regex.Pattern$BmpCharPropertyGreedy::match (89 bytes)
+Event: 13.581 Thread 0x0000013a1b79e480 nmethod 4534 0x00000139c517cb10 code [0x00000139c517cce0, 0x00000139c517d050]
+Event: 13.581 Thread 0x0000013a1b79e480 4535       3       java.util.concurrent.locks.ReentrantReadWriteLock$Sync::tryReleaseShared (146 bytes)
+Event: 13.581 Thread 0x0000013a1b79e480 nmethod 4535 0x00000139c517d210 code [0x00000139c517d460, 0x00000139c517df28]
+Event: 13.581 Thread 0x0000013a1b79e480 4532       3       java.util.concurrent.locks.ReentrantReadWriteLock$Sync::tryAcquireShared (177 bytes)
+Event: 13.582 Thread 0x0000013a1b79e480 nmethod 4532 0x00000139c517e310 code [0x00000139c517e5a0, 0x00000139c517f2c0]
+Event: 13.582 Thread 0x0000013a1b79e480 4533   !   2       org.eclipse.osgi.internal.framework.EquinoxBundle::adapt0 (939 bytes)
+Event: 14.593 Thread 0x0000013a1b79e480 nmethod 4533 0x00000139c517f710 code [0x00000139c517ff80, 0x00000139c5182ab8]
+
+GC Heap History (20 events):
+Event: 4.435 GC heap before
+{Heap before GC invocations=3 (full 0):
+ PSYoungGen      total 29696K, used 29685K [0x00000000d5580000, 0x00000000d7680000, 0x0000000100000000)
+  eden space 25600K, 99% used [0x00000000d5580000,0x00000000d6e7ff48,0x00000000d6e80000)
+  from space 4096K, 99% used [0x00000000d7280000,0x00000000d767d810,0x00000000d7680000)
+  to   space 4096K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7280000)
+ ParOldGen       total 68608K, used 2009K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 2% used [0x0000000080000000,0x00000000801f65e0,0x0000000084300000)
+ Metaspace       used 9454K, committed 9728K, reserved 1114112K
+  class space    used 1008K, committed 1152K, reserved 1048576K
+}
+Event: 4.441 GC heap after
+{Heap after GC invocations=3 (full 0):
+ PSYoungGen      total 29696K, used 4072K [0x00000000d5580000, 0x00000000d7680000, 0x0000000100000000)
+  eden space 25600K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6e80000)
+  from space 4096K, 99% used [0x00000000d6e80000,0x00000000d727a318,0x00000000d7280000)
+  to   space 4096K, 0% used [0x00000000d7280000,0x00000000d7280000,0x00000000d7680000)
+ ParOldGen       total 68608K, used 4977K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 7% used [0x0000000080000000,0x00000000804dc428,0x0000000084300000)
+ Metaspace       used 9454K, committed 9728K, reserved 1114112K
+  class space    used 1008K, committed 1152K, reserved 1048576K
+}
+Event: 5.249 GC heap before
+{Heap before GC invocations=4 (full 0):
+ PSYoungGen      total 29696K, used 29672K [0x00000000d5580000, 0x00000000d7680000, 0x0000000100000000)
+  eden space 25600K, 100% used [0x00000000d5580000,0x00000000d6e80000,0x00000000d6e80000)
+  from space 4096K, 99% used [0x00000000d6e80000,0x00000000d727a318,0x00000000d7280000)
+  to   space 4096K, 0% used [0x00000000d7280000,0x00000000d7280000,0x00000000d7680000)
+ ParOldGen       total 68608K, used 4977K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 7% used [0x0000000080000000,0x00000000804dc428,0x0000000084300000)
+ Metaspace       used 11711K, committed 12096K, reserved 1114112K
+  class space    used 1238K, committed 1408K, reserved 1048576K
+}
+Event: 5.254 GC heap after
+{Heap after GC invocations=4 (full 0):
+ PSYoungGen      total 29696K, used 4090K [0x00000000d5580000, 0x00000000d7680000, 0x0000000100000000)
+  eden space 25600K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6e80000)
+  from space 4096K, 99% used [0x00000000d7280000,0x00000000d767e878,0x00000000d7680000)
+  to   space 4096K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7280000)
+ ParOldGen       total 68608K, used 6694K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 9% used [0x0000000080000000,0x0000000080689be8,0x0000000084300000)
+ Metaspace       used 11711K, committed 12096K, reserved 1114112K
+  class space    used 1238K, committed 1408K, reserved 1048576K
+}
+Event: 5.947 GC heap before
+{Heap before GC invocations=5 (full 0):
+ PSYoungGen      total 29696K, used 29690K [0x00000000d5580000, 0x00000000d7680000, 0x0000000100000000)
+  eden space 25600K, 100% used [0x00000000d5580000,0x00000000d6e80000,0x00000000d6e80000)
+  from space 4096K, 99% used [0x00000000d7280000,0x00000000d767e878,0x00000000d7680000)
+  to   space 4096K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7280000)
+ ParOldGen       total 68608K, used 6694K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 9% used [0x0000000080000000,0x0000000080689be8,0x0000000084300000)
+ Metaspace       used 15718K, committed 16320K, reserved 1114112K
+  class space    used 1628K, committed 1920K, reserved 1048576K
+}
+Event: 5.951 GC heap after
+{Heap after GC invocations=5 (full 0):
+ PSYoungGen      total 29184K, used 4078K [0x00000000d5580000, 0x00000000d7900000, 0x0000000100000000)
+  eden space 25088K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6e00000)
+  from space 4096K, 99% used [0x00000000d6e80000,0x00000000d727bb10,0x00000000d7280000)
+  to   space 5632K, 0% used [0x00000000d7380000,0x00000000d7380000,0x00000000d7900000)
+ ParOldGen       total 68608K, used 7831K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 11% used [0x0000000080000000,0x00000000807a5c08,0x0000000084300000)
+ Metaspace       used 15718K, committed 16320K, reserved 1114112K
+  class space    used 1628K, committed 1920K, reserved 1048576K
+}
+Event: 8.637 GC heap before
+{Heap before GC invocations=6 (full 0):
+ PSYoungGen      total 29184K, used 29166K [0x00000000d5580000, 0x00000000d7900000, 0x0000000100000000)
+  eden space 25088K, 100% used [0x00000000d5580000,0x00000000d6e00000,0x00000000d6e00000)
+  from space 4096K, 99% used [0x00000000d6e80000,0x00000000d727bb10,0x00000000d7280000)
+  to   space 5632K, 0% used [0x00000000d7380000,0x00000000d7380000,0x00000000d7900000)
+ ParOldGen       total 68608K, used 7831K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 11% used [0x0000000080000000,0x00000000807a5c08,0x0000000084300000)
+ Metaspace       used 18807K, committed 19520K, reserved 1114112K
+  class space    used 1976K, committed 2240K, reserved 1048576K
+}
+Event: 8.642 GC heap after
+{Heap after GC invocations=6 (full 0):
+ PSYoungGen      total 29696K, used 4841K [0x00000000d5580000, 0x00000000d7880000, 0x0000000100000000)
+  eden space 24576K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6d80000)
+  from space 5120K, 94% used [0x00000000d7380000,0x00000000d783a760,0x00000000d7880000)
+  to   space 5120K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7380000)
+ ParOldGen       total 68608K, used 7839K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 11% used [0x0000000080000000,0x00000000807a7c08,0x0000000084300000)
+ Metaspace       used 18807K, committed 19520K, reserved 1114112K
+  class space    used 1976K, committed 2240K, reserved 1048576K
+}
+Event: 8.956 GC heap before
+{Heap before GC invocations=7 (full 0):
+ PSYoungGen      total 29696K, used 24430K [0x00000000d5580000, 0x00000000d7880000, 0x0000000100000000)
+  eden space 24576K, 79% used [0x00000000d5580000,0x00000000d68a1488,0x00000000d6d80000)
+  from space 5120K, 94% used [0x00000000d7380000,0x00000000d783a760,0x00000000d7880000)
+  to   space 5120K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7380000)
+ ParOldGen       total 68608K, used 7839K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 11% used [0x0000000080000000,0x00000000807a7c08,0x0000000084300000)
+ Metaspace       used 20748K, committed 21504K, reserved 1114112K
+  class space    used 2198K, committed 2560K, reserved 1048576K
+}
+Event: 8.960 GC heap after
+{Heap after GC invocations=7 (full 0):
+ PSYoungGen      total 29184K, used 4448K [0x00000000d5580000, 0x00000000d7780000, 0x0000000100000000)
+  eden space 24576K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6d80000)
+  from space 4608K, 96% used [0x00000000d6e80000,0x00000000d72d80a0,0x00000000d7300000)
+  to   space 4608K, 0% used [0x00000000d7300000,0x00000000d7300000,0x00000000d7780000)
+ ParOldGen       total 68608K, used 9422K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 13% used [0x0000000080000000,0x0000000080933ba0,0x0000000084300000)
+ Metaspace       used 20748K, committed 21504K, reserved 1114112K
+  class space    used 2198K, committed 2560K, reserved 1048576K
+}
+Event: 8.960 GC heap before
+{Heap before GC invocations=8 (full 1):
+ PSYoungGen      total 29184K, used 4448K [0x00000000d5580000, 0x00000000d7780000, 0x0000000100000000)
+  eden space 24576K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6d80000)
+  from space 4608K, 96% used [0x00000000d6e80000,0x00000000d72d80a0,0x00000000d7300000)
+  to   space 4608K, 0% used [0x00000000d7300000,0x00000000d7300000,0x00000000d7780000)
+ ParOldGen       total 68608K, used 9422K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 13% used [0x0000000080000000,0x0000000080933ba0,0x0000000084300000)
+ Metaspace       used 20748K, committed 21504K, reserved 1114112K
+  class space    used 2198K, committed 2560K, reserved 1048576K
+}
+Event: 9.058 GC heap after
+{Heap after GC invocations=8 (full 1):
+ PSYoungGen      total 29184K, used 0K [0x00000000d5580000, 0x00000000d7780000, 0x0000000100000000)
+  eden space 24576K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6d80000)
+  from space 4608K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7300000)
+  to   space 4608K, 0% used [0x00000000d7300000,0x00000000d7300000,0x00000000d7780000)
+ ParOldGen       total 68608K, used 13196K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 19% used [0x0000000080000000,0x0000000080ce3000,0x0000000084300000)
+ Metaspace       used 20736K, committed 21504K, reserved 1114112K
+  class space    used 2194K, committed 2560K, reserved 1048576K
+}
+Event: 9.340 GC heap before
+{Heap before GC invocations=9 (full 1):
+ PSYoungGen      total 29184K, used 24576K [0x00000000d5580000, 0x00000000d7780000, 0x0000000100000000)
+  eden space 24576K, 100% used [0x00000000d5580000,0x00000000d6d80000,0x00000000d6d80000)
+  from space 4608K, 0% used [0x00000000d6e80000,0x00000000d6e80000,0x00000000d7300000)
+  to   space 4608K, 0% used [0x00000000d7300000,0x00000000d7300000,0x00000000d7780000)
+ ParOldGen       total 68608K, used 13196K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 19% used [0x0000000080000000,0x0000000080ce3000,0x0000000084300000)
+ Metaspace       used 23289K, committed 24128K, reserved 1114112K
+  class space    used 2356K, committed 2688K, reserved 1048576K
+}
+Event: 9.341 GC heap after
+{Heap after GC invocations=9 (full 1):
+ PSYoungGen      total 25088K, used 811K [0x00000000d5580000, 0x00000000d7400000, 0x0000000100000000)
+  eden space 24064K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6d00000)
+  from space 1024K, 79% used [0x00000000d7300000,0x00000000d73cadc8,0x00000000d7400000)
+  to   space 2560K, 0% used [0x00000000d6f00000,0x00000000d6f00000,0x00000000d7180000)
+ ParOldGen       total 68608K, used 13196K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 19% used [0x0000000080000000,0x0000000080ce3000,0x0000000084300000)
+ Metaspace       used 23289K, committed 24128K, reserved 1114112K
+  class space    used 2356K, committed 2688K, reserved 1048576K
+}
+Event: 9.940 GC heap before
+{Heap before GC invocations=10 (full 1):
+ PSYoungGen      total 25088K, used 24875K [0x00000000d5580000, 0x00000000d7400000, 0x0000000100000000)
+  eden space 24064K, 100% used [0x00000000d5580000,0x00000000d6d00000,0x00000000d6d00000)
+  from space 1024K, 79% used [0x00000000d7300000,0x00000000d73cadc8,0x00000000d7400000)
+  to   space 2560K, 0% used [0x00000000d6f00000,0x00000000d6f00000,0x00000000d7180000)
+ ParOldGen       total 68608K, used 13196K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 19% used [0x0000000080000000,0x0000000080ce3000,0x0000000084300000)
+ Metaspace       used 26534K, committed 27392K, reserved 1114112K
+  class space    used 2606K, committed 2944K, reserved 1048576K
+}
+Event: 9.942 GC heap after
+{Heap after GC invocations=10 (full 1):
+ PSYoungGen      total 25600K, used 1885K [0x00000000d5580000, 0x00000000d7380000, 0x0000000100000000)
+  eden space 23552K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6c80000)
+  from space 2048K, 92% used [0x00000000d6f00000,0x00000000d70d7420,0x00000000d7100000)
+  to   space 2560K, 0% used [0x00000000d7100000,0x00000000d7100000,0x00000000d7380000)
+ ParOldGen       total 68608K, used 13985K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 20% used [0x0000000080000000,0x0000000080da8510,0x0000000084300000)
+ Metaspace       used 26534K, committed 27392K, reserved 1114112K
+  class space    used 2606K, committed 2944K, reserved 1048576K
+}
+Event: 10.136 GC heap before
+{Heap before GC invocations=11 (full 1):
+ PSYoungGen      total 25600K, used 25437K [0x00000000d5580000, 0x00000000d7380000, 0x0000000100000000)
+  eden space 23552K, 100% used [0x00000000d5580000,0x00000000d6c80000,0x00000000d6c80000)
+  from space 2048K, 92% used [0x00000000d6f00000,0x00000000d70d7420,0x00000000d7100000)
+  to   space 2560K, 0% used [0x00000000d7100000,0x00000000d7100000,0x00000000d7380000)
+ ParOldGen       total 68608K, used 13985K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 20% used [0x0000000080000000,0x0000000080da8510,0x0000000084300000)
+ Metaspace       used 27976K, committed 28864K, reserved 1114112K
+  class space    used 2789K, committed 3136K, reserved 1048576K
+}
+Event: 10.137 GC heap after
+{Heap after GC invocations=11 (full 1):
+ PSYoungGen      total 25088K, used 1827K [0x00000000d5580000, 0x00000000d7300000, 0x0000000100000000)
+  eden space 23040K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6c00000)
+  from space 2048K, 89% used [0x00000000d7100000,0x00000000d72c8e90,0x00000000d7300000)
+  to   space 2048K, 0% used [0x00000000d6f00000,0x00000000d6f00000,0x00000000d7100000)
+ ParOldGen       total 68608K, used 14593K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 21% used [0x0000000080000000,0x0000000080e405e0,0x0000000084300000)
+ Metaspace       used 27976K, committed 28864K, reserved 1114112K
+  class space    used 2789K, committed 3136K, reserved 1048576K
+}
+Event: 13.414 GC heap before
+{Heap before GC invocations=12 (full 1):
+ PSYoungGen      total 25088K, used 24867K [0x00000000d5580000, 0x00000000d7300000, 0x0000000100000000)
+  eden space 23040K, 100% used [0x00000000d5580000,0x00000000d6c00000,0x00000000d6c00000)
+  from space 2048K, 89% used [0x00000000d7100000,0x00000000d72c8e90,0x00000000d7300000)
+  to   space 2048K, 0% used [0x00000000d6f00000,0x00000000d6f00000,0x00000000d7100000)
+ ParOldGen       total 68608K, used 14593K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 21% used [0x0000000080000000,0x0000000080e405e0,0x0000000084300000)
+ Metaspace       used 31564K, committed 32512K, reserved 1114112K
+  class space    used 3205K, committed 3584K, reserved 1048576K
+}
+Event: 13.416 GC heap after
+{Heap after GC invocations=12 (full 1):
+ PSYoungGen      total 24576K, used 1601K [0x00000000d5580000, 0x00000000d7180000, 0x0000000100000000)
+  eden space 22528K, 0% used [0x00000000d5580000,0x00000000d5580000,0x00000000d6b80000)
+  from space 2048K, 78% used [0x00000000d6f00000,0x00000000d7090620,0x00000000d7100000)
+  to   space 512K, 0% used [0x00000000d7100000,0x00000000d7100000,0x00000000d7180000)
+ ParOldGen       total 68608K, used 16029K [0x0000000080000000, 0x0000000084300000, 0x00000000d5580000)
+  object space 68608K, 23% used [0x0000000080000000,0x0000000080fa74e8,0x0000000084300000)
+ Metaspace       used 31564K, committed 32512K, reserved 1114112K
+  class space    used 3205K, committed 3584K, reserved 1048576K
+}
+
+Dll operation events (10 events):
+Event: 0.038 Loaded shared library c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\java.dll
+Event: 0.374 Loaded shared library c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\zip.dll
+Event: 0.468 Loaded shared library C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\instrument.dll
+Event: 0.508 Loaded shared library C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\net.dll
+Event: 0.513 Loaded shared library C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\nio.dll
+Event: 0.519 Loaded shared library C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\zip.dll
+Event: 0.554 Loaded shared library C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\jimage.dll
+Event: 0.692 Loaded shared library c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\verify.dll
+Event: 3.962 Loaded shared library C:\Users\prcri\AppData\Roaming\Code\User\globalStorage\redhat.java\1.51.0\config_win\org.eclipse.equinox.launcher\org.eclipse.equinox.launcher.win32.win32.x86_64_1.2.1400.v20250801-0854\eclipse_11916.dll
+Event: 8.095 Loaded shared library C:\Users\prcri\AppData\Local\Temp\jna-106929304\jna15381168658908417585.dll
+
+Deoptimization events (20 events):
+Event: 13.535 Thread 0x0000013a20576a20 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00000139cc421d68 relative=0x0000000000000388
+Event: 13.535 Thread 0x0000013a20576a20 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00000139cc421d68 method=java.lang.Integer.parseInt(Ljava/lang/String;I)I @ 119 c2
+Event: 13.535 Thread 0x0000013a20576a20 DEOPT PACKING pc=0x00000139cc421d68 sp=0x00000002423fcbe0
+Event: 13.535 Thread 0x0000013a20576a20 DEOPT UNPACKING pc=0x00000139cbdc3aa2 sp=0x00000002423fcb48 mode 2
+Event: 13.547 Thread 0x0000013a20576a20 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00000139cc442628 relative=0x0000000000000ba8
+Event: 13.547 Thread 0x0000013a20576a20 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00000139cc442628 method=java.util.concurrent.ConcurrentHashMap.transfer([Ljava/util/concurrent/ConcurrentHashMap$Node;[Ljava/util/concurrent/ConcurrentHashMap$Node;)V @ 26 c2
+Event: 13.548 Thread 0x0000013a20576a20 DEOPT PACKING pc=0x00000139cc442628 sp=0x00000002423fbac0
+Event: 13.548 Thread 0x0000013a20576a20 DEOPT UNPACKING pc=0x00000139cbdc3aa2 sp=0x00000002423fba20 mode 2
+Event: 13.575 Thread 0x0000013a20576a20 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00000139cc4a4010 relative=0x0000000000000170
+Event: 13.575 Thread 0x0000013a20576a20 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00000139cc4a4010 method=java.util.concurrent.locks.ReentrantReadWriteLock$Sync.tryAcquireShared(I)I @ 81 c2
+Event: 13.576 Thread 0x0000013a20576a20 DEOPT PACKING pc=0x00000139cc4a4010 sp=0x00000002423fe050
+Event: 13.576 Thread 0x0000013a20576a20 DEOPT UNPACKING pc=0x00000139cbdc3aa2 sp=0x00000002423fdfc8 mode 2
+Event: 13.576 Thread 0x0000013a20576a20 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00000139cc4a4464 relative=0x00000000000000c4
+Event: 13.576 Thread 0x0000013a20a7f030 Uncommon trap: trap_request=0xffffff45 fr.pc=0x00000139cc4a4464 relative=0x00000000000000c4
+Event: 13.576 Thread 0x0000013a20576a20 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00000139cc4a4464 method=java.util.concurrent.locks.ReentrantReadWriteLock$Sync.tryReleaseShared(I)Z @ 9 c2
+Event: 13.576 Thread 0x0000013a20a7f030 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00000139cc4a4464 method=java.util.concurrent.locks.ReentrantReadWriteLock$Sync.tryReleaseShared(I)Z @ 9 c2
+Event: 13.576 Thread 0x0000013a20576a20 DEOPT PACKING pc=0x00000139cc4a4464 sp=0x00000002423fe0c0
+Event: 13.576 Thread 0x0000013a20a7f030 DEOPT PACKING pc=0x00000139cc4a4464 sp=0x0000000242cfe540
+Event: 13.576 Thread 0x0000013a20576a20 DEOPT UNPACKING pc=0x00000139cbdc3aa2 sp=0x00000002423fe040 mode 2
+Event: 13.576 Thread 0x0000013a20a7f030 DEOPT UNPACKING pc=0x00000139cbdc3aa2 sp=0x0000000242cfe4c0 mode 2
+
+Classes loaded (20 events):
+Event: 13.516 Loading class sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl
+Event: 13.516 Loading class sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl done
+Event: 13.542 Loading class javax/crypto/IllegalBlockSizeException
+Event: 13.542 Loading class javax/crypto/IllegalBlockSizeException done
+Event: 13.542 Loading class javax/crypto/BadPaddingException
+Event: 13.543 Loading class javax/crypto/BadPaddingException done
+Event: 13.545 Loading class java/security/InvalidAlgorithmParameterException
+Event: 13.546 Loading class java/security/InvalidAlgorithmParameterException done
+Event: 13.546 Loading class java/security/spec/InvalidKeySpecException
+Event: 13.546 Loading class java/security/spec/InvalidKeySpecException done
+Event: 13.546 Loading class javax/crypto/NoSuchPaddingException
+Event: 13.546 Loading class javax/crypto/NoSuchPaddingException done
+Event: 13.546 Loading class java/security/spec/InvalidParameterSpecException
+Event: 13.546 Loading class java/security/spec/InvalidParameterSpecException done
+Event: 13.547 Loading class javax/crypto/spec/PBEKeySpec
+Event: 13.547 Loading class javax/crypto/spec/PBEKeySpec done
+Event: 13.552 Loading class jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl
+Event: 13.552 Loading class jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl done
+Event: 13.576 Loading class java/util/concurrent/locks/ReentrantReadWriteLock$Sync$HoldCounter
+Event: 13.576 Loading class java/util/concurrent/locks/ReentrantReadWriteLock$Sync$HoldCounter done
+
+Classes unloaded (7 events):
+Event: 8.972 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a2800 'java/lang/invoke/LambdaForm$MH+0x00000139da1a2800'
+Event: 8.980 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a2400 'java/lang/invoke/LambdaForm$MH+0x00000139da1a2400'
+Event: 8.980 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a2000 'java/lang/invoke/LambdaForm$MH+0x00000139da1a2000'
+Event: 8.980 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a1c00 'java/lang/invoke/LambdaForm$MH+0x00000139da1a1c00'
+Event: 8.980 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a1800 'java/lang/invoke/LambdaForm$BMH+0x00000139da1a1800'
+Event: 8.980 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a1400 'java/lang/invoke/LambdaForm$DMH+0x00000139da1a1400'
+Event: 8.980 Thread 0x00000139d86c3b30 Unloading class 0x00000139da1a0000 'java/lang/invoke/LambdaForm$DMH+0x00000139da1a0000'
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (20 events):
+Event: 9.960 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d5f90fe8}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, float, float)'> (0x00000000d5f90fe8) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.961 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d5f97c68}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStaticInit(java.lang.Object, double, double)'> (0x00000000d5f97c68) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.961 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d5f9c170}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, long)'> (0x00000000d5f9c170) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.964 Thread 0x0000013a20a7dc80 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d5fcb5a0}: 'int java.lang.invoke.Invokers$Holder.linkToTargetMethod(java.lang.Object, java.lang.Object)'> (0x00000000d5fcb5a0) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.964 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d5fcf208}: 'int java.lang.invoke.Invokers$Holder.linkToTargetMethod(java.lang.Object, java.lang.Object)'> (0x00000000d5fcf208) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.966 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d5feb750}: 'int java.lang.invoke.DirectMethodHandle$Holder.invokeSpecial(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x00000000d5feb750) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.968 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d603c180}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(java.lang.Object, int, java.lang.Object, java.lang.Object)'> (0x00000000d603c180) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.968 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d60486b8}: 'java.lang.Object java.lang.invoke.DelegatingMethodHandle$Holder.delegate(java.lang.Object, int, java.lang.Object, java.lang.Object)'> (0x00000000d60486b8) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 9.972 Thread 0x0000013a20a7d5f0 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d60df368}: 'int java.lang.invoke.Invokers$Holder.linkToTargetMethod(java.lang.Object, java.lang.Object, java.lang.Object)'> (0x00000000d60df368) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 10.016 Thread 0x0000013a20a7dc80 Exception <a 'java/lang/NoSuchMethodError'{0x00000000d634d910}: 'java.lang.Object java.lang.invoke.DirectMethodHandle$Holder.invokeSpecialIFC(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object)'> (0x00000000d634d910) 
+thrown [s\src\hotspot\share\interpreter\linkResolver.cpp, line 773]
+Event: 10.217 Thread 0x0000013a20576a20 Exception <a 'java/lang/ClassNotFoundException'{0x00000000d5b44ea0}: com/sun/org/apache/xerces/internal/impl/msg/spi/DOMMessagesProvider> (0x00000000d5b44ea0) 
+thrown [s\src\hotspot\share\classfile\systemDictionary.cpp, line 312]
+Event: 10.220 Thread 0x0000013a20576a20 Exception <a 'java/lang/ClassNotFoundException'{0x00000000d5b56658}: com/sun/org/apache/xerces/internal/impl/msg/spi/XMLSerializerMessagesProvider> (0x00000000d5b56658) 
+thrown [s\src\hotspot\share\classfile\systemDictionary.cpp, line 312]
+Event: 10.221 Thread 0x0000013a20576a20 Exception <a 'java/lang/ClassNotFoundException'{0x00000000d5b63928}: com/sun/org/apache/xerces/internal/impl/msg/spi/XMLMessagesProvider> (0x00000000d5b63928) 
+thrown [s\src\hotspot\share\classfile\systemDictionary.cpp, line 312]
+Event: 13.407 Thread 0x0000013a20576a20 Exception <a 'java/lang/ClassNotFoundException'{0x00000000d6a77c70}: com/sun/org/apache/xml/internal/serializer/spi/XMLEntitiesProvider> (0x00000000d6a77c70) 
+thrown [s\src\hotspot\share\classfile\systemDictionary.cpp, line 312]
+Event: 13.424 Thread 0x0000013a20a7dc80 Exception <a 'java/lang/NoClassDefFoundError'{0x00000000d5644a30}: javax/enterprise/inject/Typed> (0x00000000d5644a30) 
+thrown [s\src\hotspot\share\classfile\systemDictionary.cpp, line 301]
+Event: 13.495 Thread 0x0000013a20576a20 Exception <a 'java/io/FileNotFoundException'{0x00000000d5f3e1a0}> (0x00000000d5f3e1a0) 
+thrown [s\src\hotspot\share\prims\jni.cpp, line 520]
+Event: 13.517 Thread 0x0000013a20576a20 Exception <a 'java/lang/UnsatisfiedLinkError'{0x00000000d63af458}: The specified procedure could not be found.
+> (0x00000000d63af458) 
+thrown [s\src\hotspot\share\prims\jni.cpp, line 539]
+Event: 13.535 Thread 0x0000013a20576a20 Exception <a 'java/io/FileNotFoundException'{0x00000000d63c72e8}> (0x00000000d63c72e8) 
+thrown [s\src\hotspot\share\prims\jni.cpp, line 520]
+Event: 13.547 Thread 0x0000013a20576a20 Exception <a 'java/io/FileNotFoundException'{0x00000000d6636da0}> (0x00000000d6636da0) 
+thrown [s\src\hotspot\share\prims\jni.cpp, line 520]
+Event: 13.553 Thread 0x0000013a20576a20 Exception <a 'java/lang/UnsatisfiedLinkError'{0x00000000d668f828}: The specified procedure could not be found.
+> (0x00000000d668f828) 
+thrown [s\src\hotspot\share\prims\jni.cpp, line 539]
+
+ZGC Phase Switch (0 events):
+No events
+
+VM Operations (20 events):
+Event: 9.058 Executing VM operation: CollectForMetadataAllocation (Metadata GC Threshold) done
+Event: 9.340 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure)
+Event: 9.341 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure) done
+Event: 9.940 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure)
+Event: 9.942 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure) done
+Event: 9.972 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 9.972 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 10.135 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure)
+Event: 10.137 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure) done
+Event: 10.274 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 10.274 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 11.274 Executing VM operation: Cleanup
+Event: 13.381 Executing VM operation: Cleanup done
+Event: 13.413 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure)
+Event: 13.416 Executing VM operation: ParallelGCFailedAllocation (Allocation Failure) done
+Event: 13.417 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 13.417 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 13.435 Executing VM operation: HandshakeAllThreads (Deoptimize)
+Event: 13.436 Executing VM operation: HandshakeAllThreads (Deoptimize) done
+Event: 14.439 Executing VM operation: Cleanup
+
+Memory protections (0 events):
+No events
+
+Nmethod flushes (0 events):
+No events
+
+Events (20 events):
+Event: 0.295 Thread 0x00000139c0054360 Thread added: 0x0000013a1b778560
+Event: 0.296 Thread 0x00000139c0054360 Thread added: 0x0000013a1b77eda0
+Event: 0.296 Thread 0x00000139c0054360 Thread added: 0x0000013a1b785e20
+Event: 0.296 Thread 0x00000139c0054360 Thread added: 0x0000013a1b799e80
+Event: 0.296 Thread 0x00000139c0054360 Thread added: 0x0000013a1b79e480
+Event: 0.500 Thread 0x00000139c0054360 Thread added: 0x0000013a1b916f80
+Event: 0.850 Thread 0x00000139c0054360 Thread added: 0x0000013a1ba7a720
+Event: 3.462 Thread 0x00000139c0054360 Thread added: 0x0000013a205c7710
+Event: 3.946 Thread 0x00000139c0054360 Thread added: 0x0000013a205ba790
+Event: 3.986 Thread 0x0000013a205ba790 Thread added: 0x0000013a204afeb0
+Event: 3.989 Thread 0x00000139c0054360 Thread added: 0x0000013a20576a20
+Event: 4.516 Thread 0x0000013a20576a20 Thread added: 0x0000013a20cfbaf0
+Event: 5.077 Thread 0x0000013a20576a20 Thread added: 0x0000013a20b2f1d0
+Event: 5.640 Thread 0x0000013a20576a20 Thread added: 0x0000013a20a7c8d0
+Event: 8.148 Thread 0x0000013a20576a20 Thread added: 0x0000013a20a7c240
+Event: 8.227 Thread 0x0000013a20576a20 Thread added: 0x0000013a20a7d5f0
+Event: 8.274 Thread 0x0000013a20576a20 Thread added: 0x0000013a20a7dc80
+Event: 9.947 Thread 0x0000013a20a7d5f0 Thread added: 0x0000013a20a7f030
+Event: 10.186 Thread 0x0000013a20a7f030 Thread added: 0x0000013a20a7bbb0
+Event: 10.247 Thread 0x0000013a20576a20 Thread added: 0x0000013a20a7e310
+
+
+Dynamic libraries:
+0x00007ff64bca0000 - 0x00007ff64bcae000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\java.exe
+0x00007ffd68220000 - 0x00007ffd68487000 	C:\windows\SYSTEM32\ntdll.dll
+0x00007ffd674d0000 - 0x00007ffd67599000 	C:\windows\System32\KERNEL32.DLL
+0x00007ffd65b90000 - 0x00007ffd65f7f000 	C:\windows\System32\KERNELBASE.dll
+0x00007ffd656f0000 - 0x00007ffd6583b000 	C:\windows\System32\ucrtbase.dll
+0x00007ffd3a830000 - 0x00007ffd3a848000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\jli.dll
+0x00007ffd672a0000 - 0x00007ffd67465000 	C:\windows\System32\USER32.dll
+0x00007ffd65f90000 - 0x00007ffd65fb7000 	C:\windows\System32\win32u.dll
+0x00007ffd3a390000 - 0x00007ffd3a3ae000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\VCRUNTIME140.dll
+0x00007ffd67f30000 - 0x00007ffd67f5b000 	C:\windows\System32\GDI32.dll
+0x00007ffd65840000 - 0x00007ffd6596c000 	C:\windows\System32\gdi32full.dll
+0x00007ffd65ae0000 - 0x00007ffd65b83000 	C:\windows\System32\msvcp_win.dll
+0x00007ffd4a2a0000 - 0x00007ffd4a533000 	C:\windows\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.7309_none_3e05feeae336a044\COMCTL32.dll
+0x00007ffd67ca0000 - 0x00007ffd67d49000 	C:\windows\System32\msvcrt.dll
+0x00007ffd664d0000 - 0x00007ffd66501000 	C:\windows\System32\IMM32.DLL
+0x00007ffd4adc0000 - 0x00007ffd4adcc000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\vcruntime140_1.dll
+0x00007ffd21ae0000 - 0x00007ffd21b6d000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\msvcp140.dll
+0x00007ffc5c8b0000 - 0x00007ffc5d650000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\server\jvm.dll
+0x00007ffd67710000 - 0x00007ffd677c4000 	C:\windows\System32\ADVAPI32.dll
+0x00007ffd66610000 - 0x00007ffd666b6000 	C:\windows\System32\sechost.dll
+0x00007ffd67e10000 - 0x00007ffd67f28000 	C:\windows\System32\RPCRT4.dll
+0x00007ffd68150000 - 0x00007ffd681c4000 	C:\windows\System32\WS2_32.dll
+0x00007ffd58720000 - 0x00007ffd58755000 	C:\windows\SYSTEM32\WINMM.dll
+0x00007ffd651d0000 - 0x00007ffd6522e000 	C:\windows\SYSTEM32\POWRPROF.dll
+0x00007ffd57840000 - 0x00007ffd5784b000 	C:\windows\SYSTEM32\VERSION.dll
+0x00007ffd651b0000 - 0x00007ffd651c4000 	C:\windows\SYSTEM32\UMPDC.dll
+0x00007ffd64120000 - 0x00007ffd6413b000 	C:\windows\SYSTEM32\kernel.appcore.dll
+0x00007ffd49670000 - 0x00007ffd4967a000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\jimage.dll
+0x00007ffd56280000 - 0x00007ffd564c2000 	C:\windows\SYSTEM32\DBGHELP.DLL
+0x00007ffd666d0000 - 0x00007ffd66a56000 	C:\windows\System32\combase.dll
+0x00007ffd67f60000 - 0x00007ffd68036000 	C:\windows\System32\OLEAUT32.dll
+0x00007ffd4a260000 - 0x00007ffd4a29c000 	C:\windows\SYSTEM32\dbgcore.DLL
+0x00007ffd65580000 - 0x00007ffd65625000 	C:\windows\System32\bcryptPrimitives.dll
+0x00007ffd48f30000 - 0x00007ffd48f3f000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\instrument.dll
+0x00007ffd294e0000 - 0x00007ffd29500000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\java.dll
+0x00007ffd66b40000 - 0x00007ffd67293000 	C:\windows\System32\SHELL32.dll
+0x00007ffd65970000 - 0x00007ffd65ada000 	C:\windows\System32\wintypes.dll
+0x00007ffd62f40000 - 0x00007ffd6379e000 	C:\windows\SYSTEM32\windows.storage.dll
+0x00007ffd68040000 - 0x00007ffd68135000 	C:\windows\System32\SHCORE.dll
+0x00007ffd677d0000 - 0x00007ffd67836000 	C:\windows\System32\shlwapi.dll
+0x00007ffd65290000 - 0x00007ffd652b9000 	C:\windows\SYSTEM32\profapi.dll
+0x00007ffd28980000 - 0x00007ffd28998000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\zip.dll
+0x00007ffd43d10000 - 0x00007ffd43d20000 	C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\net.dll
+0x00007ffd5dae0000 - 0x00007ffd5dc08000 	C:\windows\SYSTEM32\WINHTTP.dll
+0x00007ffd64690000 - 0x00007ffd646fb000 	C:\windows\system32\mswsock.dll
+0x00007ffd345a0000 - 0x00007ffd345b6000 	C:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\nio.dll
+0x00007ffd40370000 - 0x00007ffd40380000 	c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\verify.dll
+0x00007ffd3a410000 - 0x00007ffd3a454000 	C:\Users\prcri\AppData\Roaming\Code\User\globalStorage\redhat.java\1.51.0\config_win\org.eclipse.equinox.launcher\org.eclipse.equinox.launcher.win32.win32.x86_64_1.2.1400.v20250801-0854\eclipse_11916.dll
+0x00007ffd67900000 - 0x00007ffd67a97000 	C:\windows\System32\ole32.dll
+0x00007ffd64950000 - 0x00007ffd6496b000 	C:\windows\SYSTEM32\CRYPTSP.dll
+0x00007ffd64080000 - 0x00007ffd640ba000 	C:\windows\system32\rsaenh.dll
+0x00007ffd64740000 - 0x00007ffd6476b000 	C:\windows\SYSTEM32\USERENV.dll
+0x00007ffd65260000 - 0x00007ffd6528a000 	C:\windows\SYSTEM32\bcrypt.dll
+0x00007ffd64970000 - 0x00007ffd6497c000 	C:\windows\SYSTEM32\CRYPTBASE.dll
+0x00007ffd63ae0000 - 0x00007ffd63b14000 	C:\windows\SYSTEM32\IPHLPAPI.DLL
+0x00007ffd666c0000 - 0x00007ffd666ca000 	C:\windows\System32\NSI.dll
+0x00007ffd39c80000 - 0x00007ffd39cc9000 	C:\Users\prcri\AppData\Local\Temp\jna-106929304\jna15381168658908417585.dll
+0x00007ffd681d0000 - 0x00007ffd681d8000 	C:\windows\System32\PSAPI.DLL
+0x00007ffd5ea30000 - 0x00007ffd5ea4e000 	C:\windows\SYSTEM32\dhcpcsvc6.DLL
+0x00007ffd5ea00000 - 0x00007ffd5ea23000 	C:\windows\SYSTEM32\dhcpcsvc.DLL
+
+JVMTI agents:
+c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\lombok\lombok-1.18.39-4050.jar path:c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\instrument.dll, loaded, initialized, instrumentlib options:none
+
+dbghelp: loaded successfully - version: 4.0.5 - missing functions: none
+symbol engine: initialized successfully - sym options: 0x614 - pdb path: .;c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin;C:\windows\SYSTEM32;C:\windows\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.7309_none_3e05feeae336a044;c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\jre\21.0.9-win32-x86_64\bin\server;C:\Users\prcri\AppData\Roaming\Code\User\globalStorage\redhat.java\1.51.0\config_win\org.eclipse.equinox.launcher\org.eclipse.equinox.launcher.win32.win32.x86_64_1.2.1400.v20250801-0854;C:\Users\prcri\AppData\Local\Temp\jna-106929304
+
+VM Arguments:
+jvm_args: --add-modules=ALL-SYSTEM --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Djava.import.generatesMetadataFilesAtProjectRoot=false -DDetectVMInstallationsJob.disabled=true -Dfile.encoding=utf8 -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable -javaagent:c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\lombok\lombok-1.18.39-4050.jar -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=c:\Users\prcri\AppData\Roaming\Code\User\workspaceStorage\9bac68a4509a4c6ff0f03304305a388a\redhat.java -Daether.dependencyCollector.impl=bf 
+java_command: c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\server\plugins\org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar -configuration c:\Users\prcri\AppData\Roaming\Code\User\globalStorage\redhat.java\1.51.0\config_win -data c:\Users\prcri\AppData\Roaming\Code\User\workspaceStorage\9bac68a4509a4c6ff0f03304305a388a\redhat.java\jdt_ws --pipe=\\.\pipe\lsp-3076be3d7f3b703a6f480eed6a94ad77-sock
+java_class_path (initial): c:\Users\prcri\.vscode\extensions\redhat.java-1.51.0-win32-x64\server\plugins\org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+    uintx AdaptiveSizePolicyWeight                 = 90                                        {product} {command line}
+     intx CICompilerCount                          = 4                                         {product} {ergonomic}
+    uintx GCTimeRatio                              = 4                                         {product} {command line}
+     bool HeapDumpOnOutOfMemoryError               = true                                   {manageable} {command line}
+    ccstr HeapDumpPath                             = c:\Users\prcri\AppData\Roaming\Code\User\workspaceStorage\9bac68a4509a4c6ff0f03304305a388a\redhat.java         {manageable} {command line}
+   size_t InitialHeapSize                          = 104857600                                 {product} {command line}
+   size_t MaxHeapSize                              = 2147483648                                {product} {command line}
+   size_t MaxNewSize                               = 715653120                                 {product} {ergonomic}
+   size_t MinHeapDeltaBytes                        = 524288                                    {product} {ergonomic}
+   size_t MinHeapSize                              = 104857600                                 {product} {command line}
+   size_t NewSize                                  = 34603008                                  {product} {ergonomic}
+    uintx NonNMethodCodeHeapSize                   = 5839372                                {pd product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 122909434                              {pd product} {ergonomic}
+   size_t OldSize                                  = 70254592                                  {product} {ergonomic}
+    uintx ProfiledCodeHeapSize                     = 122909434                              {pd product} {ergonomic}
+    uintx ReservedCodeCacheSize                    = 251658240                              {pd product} {ergonomic}
+     bool SegmentedCodeCache                       = true                                      {product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 2147483648                             {manageable} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseLargePagesIndividualAllocation        = false                                  {pd product} {ergonomic}
+     bool UseParallelGC                            = true                                      {product} {command line}
+
+Logging:
+Log output configuration:
+ #0: stdout all=off uptime,level,tags foldmultilines=false
+ #1: stderr all=off uptime,level,tags foldmultilines=false
+
+Release file:
+JAVA_VERSION="21.0.9" 
+MODULES="java.base java.compiler java.datatransfer java.xml java.prefs java.desktop java.instrument java.logging java.management java.security.sasl java.naming java.rmi java.management.rmi java.net.http java.scripting java.security.jgss java.transaction.xa java.sql java.sql.rowset java.xml.crypto java.se java.smartcardio jdk.accessibility jdk.internal.jvmstat jdk.attach jdk.charsets jdk.internal.opt jdk.zipfs jdk.compiler jdk.crypto.ec jdk.crypto.cryptoki jdk.crypto.mscapi jdk.dynalink jdk.internal.ed jdk.editpad jdk.hotspot.agent jdk.httpserver jdk.internal.le jdk.internal.vm.ci jdk.internal.vm.compiler jdk.internal.vm.compiler.management jdk.jartool jdk.javadoc jdk.jcmd jdk.management jdk.management.agent jdk.jconsole jdk.jdeps jdk.jdwp.agent jdk.jdi jdk.jfr jdk.jshell jdk.jsobject jdk.jstatd jdk.localedata jdk.management.jfr jdk.naming.dns jdk.naming.rmi jdk.net jdk.nio.mapmode jdk.random jdk.sctp jdk.security.auth jdk.security.jgss jdk.unsupported jdk.unsupported.desktop jdk.xml.dom" 
+
+Environment Variables:
+JAVA_HOME=C:\Program Files\Eclipse Adoptium\jdk-21.0.8.9-hotspot\
+PATH=C:\Users\prcri\Downloads\apache-maven-3.9.11-bin\apache-maven-3.9.11\bin;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0\;C:\windows\System32\OpenSSH\;C:\Program Files\HP\HP One Agent;C:\Program Files\Git\cmd;C:\Program Files\Wolfram Research\WolframScript\;C:\Users\prcri\Downloads\clojure_projects\;C:\Program Files\MongoDB\Server\8.0\bin;C:\Program Files\MongoDB\Tools\100\bin;C:\Program Files\nodejs\;C:\Users\prcri\AppData\Local\Programs\Python\Launcher\;C:\Users\prcri\AppData\Local\Microsoft\WindowsApps;C:\Users\prcri\AppData\Local\Apps\clojure\;C:\Users\prcri\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\prcri\AppData\Local\gitkraken\bin;C:\Users\prcri\AppData\Local\Programs\mongosh\;C:\Users\prcri\AppData\Local\Microsoft\WinGet\Packages\Schniz.fnm_Microsoft.Winget.Source_8wekyb3d8bbwe;C:\Users\prcri\AppData\Roaming\npm
+USERNAME=prcri
+OS=Windows_NT
+PROCESSOR_IDENTIFIER=AMD64 Family 25 Model 68 Stepping 1, AuthenticAMD
+TMP=C:\Users\prcri\AppData\Local\Temp
+TEMP=C:\Users\prcri\AppData\Local\Temp
+
+
+
+
+Periodic native trim disabled
+
+---------------  S Y S T E M  ---------------
+
+OS:
+ Windows 11 , 64 bit Build 26100 (10.0.26100.7623)
+OS uptime: 2 days 20:40 hours
+Hyper-V role detected
+
+CPU: total 12 (initial active 12) (12 cores per cpu, 2 threads per core) family 25 model 68 stepping 1 microcode 0xa40410a, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4a, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, sha, fma, vzeroupper, clflush, clflushopt, hv, rdtscp, rdpid, fsrm, f16c, cet_ss
+Processor Information for the first 12 processors :
+  Max Mhz: 3301, Current Mhz: 3301, Mhz Limit: 3301
+
+Memory: 4k page, system-wide physical 7381M (315M free)
+TotalPageFile size 29909M (AvailPageFile size 0M)
+current process WorkingSet (physical memory assigned to process): 164M, peak: 164M
+current process commit charge ("private bytes"): 311M, peak: 312M
+
+vm_info: OpenJDK 64-Bit Server VM (21.0.9+10-LTS) for windows-amd64 JRE (21.0.9+10-LTS), built on 2025-10-21T00:00:00Z by "admin" with unknown MS VC++:1942
+
+END.

--- a/replay_pid26680.log
+++ b/replay_pid26680.log
@@ -1,0 +1,5671 @@
+version 2
+JvmtiExport can_access_local_variables 0
+JvmtiExport can_hotswap_or_post_breakpoint 1
+JvmtiExport can_post_on_exceptions 0
+# 515 ciObject found
+instanceKlass org/lombokweb/asm/ClassReader
+ciInstanceKlass java/lang/Cloneable 1 0 7 100 1 100 1 1 1
+instanceKlass org/eclipse/aether/transport/wagon/WagonTransporterFactory
+instanceKlass org/eclipse/aether/internal/transport/wagon/PlexusWagonProvider
+instanceKlass org/eclipse/aether/transport/wagon/WagonProvider
+instanceKlass org/eclipse/aether/internal/transport/wagon/PlexusWagonConfigurator
+instanceKlass org/eclipse/aether/transport/wagon/WagonConfigurator
+instanceKlass com/google/gson/internal/Primitives
+instanceKlass org/eclipse/aether/transport/http/ChecksumExtractor
+instanceKlass org/eclipse/aether/transport/http/HttpTransporterFactory
+instanceKlass org/eclipse/aether/transport/file/FileTransporterFactory
+instanceKlass org/eclipse/aether/spi/connector/transport/TransporterFactory
+instanceKlass org/apache/maven/repository/internal/VersionsMetadataGeneratorFactory
+instanceKlass org/apache/maven/repository/internal/SnapshotMetadataGeneratorFactory
+instanceKlass org/apache/maven/repository/internal/PluginsMetadataGeneratorFactory
+instanceKlass org/eclipse/aether/impl/MetadataGeneratorFactory
+instanceKlass org/apache/maven/repository/internal/DefaultVersionResolver
+instanceKlass org/eclipse/aether/impl/VersionResolver
+instanceKlass org/apache/maven/repository/internal/DefaultVersionRangeResolver
+instanceKlass org/eclipse/aether/impl/VersionRangeResolver
+instanceKlass org/apache/maven/repository/internal/DefaultModelCacheFactory
+instanceKlass org/apache/maven/repository/internal/ModelCacheFactory
+instanceKlass org/apache/maven/repository/internal/DefaultArtifactDescriptorReader
+instanceKlass org/eclipse/aether/impl/ArtifactDescriptorReader
+instanceKlass org/eclipse/aether/named/support/NamedLockFactorySupport
+instanceKlass org/eclipse/aether/named/NamedLockFactory
+instanceKlass com/google/gson/internal/LinkedTreeMap$Node
+instanceKlass com/google/gson/internal/LinkedTreeMap$1
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/StaticNameMapperProvider
+# instanceKlass com/google/gson/internal/ConstructorConstructor$$Lambda+0x00000139da440e10
+# instanceKlass com/google/gson/internal/ConstructorConstructor$$Lambda+0x00000139da440bf0
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/GAVNameMapperProvider
+instanceKlass com/google/gson/internal/ObjectConstructor
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileStaticNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileHashingGAVNameMapperProvider
+instanceKlass com/google/gson/internal/ReflectionAccessFilterHelper
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/FileGAVNameMapperProvider
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NameMapper
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/providers/DiscriminatingNameMapperProvider
+instanceKlass com/google/gson/internal/reflect/ReflectionHelper$RecordHelper
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactoryImpl
+instanceKlass org/eclipse/aether/internal/impl/synccontext/named/NamedLockFactoryAdapterFactory
+instanceKlass com/google/gson/internal/reflect/ReflectionHelper
+instanceKlass org/eclipse/aether/internal/impl/synccontext/legacy/DefaultSyncContextFactory
+instanceKlass org/eclipse/aether/impl/SyncContextFactory
+instanceKlass org/eclipse/aether/internal/impl/synccontext/DefaultSyncContextFactory
+instanceKlass org/eclipse/aether/spi/synccontext/SyncContextFactory
+instanceKlass com/google/gson/internal/JsonReaderInternalAccess
+instanceKlass com/google/gson/internal/GsonTypes$ParameterizedTypeImpl
+instanceKlass org/eclipse/aether/internal/impl/slf4j/Slf4jLoggerFactory
+instanceKlass com/google/gson/internal/GsonTypes
+instanceKlass org/eclipse/aether/internal/impl/resolution/ArtifactResolverPostProcessorSupport
+instanceKlass com/google/gson/internal/bind/ReflectiveTypeAdapterFactory$BoundField
+instanceKlass org/eclipse/jdt/ls/core/internal/ParentProcessWatcher
+instanceKlass com/google/gson/internal/bind/ReflectiveTypeAdapterFactory
+instanceKlass sun/nio/ch/PendingIoCache
+instanceKlass org/eclipse/aether/internal/impl/filter/RemoteRepositoryFilterSourceSupport
+instanceKlass org/eclipse/aether/spi/connector/filter/RemoteRepositoryFilterSource
+instanceKlass com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory$DummyTypeAdapterFactory
+instanceKlass org/eclipse/aether/spi/resolution/ArtifactResolverPostProcessor
+instanceKlass sun/nio/ch/Invoker$GroupAndInvokeCount
+instanceKlass sun/nio/ch/Invoker
+instanceKlass sun/nio/ch/AsynchronousChannelGroupImpl$1
+instanceKlass com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory
+instanceKlass sun/nio/ch/AsynchronousChannelGroupImpl$2
+instanceKlass com/google/gson/internal/bind/MapTypeAdapterFactory
+instanceKlass sun/nio/ch/Iocp$EventHandlerTask
+instanceKlass org/eclipse/aether/internal/impl/filter/DefaultRemoteRepositoryFilterManager
+instanceKlass org/eclipse/aether/impl/RemoteRepositoryFilterManager
+instanceKlass com/google/gson/internal/bind/CollectionTypeAdapterFactory
+# instanceKlass sun/nio/ch/ThreadPool$$Lambda+0x00000139da3c8cd8
+instanceKlass com/google/gson/internal/bind/ArrayTypeAdapter$1
+instanceKlass sun/nio/ch/ThreadPool
+instanceKlass sun/nio/ch/Iocp$CompletionStatus
+instanceKlass java/nio/channels/AsynchronousChannelGroup
+instanceKlass com/google/gson/internal/bind/DefaultDateTypeAdapter$1
+instanceKlass sun/nio/ch/WindowsAsynchronousFileChannelImpl$DefaultIocpHolder
+instanceKlass java/util/concurrent/atomic/AtomicLongArray
+instanceKlass org/eclipse/aether/internal/impl/collect/DependencyCollectorDelegate
+instanceKlass com/google/gson/internal/bind/NumberTypeAdapter$1
+instanceKlass sun/nio/ch/Groupable
+instanceKlass sun/nio/ch/Iocp$OverlappedChannel
+instanceKlass com/google/gson/internal/bind/ObjectTypeAdapter$1
+instanceKlass sun/nio/fs/WindowsChannelFactory$2
+instanceKlass java/nio/channels/AsynchronousFileChannel
+instanceKlass com/google/gson/internal/bind/EnumTypeAdapter$1
+instanceKlass org/eclipse/aether/internal/impl/collect/DefaultDependencyCollector
+instanceKlass org/eclipse/aether/impl/DependencyCollector
+instanceKlass java/net/ProtocolFamily
+instanceKlass com/google/gson/internal/bind/TypeAdapters$31
+instanceKlass java/util/Currency
+instanceKlass org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory$PipeStreamProvider
+instanceKlass org/eclipse/aether/internal/impl/checksum/TrustedToProvidedChecksumsSourceAdapter
+instanceKlass org/eclipse/aether/spi/checksums/ProvidedChecksumsSource
+# instanceKlass org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory$$Lambda+0x00000139da431568
+instanceKlass com/google/gson/internal/bind/TypeAdapters$32
+instanceKlass java/util/concurrent/atomic/AtomicIntegerArray
+instanceKlass org/eclipse/aether/internal/impl/checksum/FileTrustedChecksumsSourceSupport
+instanceKlass org/eclipse/aether/spi/checksums/TrustedChecksumsSource
+instanceKlass java/lang/ProcessHandleImpl$Info
+instanceKlass java/lang/ProcessHandle$Info
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da434800
+instanceKlass com/google/gson/internal/bind/TypeAdapters$30
+# instanceKlass java/lang/ProcessHandleImpl$$Lambda+0x00000139da3c5ed0
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da434400
+instanceKlass com/google/gson/internal/bind/TypeAdapters$29
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da434000
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager wakeUp (Lorg/eclipse/core/internal/jobs/InternalJob;J)V 23 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da2273c0
+# instanceKlass java/lang/ProcessHandleImpl$$Lambda+0x00000139da3c5840
+instanceKlass java/lang/ProcessHandleImpl
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySupport
+instanceKlass org/eclipse/jdt/ls/core/internal/JobHelpers$ProjectRegistryRefreshJobMatcher
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactory
+instanceKlass org/eclipse/jdt/ls/core/internal/JobHelpers$IJobMatcher
+instanceKlass java/lang/ProcessHandle
+instanceKlass org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory$StreamProvider
+instanceKlass org/eclipse/jdt/ls/core/internal/JobHelpers
+instanceKlass org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory
+instanceKlass org/eclipse/aether/internal/impl/checksum/DefaultChecksumAlgorithmFactorySelector
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumAlgorithmFactorySelector
+instanceKlass org/eclipse/jdt/ls/core/internal/JVMConfigurator
+instanceKlass org/eclipse/aether/internal/impl/SimpleLocalRepositoryManagerFactory
+instanceKlass org/eclipse/aether/internal/impl/Maven2RepositoryLayoutFactory
+instanceKlass org/eclipse/aether/spi/connector/layout/RepositoryLayoutFactory
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyHandler
+instanceKlass  @bci org/eclipse/buildship/core/internal/CorePlugin scheduleSynchronizationForAbsentModels ()V 15 <appendix> argL0 ; # org/eclipse/buildship/core/internal/CorePlugin$$Lambda+0x00000139da42c6d8
+instanceKlass org/eclipse/aether/spi/log/LoggerFactory
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler$CommandHandlerHolder
+instanceKlass java/util/Collections$2
+instanceKlass com/google/gson/internal/bind/TypeAdapters
+instanceKlass org/eclipse/aether/internal/impl/LoggerFactoryProvider
+instanceKlass org/eclipse/buildship/core/internal/extension/DefaultExtensionManager
+instanceKlass org/eclipse/aether/internal/impl/EnhancedLocalRepositoryManagerFactory
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler
+instanceKlass org/eclipse/aether/spi/localrepo/LocalRepositoryManagerFactory
+instanceKlass com/google/gson/internal/ConstructorConstructor
+instanceKlass org/eclipse/buildship/core/internal/operation/DefaultToolingApiOperationManager
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdatePolicyAnalyzer
+instanceKlass org/eclipse/aether/impl/UpdatePolicyAnalyzer
+instanceKlass org/eclipse/buildship/core/internal/launch/DefaultExternalLaunchConfigurationManager$LaunchConfigurationListener
+instanceKlass com/google/gson/internal/sql/SqlTimestampTypeAdapter$1
+instanceKlass org/eclipse/buildship/core/internal/launch/DefaultExternalLaunchConfigurationManager
+instanceKlass com/google/gson/internal/sql/SqlTimeTypeAdapter$1
+instanceKlass org/eclipse/buildship/core/internal/configuration/BuildConfigurationPersistence
+instanceKlass org/eclipse/aether/internal/impl/DefaultUpdateCheckManager
+instanceKlass org/eclipse/aether/impl/UpdateCheckManager
+instanceKlass com/google/gson/internal/sql/SqlDateTypeAdapter$1
+instanceKlass org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationPersistence
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler
+instanceKlass org/eclipse/buildship/core/GradleDistribution
+instanceKlass org/eclipse/aether/internal/impl/DefaultTransporterProvider
+instanceKlass org/eclipse/aether/spi/connector/transport/TransporterProvider
+instanceKlass org/eclipse/buildship/core/internal/configuration/TestRunConfiguration
+instanceKlass org/eclipse/buildship/core/internal/configuration/RunConfiguration
+instanceKlass org/eclipse/buildship/core/internal/configuration/BaseRunConfiguration
+instanceKlass com/google/gson/internal/bind/DefaultDateTypeAdapter$DateType
+instanceKlass org/eclipse/aether/internal/impl/DefaultTrackingFileManager
+instanceKlass org/eclipse/lsp4j/WorkDoneProgressParams
+instanceKlass org/eclipse/aether/internal/impl/TrackingFileManager
+instanceKlass org/eclipse/buildship/core/internal/launch/BaseRunConfigurationAttributes
+instanceKlass com/google/gson/internal/sql/SqlTypesSupport
+instanceKlass org/eclipse/lsp4j/PartialResultParams
+instanceKlass org/eclipse/buildship/core/internal/configuration/ProjectConfiguration
+instanceKlass org/eclipse/buildship/core/internal/configuration/BuildConfiguration
+instanceKlass org/eclipse/buildship/core/internal/configuration/DefaultConfigurationManager
+instanceKlass org/eclipse/lsp4j/TextDocumentPositionParams
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositorySystemLifecycle
+instanceKlass org/eclipse/aether/impl/RepositorySystemLifecycle
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositorySystem
+instanceKlass org/eclipse/aether/RepositorySystem
+instanceKlass org/eclipse/buildship/core/internal/invocation/InvocationCustomizerCollector
+instanceKlass com/google/gson/FormattingStyle
+instanceKlass org/eclipse/buildship/core/internal/operation/ToolingApiJobResultHandler
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryLayoutProvider
+instanceKlass org/eclipse/aether/spi/connector/layout/RepositoryLayoutProvider
+instanceKlass org/eclipse/buildship/core/internal/workspace/SynchronizingBuildScriptUpdateListener
+instanceKlass org/eclipse/buildship/core/internal/configuration/GradleProjectNature
+instanceKlass org/eclipse/buildship/core/internal/workspace/ProjectChangeListener
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryEventDispatcher
+instanceKlass org/eclipse/aether/impl/RepositoryEventDispatcher
+instanceKlass com/google/gson/stream/JsonWriter
+instanceKlass org/eclipse/aether/internal/impl/DefaultRepositoryConnectorProvider
+instanceKlass org/eclipse/debug/core/model/ISourceLocator
+instanceKlass org/eclipse/aether/impl/RepositoryConnectorProvider
+instanceKlass org/eclipse/jdt/internal/launching/sourcelookup/advanced/AdvancedSourceLookupSupport
+instanceKlass org/eclipse/aether/internal/impl/DefaultRemoteRepositoryManager
+instanceKlass org/eclipse/aether/impl/RemoteRepositoryManager
+instanceKlass org/eclipse/buildship/core/internal/preferences/PersistentModel
+instanceKlass org/eclipse/jdt/launching/StandardClasspathProvider
+instanceKlass com/google/gson/stream/JsonReader
+instanceKlass org/eclipse/buildship/core/internal/preferences/DefaultModelPersistence
+instanceKlass org/eclipse/aether/internal/impl/DefaultOfflineController
+instanceKlass org/eclipse/aether/impl/OfflineController
+instanceKlass org/eclipse/buildship/core/internal/event/EventListener
+instanceKlass org/eclipse/aether/internal/impl/DefaultMetadataResolver
+instanceKlass org/eclipse/jdt/launching/IVMConnector
+instanceKlass org/eclipse/aether/impl/MetadataResolver
+instanceKlass org/eclipse/jdt/launching/IRuntimeClasspathEntry
+instanceKlass com/google/gson/ToNumberStrategy
+instanceKlass org/eclipse/buildship/core/internal/event/DefaultListenerRegistry
+instanceKlass org/eclipse/jdt/launching/IRuntimeClasspathEntryResolver
+instanceKlass com/google/gson/Gson
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalRepositoryProvider
+instanceKlass org/eclipse/aether/impl/LocalRepositoryProvider
+instanceKlass org/eclipse/jdt/launching/environments/IExecutionEnvironmentsManager
+instanceKlass org/eclipse/debug/internal/core/groups/GroupMemberChangeListener
+instanceKlass org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactorySupport
+instanceKlass org/eclipse/aether/internal/impl/LocalPathPrefixComposerFactory
+instanceKlass org/eclipse/jdt/launching/IVMInstall
+instanceKlass org/eclipse/core/internal/watson/ElementTreeIterator
+instanceKlass org/eclipse/jdt/launching/IRuntimeClasspathProvider
+instanceKlass org/eclipse/jdt/launching/JavaRuntime
+instanceKlass  @bci org/eclipse/core/internal/resources/Resource accept (Lorg/eclipse/core/resources/IResourceProxyVisitor;II)V 50 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da419c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da419800
+instanceKlass  @bci org/eclipse/core/internal/resources/Resource accept (Lorg/eclipse/core/resources/IResourceProxyVisitor;II)V 50 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da419400
+instanceKlass  @bci org/eclipse/core/internal/resources/Resource accept (Lorg/eclipse/core/resources/IResourceProxyVisitor;II)V 50 <appendix> member <vmtarget> ; # org/eclipse/core/internal/resources/Resource$$Lambda+0x00000139da2973a8
+instanceKlass  @cpi org/eclipse/core/internal/resources/Resource 1633 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da419000
+instanceKlass org/eclipse/core/internal/resources/ResourceProxy
+instanceKlass org/eclipse/aether/internal/impl/DefaultLocalPathComposer
+instanceKlass org/eclipse/aether/internal/impl/LocalPathComposer
+instanceKlass com/google/gson/TypeAdapter
+instanceKlass org/eclipse/debug/internal/core/LaunchManager$ResourceProxyVisitor
+instanceKlass org/eclipse/aether/internal/impl/DefaultInstaller
+instanceKlass org/eclipse/aether/impl/Installer
+instanceKlass com/google/gson/internal/Excluder
+instanceKlass com/google/gson/TypeAdapterFactory
+instanceKlass org/eclipse/aether/internal/impl/DefaultFileProcessor
+instanceKlass org/eclipse/aether/spi/io/FileProcessor
+instanceKlass com/google/gson/FieldNamingStrategy
+instanceKlass org/eclipse/debug/core/ILaunchMode
+instanceKlass org/eclipse/core/resources/IResourceProxyVisitor
+instanceKlass org/eclipse/aether/internal/impl/DefaultDeployer
+instanceKlass org/eclipse/aether/impl/Deployer
+instanceKlass com/google/gson/GsonBuilder
+instanceKlass org/eclipse/debug/core/ILaunchDelegate
+instanceKlass org/eclipse/aether/internal/impl/DefaultChecksumPolicyProvider
+instanceKlass org/eclipse/aether/spi/connector/checksum/ChecksumPolicyProvider
+instanceKlass com/google/common/base/Optional
+instanceKlass org/eclipse/jdt/internal/launching/LaunchingPlugin$1$1
+instanceKlass org/eclipse/aether/internal/impl/DefaultArtifactResolver
+instanceKlass org/eclipse/aether/impl/ArtifactResolver
+instanceKlass com/google/common/io/ByteArrayDataOutput
+instanceKlass com/google/common/io/ByteArrayDataInput
+instanceKlass org/eclipse/debug/core/model/IDebugElement
+instanceKlass org/eclipse/debug/core/ILaunch
+instanceKlass org/eclipse/debug/core/model/ISuspendResume
+instanceKlass org/eclipse/debug/core/model/IStepFilters
+instanceKlass org/eclipse/debug/core/model/IStep
+instanceKlass org/eclipse/debug/core/model/IDropToFrame
+instanceKlass org/eclipse/debug/core/model/IDisconnect
+instanceKlass org/eclipse/aether/connector/basic/BasicRepositoryConnectorFactory
+instanceKlass org/eclipse/aether/spi/locator/Service
+instanceKlass com/google/common/io/ByteStreams
+instanceKlass org/eclipse/aether/spi/connector/RepositoryConnectorFactory
+instanceKlass java/nio/channels/spi/AbstractInterruptibleChannel$1
+instanceKlass sun/nio/ch/Interruptible
+instanceKlass  @bci com/google/common/io/Closer <clinit> ()V 0 <appendix> argL0 ; # com/google/common/io/Closer$$Lambda+0x00000139da40c000
+instanceKlass  @cpi com/google/common/io/Closer 177 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da40a000
+instanceKlass org/apache/maven/model/validation/DefaultModelValidator
+instanceKlass com/google/common/io/Closer$Suppressor
+instanceKlass org/apache/maven/model/validation/ModelValidator
+instanceKlass com/google/common/io/Closer
+instanceKlass org/eclipse/debug/internal/core/commands/ForEachCommand$ExclusiveRule
+instanceKlass org/eclipse/debug/core/commands/AbstractDebugCommand
+instanceKlass org/apache/maven/model/superpom/DefaultSuperPomProvider
+instanceKlass org/apache/maven/model/superpom/SuperPomProvider
+instanceKlass com/google/common/io/CharSource
+instanceKlass org/apache/maven/model/profile/activation/PropertyProfileActivator
+instanceKlass org/eclipse/debug/core/commands/IStepFiltersHandler
+instanceKlass org/eclipse/debug/core/commands/IResumeHandler
+instanceKlass org/eclipse/debug/core/commands/ISuspendHandler
+instanceKlass org/eclipse/debug/core/commands/IDisconnectHandler
+instanceKlass org/eclipse/debug/core/commands/IDropToFrameHandler
+instanceKlass org/eclipse/debug/core/commands/IStepReturnHandler
+instanceKlass org/eclipse/debug/core/commands/IStepIntoHandler
+instanceKlass org/eclipse/debug/core/commands/IStepOverHandler
+instanceKlass org/eclipse/debug/core/commands/ITerminateHandler
+instanceKlass org/eclipse/debug/core/commands/IDebugCommandHandler
+instanceKlass org/apache/maven/model/profile/activation/OperatingSystemProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/JdkVersionProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/FileProfileActivator
+instanceKlass org/apache/maven/model/profile/activation/ProfileActivator
+instanceKlass org/eclipse/debug/internal/core/commands/CommandAdapterFactory
+instanceKlass com/google/common/hash/PrimitiveSink
+instanceKlass org/eclipse/debug/core/DebugPlugin$1$1
+instanceKlass org/eclipse/debug/internal/core/DebugOptions
+instanceKlass  @bci com/google/common/io/Files <clinit> ()V 0 <appendix> argL0 ; # com/google/common/io/Files$$Lambda+0x00000139da36dc50
+instanceKlass com/google/common/graph/SuccessorsFunction
+instanceKlass org/eclipse/debug/core/DebugPlugin$AsynchRunner
+instanceKlass org/eclipse/debug/core/DebugPlugin$EventNotifier
+instanceKlass org/apache/maven/model/profile/DefaultProfileSelector
+instanceKlass org/apache/maven/model/profile/ProfileSelector
+instanceKlass org/apache/maven/model/profile/DefaultProfileInjector
+instanceKlass org/apache/maven/model/profile/ProfileInjector
+instanceKlass com/google/common/io/ByteSource
+instanceKlass org/apache/maven/model/plugin/DefaultReportingConverter
+instanceKlass org/apache/maven/model/plugin/ReportingConverter
+instanceKlass org/apache/maven/model/plugin/DefaultReportConfigurationExpander
+instanceKlass org/apache/maven/model/plugin/ReportConfigurationExpander
+instanceKlass com/google/common/io/ByteSink
+instanceKlass org/apache/maven/model/plugin/DefaultPluginConfigurationExpander
+instanceKlass org/apache/maven/model/plugin/PluginConfigurationExpander
+instanceKlass org/apache/maven/model/path/ProfileActivationFilePathInterpolator
+instanceKlass org/apache/maven/model/path/DefaultUrlNormalizer
+instanceKlass org/apache/maven/model/path/UrlNormalizer
+instanceKlass com/google/common/io/LineProcessor
+instanceKlass org/eclipse/debug/core/IMemoryBlockManager
+instanceKlass org/eclipse/debug/core/IExpressionManager
+instanceKlass org/apache/maven/model/path/DefaultPathTranslator
+instanceKlass org/apache/maven/model/path/PathTranslator
+instanceKlass org/eclipse/debug/core/IBreakpointManager
+instanceKlass com/google/common/io/Files
+instanceKlass org/apache/maven/model/path/DefaultModelUrlNormalizer
+instanceKlass org/apache/maven/model/path/ModelUrlNormalizer
+instanceKlass org/eclipse/debug/core/ILaunchManager
+instanceKlass org/eclipse/debug/core/ILaunchConfigurationListener
+instanceKlass org/apache/maven/model/path/DefaultModelPathTranslator
+instanceKlass org/apache/maven/model/path/ModelPathTranslator
+instanceKlass org/eclipse/debug/core/model/IProcess
+instanceKlass com/google/common/base/Charsets
+instanceKlass org/eclipse/debug/core/model/ITerminate
+instanceKlass org/apache/maven/model/normalization/DefaultModelNormalizer
+instanceKlass org/apache/maven/model/normalization/ModelNormalizer
+instanceKlass org/apache/maven/model/management/DefaultPluginManagementInjector
+instanceKlass org/apache/maven/model/management/PluginManagementInjector
+instanceKlass org/apache/maven/model/management/DefaultDependencyManagementInjector
+instanceKlass org/apache/maven/model/management/DependencyManagementInjector
+instanceKlass org/apache/maven/model/locator/DefaultModelLocator
+instanceKlass org/apache/maven/model/io/DefaultModelWriter
+instanceKlass org/apache/maven/model/io/ModelWriter
+instanceKlass org/apache/maven/model/io/DefaultModelReader
+instanceKlass org/eclipse/debug/core/ILaunchConfiguration
+instanceKlass org/eclipse/debug/core/IDebugEventSetListener
+instanceKlass org/eclipse/debug/core/ILaunchesListener
+instanceKlass org/apache/maven/model/interpolation/AbstractStringBasedModelInterpolator
+instanceKlass org/apache/maven/model/interpolation/ModelInterpolator
+instanceKlass org/apache/maven/model/interpolation/DefaultModelVersionProcessor
+instanceKlass org/apache/maven/model/interpolation/ModelVersionProcessor
+instanceKlass org/eclipse/buildship/core/internal/launch/DefaultGradleLaunchConfigurationManager
+instanceKlass org/eclipse/buildship/core/internal/console/StdProcessStreamsProvider$1
+instanceKlass org/eclipse/jdt/launching/IVMInstallChangedListener
+instanceKlass org/eclipse/buildship/core/internal/console/ProcessStreams
+instanceKlass org/eclipse/buildship/core/internal/console/StdProcessStreamsProvider
+instanceKlass org/apache/maven/model/inheritance/DefaultInheritanceAssembler
+instanceKlass org/apache/maven/model/inheritance/InheritanceAssembler
+instanceKlass org/eclipse/buildship/core/internal/workspace/InternalGradleBuild
+instanceKlass org/apache/maven/model/composition/DefaultDependencyManagementImporter
+instanceKlass org/apache/maven/model/composition/DependencyManagementImporter
+instanceKlass org/eclipse/buildship/core/internal/workspace/DefaultGradleWorkspace
+instanceKlass com/google/gson/reflect/TypeToken
+instanceKlass  @bci sun/reflect/annotation/AnnotationParser parseClassArray (ILjava/nio/ByteBuffer;Ljdk/internal/reflect/ConstantPool;Ljava/lang/Class;)Ljava/lang/Object; 10 <appendix> member <vmtarget> ; # sun/reflect/annotation/AnnotationParser$$Lambda+0x00000139da3c41e0
+instanceKlass org/apache/maven/model/building/DefaultModelProcessor
+instanceKlass java/util/concurrent/Executors$DefaultThreadFactory
+instanceKlass org/apache/maven/model/building/ModelProcessor
+instanceKlass org/apache/maven/model/io/ModelReader
+instanceKlass org/eclipse/buildship/core/internal/event/Event
+instanceKlass org/apache/maven/model/locator/ModelLocator
+instanceKlass org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions
+instanceKlass org/eclipse/jdt/ls/core/internal/ProjectUtils
+instanceKlass org/apache/maven/model/building/DefaultModelBuilder
+instanceKlass org/eclipse/buildship/core/internal/workspace/DefaultWorkspaceOperations
+instanceKlass org/apache/maven/model/building/ModelBuilder
+instanceKlass org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersionsWrapper$LoadVersionsJob$1
+instanceKlass org/apache/maven/cli/internal/BootstrapCoreExtensionManager
+instanceKlass com/google/gson/JsonElement
+instanceKlass org/eclipse/buildship/core/internal/util/logging/EclipseLogger
+instanceKlass org/apache/maven/toolchain/io/DefaultToolchainsWriter
+instanceKlass org/apache/maven/toolchain/io/ToolchainsWriter
+instanceKlass org/apache/maven/toolchain/io/DefaultToolchainsReader
+instanceKlass org/apache/maven/toolchain/io/ToolchainsReader
+instanceKlass org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersionsWrapper
+instanceKlass org/apache/maven/toolchain/building/DefaultToolchainsBuilder
+instanceKlass org/apache/maven/toolchain/building/ToolchainsBuilder
+instanceKlass org/eclipse/jdt/ls/core/internal/managers/TelemetryManager
+instanceKlass org/eclipse/buildship/core/internal/Logger
+instanceKlass org/apache/maven/session/scope/internal/SessionScope$ScopeState
+instanceKlass  @bci org/apache/maven/session/scope/internal/SessionScope <clinit> ()V 0 <appendix> argL0 ; # org/apache/maven/session/scope/internal/SessionScope$$Lambda+0x00000139da3b04c0
+instanceKlass org/apache/maven/session/scope/internal/SessionScope
+instanceKlass org/eclipse/buildship/core/internal/launch/ExternalLaunchConfigurationManager
+instanceKlass org/eclipse/buildship/core/internal/launch/GradleLaunchConfigurationManager
+instanceKlass org/eclipse/core/runtime/jobs/ProgressProvider
+instanceKlass org/eclipse/jdt/ls/core/internal/LanguageServerApplication
+instanceKlass org/eclipse/equinox/app/IApplication
+instanceKlass org/eclipse/buildship/core/GradleBuild
+instanceKlass org/apache/maven/plugin/internal/AbstractMavenPluginDependenciesValidator
+instanceKlass org/apache/maven/plugin/internal/MavenPluginDependenciesValidator
+instanceKlass org/eclipse/buildship/core/internal/workspace/InternalGradleWorkspace
+instanceKlass org/eclipse/buildship/core/GradleWorkspace
+instanceKlass org/eclipse/core/runtime/internal/adaptor/EclipseAppLauncher
+instanceKlass org/apache/maven/plugin/internal/AbstractMavenPluginParametersValidator
+instanceKlass org/eclipse/buildship/core/internal/event/ListenerRegistry
+instanceKlass org/apache/maven/plugin/internal/MavenPluginConfigurationValidator
+instanceKlass org/eclipse/buildship/core/internal/workspace/WorkspaceOperations
+instanceKlass org/eclipse/buildship/core/internal/console/ProcessStreamsProvider
+instanceKlass org/eclipse/buildship/core/internal/preferences/ModelPersistence
+instanceKlass org/apache/maven/eventspy/AbstractEventSpy
+instanceKlass org/eclipse/buildship/core/internal/extension/ExtensionManager
+instanceKlass org/apache/maven/plugin/PluginValidationManager
+instanceKlass org/eclipse/buildship/core/internal/operation/ToolingApiOperationManager
+instanceKlass org/eclipse/buildship/core/internal/configuration/ConfigurationManager
+instanceKlass org/eclipse/buildship/core/invocation/InvocationCustomizer
+instanceKlass org/eclipse/buildship/core/internal/TraceScope
+instanceKlass org/apache/maven/plugin/DefaultMojosExecutionStrategy
+instanceKlass org/apache/maven/plugin/MojosExecutionStrategy
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDependencyResolver
+instanceKlass org/apache/maven/lifecycle/internal/DefaultProjectArtifactFactory
+instanceKlass org/apache/maven/lifecycle/internal/ProjectArtifactFactory
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock$Sync$HoldCounter
+instanceKlass org/apache/maven/internal/aether/ResolverLifecycle
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/BundleUtils
+instanceKlass org/apache/maven/internal/aether/DefaultRepositorySystemSessionFactory
+instanceKlass org/apache/maven/extension/internal/CoreExportsProvider
+instanceKlass org/apache/maven/execution/MojoExecutionEvent
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope$ScopeState
+instanceKlass org/apache/maven/execution/scope/MojoExecutionScoped
+instanceKlass com/google/inject/RestrictedBindingSource$Permit
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope$1
+instanceKlass org/apache/maven/execution/scope/internal/MojoExecutionScope
+instanceKlass org/apache/maven/execution/MojoExecutionListener
+instanceKlass org/eclipse/sisu/space/QualifiedTypeBinder$1
+instanceKlass org/apache/maven/execution/DefaultMavenExecutionRequestPopulator
+instanceKlass org/apache/maven/execution/MavenExecutionRequestPopulator
+instanceKlass org/apache/maven/classrealm/DefaultClassRealmManager
+instanceKlass org/apache/maven/classrealm/ClassRealmManager
+instanceKlass org/apache/maven/SessionScoped
+instanceKlass org/apache/maven/ReactorReader
+instanceKlass org/apache/maven/repository/internal/MavenWorkspaceReader
+instanceKlass org/apache/maven/DefaultArtifactFilterManager
+instanceKlass org/apache/maven/ArtifactFilterManager
+instanceKlass org/eclipse/sisu/space/WildcardKey$QualifiedImpl
+instanceKlass org/eclipse/sisu/space/WildcardKey$Qualified
+instanceKlass org/eclipse/sisu/space/WildcardKey
+instanceKlass org/eclipse/sisu/Typed
+instanceKlass org/sonatype/inject/EagerSingleton
+instanceKlass org/eclipse/sisu/EagerSingleton
+instanceKlass org/sonatype/inject/Mediator
+instanceKlass org/eclipse/sisu/inject/TypeArguments
+instanceKlass org/eclipse/m2e/internal/maven/listener/M2EMavenBuildDataBridge
+instanceKlass org/apache/maven/eventspy/EventSpy
+instanceKlass org/objectweb/asm/Context
+instanceKlass org/objectweb/asm/Attribute
+instanceKlass org/eclipse/equinox/internal/security/storage/SecurePreferencesWrapper
+instanceKlass org/objectweb/asm/AnnotationVisitor
+instanceKlass org/eclipse/equinox/security/storage/ISecurePreferences
+instanceKlass org/eclipse/equinox/internal/security/storage/SecurePreferencesContainer
+instanceKlass  @bci org/eclipse/equinox/internal/security/storage/SecurePreferencesRoot load ()V 241 <appendix> member <vmtarget> ; # org/eclipse/equinox/internal/security/storage/SecurePreferencesRoot$$Lambda+0x00000139da3a5348
+instanceKlass javax/crypto/spec/PBEKeySpec
+instanceKlass org/eclipse/equinox/internal/security/storage/PasswordExt
+instanceKlass org/eclipse/equinox/internal/security/storage/JavaEncryption
+instanceKlass org/objectweb/asm/ClassReader
+instanceKlass org/eclipse/equinox/security/storage/provider/IPreferencesContainer
+instanceKlass org/eclipse/equinox/internal/security/storage/SecurePreferences
+instanceKlass org/eclipse/sisu/space/IndexedClassFinder$1
+instanceKlass org/eclipse/equinox/internal/security/storage/friends/IStorageConstants
+instanceKlass org/eclipse/equinox/internal/security/storage/StorageUtils
+instanceKlass org/eclipse/equinox/internal/security/storage/SecurePreferencesMapper
+instanceKlass org/eclipse/sisu/inject/Logs$SLF4JSink
+instanceKlass org/eclipse/sisu/inject/Logs$Sink
+instanceKlass org/eclipse/equinox/security/storage/SecurePreferencesFactory
+instanceKlass org/eclipse/sisu/inject/Logs
+instanceKlass org/eclipse/sisu/space/QualifierCache
+instanceKlass org/eclipse/sisu/space/QualifiedTypeVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeVisitor$ComponentAnnotationVisitor
+instanceKlass com/sun/jna/Function$PostCallRead
+instanceKlass org/eclipse/sisu/space/AnnotationVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeVisitor
+instanceKlass org/eclipse/sisu/space/ClassVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlBeanModule$PlexusXmlBeanSource
+instanceKlass org/eclipse/sisu/inject/DescriptionSource
+instanceKlass org/eclipse/sisu/inject/AnnotatedSource
+instanceKlass org/eclipse/sisu/Hidden
+instanceKlass org/eclipse/sisu/Priority
+instanceKlass org/eclipse/sisu/Description
+instanceKlass org/eclipse/sisu/inject/Sources
+instanceKlass com/sun/jna/NativeString
+instanceKlass com/sun/jna/Library$Handler$FunctionInfo
+instanceKlass com/google/inject/internal/MoreTypes$ParameterizedTypeImpl
+instanceKlass sun/reflect/generics/reflectiveObjects/ParameterizedTypeImpl
+instanceKlass sun/reflect/generics/reflectiveObjects/LazyReflectiveObjectGenerator
+instanceKlass com/sun/jna/internal/ReflectionUtils
+instanceKlass com/sun/jna/Native$3
+instanceKlass org/apache/maven/wagon/Wagon
+instanceKlass org/apache/maven/toolchain/ToolchainsBuilder
+instanceKlass org/apache/maven/toolchain/ToolchainManagerPrivate
+instanceKlass org/apache/maven/toolchain/ToolchainManager
+instanceKlass org/apache/maven/toolchain/ToolchainFactory
+instanceKlass com/sun/jna/Library$Handler
+instanceKlass org/apache/maven/settings/MavenSettingsBuilder
+instanceKlass com/sun/jna/win32/W32APIFunctionMapper
+instanceKlass com/sun/jna/FunctionMapper
+instanceKlass org/apache/maven/rtinfo/RuntimeInformation
+instanceKlass org/apache/maven/project/artifact/ProjectArtifactsCache
+instanceKlass com/sun/jna/win32/W32APIOptions
+instanceKlass org/apache/maven/project/ProjectDependenciesResolver
+instanceKlass org/apache/maven/project/ProjectBuildingHelper
+instanceKlass org/eclipse/core/net/internal/proxy/win32/ProxyProviderWin32$WinHttp
+instanceKlass com/sun/jna/win32/StdCallLibrary
+instanceKlass com/sun/jna/win32/StdCall
+instanceKlass com/sun/jna/AltCallingConvention
+instanceKlass org/eclipse/core/internal/net/ProxyData
+instanceKlass org/apache/maven/project/ProjectBuilder
+instanceKlass org/apache/maven/project/MavenProjectHelper
+instanceKlass org/apache/maven/plugin/version/PluginVersionResolver
+instanceKlass org/eclipse/equinox/internal/security/auth/AuthPlugin
+instanceKlass org/apache/maven/plugin/prefix/PluginPrefixResolver
+instanceKlass org/apache/maven/plugin/PluginManager
+instanceKlass org/apache/maven/plugin/PluginDescriptorCache
+instanceKlass org/apache/maven/plugin/MavenPluginManager
+instanceKlass org/eclipse/core/internal/net/ProxyType
+instanceKlass org/apache/maven/plugin/LegacySupport
+instanceKlass org/apache/maven/plugin/BuildPluginManager
+instanceKlass org/eclipse/core/net/proxy/IProxyChangeEvent
+instanceKlass org/apache/maven/model/plugin/LifecycleBindingsInjector
+instanceKlass org/apache/maven/lifecycle/internal/builder/BuilderCommon
+instanceKlass org/apache/maven/lifecycle/internal/builder/Builder
+instanceKlass org/apache/maven/lifecycle/internal/MojoExecutor
+instanceKlass org/eclipse/core/internal/net/AbstractProxyProvider
+instanceKlass org/eclipse/core/internal/net/ProxyManager
+instanceKlass org/eclipse/core/net/proxy/IProxyService
+instanceKlass org/apache/maven/lifecycle/internal/MojoDescriptorCreator
+instanceKlass  @bci org/eclipse/core/internal/net/Policy <clinit> ()V 8 <appendix> argL0 ; # org/eclipse/core/internal/net/Policy$$Lambda+0x00000139da391618
+instanceKlass org/eclipse/core/internal/net/Policy
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleTaskSegmentCalculator
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleStarter
+instanceKlass org/apache/maven/lifecycle/internal/LifecyclePluginResolver
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleModuleBuilder
+instanceKlass org/eclipse/core/net/proxy/IProxyData
+instanceKlass org/eclipse/core/internal/net/PreferenceManager
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleExecutionPlanCalculator
+instanceKlass org/apache/maven/lifecycle/internal/LifecycleDebugLogger
+instanceKlass org/apache/maven/lifecycle/internal/ExecutionEventCatapult
+instanceKlass org/apache/maven/lifecycle/internal/BuildListCalculator
+instanceKlass org/apache/maven/lifecycle/MojoExecutionConfigurator
+instanceKlass org/eclipse/core/internal/net/Activator
+instanceKlass java/lang/foreign/MemorySegment
+instanceKlass org/eclipse/core/internal/net/ProxySelector
+instanceKlass org/apache/maven/lifecycle/LifecycleMappingDelegate
+instanceKlass org/apache/maven/lifecycle/LifecycleExecutor
+instanceKlass org/apache/maven/lifecycle/LifeCyclePluginAnalyzer
+instanceKlass java/text/DontCareFieldPosition$1
+instanceKlass org/apache/maven/lifecycle/DefaultLifecycles
+instanceKlass org/apache/maven/graph/GraphBuilder
+instanceKlass org/apache/maven/exception/ExceptionHandler
+instanceKlass org/apache/maven/eventspy/internal/EventSpyDispatcher
+instanceKlass org/apache/maven/configuration/BeanConfigurator
+instanceKlass org/eclipse/osgi/framework/log/FrameworkLogEntry
+instanceKlass org/apache/maven/bridge/MavenRepositorySystem
+instanceKlass org/apache/maven/artifact/resolver/ResolutionErrorHandler
+instanceKlass org/apache/maven/artifact/repository/metadata/io/MetadataReader
+instanceKlass org/eclipse/jdt/ls/core/internal/DiagnosticsState
+instanceKlass org/eclipse/jdt/ls/core/internal/managers/ContentProviderManager
+instanceKlass org/apache/maven/artifact/metadata/ArtifactMetadataSource
+instanceKlass org/apache/maven/repository/legacy/metadata/ArtifactMetadataSource
+instanceKlass org/apache/maven/artifact/handler/manager/ArtifactHandlerManager
+instanceKlass org/eclipse/jdt/ls/core/internal/managers/DigestStore
+instanceKlass org/apache/maven/artifact/factory/ArtifactFactory
+instanceKlass org/eclipse/lsp4j/jsonrpc/messages/Either
+instanceKlass org/apache/maven/ProjectDependenciesResolver
+instanceKlass org/apache/maven/Maven
+instanceKlass org/eclipse/jdt/ls/core/internal/framework/IFrameworkSupport
+instanceKlass org/apache/maven/artifact/handler/ArtifactHandler
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/IPreferencesChangeListener
+instanceKlass org/sonatype/plexus/components/sec/dispatcher/SecDispatcher
+instanceKlass org/apache/maven/lifecycle/Lifecycle
+instanceKlass org/eclipse/sisu/space/CloningClassSpace$1
+instanceKlass org/apache/maven/lifecycle/mapping/LifecycleMapping
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences firePreferenceEvent (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V 41 <appendix> member <vmtarget> ; # org/eclipse/core/internal/preferences/EclipsePreferences$$Lambda+0x00000139da1ab6a8
+instanceKlass org/apache/maven/repository/metadata/GraphConflictResolver
+instanceKlass org/apache/maven/repository/metadata/GraphConflictResolutionPolicy
+instanceKlass org/eclipse/text/templates/TemplateStoreCore
+instanceKlass org/eclipse/sisu/plexus/ConfigurationImpl
+instanceKlass org/apache/maven/repository/metadata/ClasspathTransformation
+instanceKlass com/sun/org/apache/xml/internal/serializer/WriterChain
+instanceKlass org/apache/maven/repository/legacy/resolver/transform/ArtifactTransformationManager
+instanceKlass org/apache/maven/repository/legacy/resolver/transform/ArtifactTransformation
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/ConflictResolverFactory
+instanceKlass com/sun/org/apache/xalan/internal/xsltc/trax/DOM2TO
+instanceKlass javax/xml/transform/stax/StAXSource
+instanceKlass org/apache/maven/repository/legacy/resolver/conflict/ConflictResolver
+instanceKlass javax/xml/transform/sax/SAXSource
+instanceKlass javax/xml/transform/stream/StreamSource
+instanceKlass com/sun/org/apache/xml/internal/serializer/NamespaceMappings$MappingRecord
+instanceKlass com/sun/org/apache/xml/internal/serializer/NamespaceMappings
+instanceKlass org/apache/maven/repository/legacy/repository/ArtifactRepositoryFactory
+instanceKlass org/apache/maven/repository/legacy/UpdateCheckManager
+instanceKlass org/apache/maven/repository/RepositorySystem
+instanceKlass org/apache/maven/repository/MirrorSelector
+instanceKlass org/apache/maven/project/validation/ModelValidator
+instanceKlass org/apache/maven/project/path/PathTranslator
+instanceKlass org/apache/maven/project/interpolation/ModelInterpolator
+instanceKlass org/apache/maven/project/inheritance/ModelInheritanceAssembler
+instanceKlass org/apache/maven/project/MavenProjectBuilder
+instanceKlass org/apache/maven/profiles/MavenProfilesBuilder
+instanceKlass org/apache/maven/execution/RuntimeInformation
+instanceKlass org/apache/maven/artifact/resolver/ArtifactResolver
+instanceKlass org/apache/maven/artifact/resolver/ArtifactCollector
+instanceKlass org/apache/maven/repository/legacy/resolver/LegacyArtifactCollector
+instanceKlass org/apache/maven/artifact/repository/metadata/RepositoryMetadataManager
+instanceKlass org/apache/maven/artifact/repository/layout/ArtifactRepositoryLayout
+instanceKlass org/apache/maven/artifact/repository/ArtifactRepositoryFactory
+instanceKlass org/apache/maven/artifact/manager/WagonManager
+instanceKlass org/apache/maven/repository/legacy/WagonManager
+instanceKlass org/apache/maven/artifact/installer/ArtifactInstaller
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlMetadata
+instanceKlass org/eclipse/sisu/plexus/Roles
+instanceKlass org/apache/maven/artifact/deployer/ArtifactDeployer
+instanceKlass org/eclipse/sisu/plexus/Hints
+instanceKlass org/eclipse/sisu/space/AbstractDeferredClass
+instanceKlass org/eclipse/sisu/plexus/RequirementImpl
+instanceKlass org/codehaus/plexus/component/annotations/Requirement
+instanceKlass sun/nio/cs/DelegatableDecoder
+instanceKlass org/eclipse/sisu/space/Streams
+instanceKlass org/eclipse/sisu/plexus/ComponentImpl
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeRegistry
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlScanner
+instanceKlass org/eclipse/sisu/space/QualifiedTypeBinder
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeBinder
+instanceKlass org/eclipse/aether/AbstractRepositoryListener
+instanceKlass org/eclipse/aether/RepositoryListener
+instanceKlass com/google/inject/Key$AnnotationInstanceStrategy
+instanceKlass java/nio/charset/Charset$1
+instanceKlass java/nio/charset/Charset$2
+instanceKlass java/nio/charset/Charset$ThreadTrackHolder
+instanceKlass com/google/inject/name/NamedImpl
+instanceKlass com/google/inject/name/Named
+instanceKlass com/google/inject/name/Names
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$IntItem
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$Item
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion
+instanceKlass org/apache/maven/artifact/versioning/DefaultArtifactVersion
+instanceKlass org/apache/maven/artifact/versioning/ArtifactVersion
+instanceKlass java/nio/charset/Charset$ExtendedProviderHolder$1
+instanceKlass java/nio/charset/Charset$ExtendedProviderHolder
+instanceKlass org/eclipse/m2e/core/internal/embedder/EclipseClassRealmManagerDelegate
+instanceKlass org/apache/maven/classrealm/ClassRealmManagerDelegate
+instanceKlass  @bci jdk/xml/internal/SecuritySupport getResourceAsStream (Ljava/lang/String;)Ljava/io/InputStream; 1 <appendix> member <vmtarget> ; # jdk/xml/internal/SecuritySupport$$Lambda+0x00000139da1fcd30
+instanceKlass org/sonatype/plexus/build/incremental/ThreadBuildContext
+instanceKlass com/sun/org/apache/xml/internal/serializer/Encodings$EncodingInfos
+instanceKlass com/sun/org/apache/xml/internal/serializer/Encodings
+instanceKlass com/sun/org/apache/xml/internal/serializer/ToStream$CharacterBuffer
+instanceKlass com/sun/org/apache/xml/internal/serializer/EncodingInfo
+instanceKlass org/sonatype/plexus/build/incremental/BuildContext
+instanceKlass com/sun/org/apache/xml/internal/serializer/ToStream$BoolStack
+instanceKlass com/sun/org/apache/xml/internal/serializer/ElemContext
+instanceKlass org/xml/sax/helpers/AttributesImpl
+instanceKlass com/sun/org/apache/xml/internal/serializer/CharInfo$CharKey
+instanceKlass org/apache/maven/plugin/internal/DefaultPluginDependenciesResolver
+instanceKlass sun/util/ResourceBundleEnumeration
+instanceKlass com/sun/org/apache/xml/internal/serializer/CharInfo
+instanceKlass com/sun/org/apache/xml/internal/serializer/SerializerBase
+instanceKlass com/sun/org/apache/xml/internal/serializer/SerializerConstants
+instanceKlass com/sun/org/apache/xml/internal/serializer/SerializationHandler
+instanceKlass com/sun/org/apache/xml/internal/serializer/Serializer
+instanceKlass com/sun/org/apache/xml/internal/serializer/DOMSerializer
+instanceKlass org/xml/sax/ext/DeclHandler
+instanceKlass com/sun/org/apache/xml/internal/serializer/XSLOutputAttributes
+instanceKlass com/sun/org/apache/xml/internal/serializer/ExtendedLexicalHandler
+instanceKlass org/xml/sax/ext/LexicalHandler
+instanceKlass org/apache/maven/plugin/internal/PluginDependenciesResolver
+instanceKlass com/sun/org/apache/xml/internal/serializer/ExtendedContentHandler
+instanceKlass org/apache/maven/plugin/DefaultPluginArtifactsCache
+instanceKlass org/apache/maven/plugin/PluginArtifactsCache
+instanceKlass org/apache/maven/plugin/DefaultPluginRealmCache
+instanceKlass javax/xml/transform/dom/DOMResult
+instanceKlass javax/xml/transform/stax/StAXResult
+instanceKlass javax/xml/transform/sax/SAXResult
+instanceKlass com/sun/org/apache/xalan/internal/xsltc/runtime/output/TransletOutputHandlerFactory
+instanceKlass org/apache/maven/plugin/PluginRealmCache
+instanceKlass javax/xml/transform/dom/DOMSource
+instanceKlass com/sun/org/apache/xml/internal/utils/XMLReaderManager
+instanceKlass org/apache/maven/project/DefaultProjectRealmCache
+instanceKlass org/apache/maven/project/ProjectRealmCache
+instanceKlass com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory
+instanceKlass org/apache/maven/plugin/DefaultExtensionRealmCache
+instanceKlass javax/xml/transform/Transformer
+instanceKlass com/sun/org/apache/xalan/internal/xsltc/DOMCache
+instanceKlass org/apache/maven/plugin/ExtensionRealmCache
+instanceKlass  @bci javax/xml/catalog/CatalogFeatures setProperties (Ljavax/xml/catalog/CatalogFeatures$Builder;)V 5 <appendix> member <vmtarget> ; # javax/xml/catalog/CatalogFeatures$$Lambda+0x00000139da1f6220
+instanceKlass javax/xml/catalog/CatalogMessages
+instanceKlass javax/xml/catalog/Util
+instanceKlass  @bci javax/xml/transform/FactoryFinder newInstance (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/ClassLoader;Z)Ljava/lang/Object; 107 <appendix> member <vmtarget> ; # javax/xml/transform/FactoryFinder$$Lambda+0x00000139da1f57a8
+instanceKlass jdk/xml/internal/JdkProperty
+instanceKlass com/sun/org/apache/xalan/internal/utils/FeaturePropertyBase
+instanceKlass org/codehaus/plexus/component/annotations/Component
+instanceKlass jdk/xml/internal/JdkXmlFeatures
+instanceKlass javax/xml/catalog/CatalogFeatures$Builder
+instanceKlass javax/xml/catalog/CatalogFeatures
+instanceKlass jdk/xml/internal/TransformErrorListener
+instanceKlass javax/xml/transform/ErrorListener
+instanceKlass org/apache/maven/project/artifact/DefaultMavenMetadataCache
+instanceKlass com/sun/org/apache/xalan/internal/xsltc/compiler/SourceLoader
+instanceKlass org/eclipse/m2e/core/internal/project/IManagedCache
+instanceKlass org/apache/maven/project/artifact/MavenMetadataCache
+instanceKlass  @bci javax/xml/transform/FactoryFinder find (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Object; 123 <appendix> member <vmtarget> ; # javax/xml/transform/FactoryFinder$$Lambda+0x00000139da1f28f0
+instanceKlass org/eclipse/m2e/core/internal/embedder/DefaultMavenComponentContributor
+instanceKlass org/eclipse/m2e/core/internal/embedder/IMavenComponentContributor
+instanceKlass javax/xml/transform/FactoryFinder$1
+instanceKlass  @bci javax/xml/transform/FactoryFinder find (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Object; 24 <appendix> member <vmtarget> ; # javax/xml/transform/FactoryFinder$$Lambda+0x00000139da1f2498
+instanceKlass javax/xml/transform/FactoryFinder
+instanceKlass javax/xml/transform/TransformerFactory
+instanceKlass javax/xml/transform/stream/StreamResult
+instanceKlass ch/qos/logback/classic/spi/LoggerContextListener
+instanceKlass org/eclipse/text/templates/TemplateReaderWriter
+instanceKlass java/lang/Deprecated
+instanceKlass  @bci org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager reloadTemplateStore ()V 24 <appendix> argL0 ; # org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager$$Lambda+0x00000139da35fd90
+instanceKlass ch/qos/logback/core/spi/ConfigurationEventListener
+instanceKlass org/eclipse/text/templates/TemplatePersistenceData
+instanceKlass ch/qos/logback/core/spi/ConfigurationEvent
+instanceKlass org/eclipse/jface/text/templates/Template
+instanceKlass ch/qos/logback/core/spi/SequenceNumberGenerator
+instanceKlass ch/qos/logback/core/LifeCycleManager
+instanceKlass com/google/inject/spi/InjectionRequest
+instanceKlass org/eclipse/sisu/bean/BeanProperty
+instanceKlass com/google/common/collect/ObjectArrays
+instanceKlass com/google/inject/internal/Nullability
+instanceKlass  @bci com/google/inject/internal/KotlinSupport$KotlinUnsupported <clinit> ()V 7 <appendix> argL0 ; # com/google/inject/internal/KotlinSupport$KotlinUnsupported$$Lambda+0x00000139da374a80
+instanceKlass com/google/inject/internal/KotlinSupport$KotlinUnsupported
+instanceKlass java/util/ResourceBundle$Control$2
+instanceKlass com/google/inject/internal/KotlinSupport$KotlinSupportHolder
+instanceKlass com/google/inject/internal/KotlinSupportInterface
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleControlProviderHolder lambda$static$0 ()Ljava/util/List; 11 <appendix> argL0 ; # java/util/ResourceBundle$ResourceBundleControlProviderHolder$$Lambda+0x00000139da1f1260
+instanceKlass com/google/inject/internal/KotlinSupport
+instanceKlass java/util/ServiceLoader$ProviderSpliterator
+instanceKlass com/google/inject/spi/InjectionPoint$OverrideIndex
+instanceKlass java/util/spi/ResourceBundleControlProvider
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleControlProviderHolder <clinit> ()V 0 <appendix> argL0 ; # java/util/ResourceBundle$ResourceBundleControlProviderHolder$$Lambda+0x00000139da1efdd8
+instanceKlass java/util/ResourceBundle$ResourceBundleControlProviderHolder
+instanceKlass org/eclipse/jface/text/templates/TextTemplateMessages
+instanceKlass org/eclipse/sisu/inject/RankedBindings
+instanceKlass org/eclipse/sisu/Mediator
+instanceKlass sun/reflect/generics/tree/TypeVariableSignature
+instanceKlass com/google/inject/Inject
+instanceKlass javax/inject/Inject
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 38 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da3631b8
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 20 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da362f78
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 15 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da362d38
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredFields (Ljava/lang/Class;)[Ljava/lang/reflect/Field; 7 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da362af8
+instanceKlass org/eclipse/jface/text/IRegion
+instanceKlass java/lang/reflect/WildcardType
+instanceKlass com/google/inject/spi/InjectionPoint$InjectableMembers
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler
+instanceKlass com/google/inject/spi/InjectionPoint$InjectableMember
+instanceKlass com/google/inject/spi/InjectionPoint
+instanceKlass java/lang/reflect/ParameterizedType
+instanceKlass com/google/inject/internal/MoreTypes$GenericArrayTypeImpl
+instanceKlass com/google/inject/internal/MoreTypes$CompositeType
+instanceKlass com/google/inject/Key$AnnotationTypeStrategy
+instanceKlass com/google/common/cache/LocalCache$StrongValueReference
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Failure
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Cancellation
+instanceKlass com/google/common/util/concurrent/AbstractFuture$DelegatingToFuture
+instanceKlass com/google/common/util/concurrent/Platform
+instanceKlass sun/nio/fs/WindowsPath$1
+instanceKlass com/google/common/util/concurrent/Uninterruptibles
+instanceKlass org/apache/commons/lang3/text/StrTokenizer
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Listener
+instanceKlass com/google/common/util/concurrent/AbstractFutureState$Waiter
+instanceKlass org/apache/commons/lang3/text/StrBuilder
+instanceKlass org/apache/commons/lang3/builder/Builder
+instanceKlass com/google/common/util/concurrent/LazyLogger
+instanceKlass  @bci java/util/regex/CharPredicates forUnicodeBlock (Ljava/lang/String;)Ljava/util/regex/Pattern$CharPredicate; 6 <appendix> member <vmtarget> ; # java/util/regex/CharPredicates$$Lambda+0x00000139da1eee78
+instanceKlass com/google/common/util/concurrent/AbstractFutureState$AtomicHelper
+instanceKlass com/google/common/util/concurrent/internal/InternalFutureFailureAccess
+instanceKlass com/google/common/util/concurrent/AbstractFuture$Trusted
+instanceKlass com/google/common/util/concurrent/ListenableFuture
+instanceKlass java/lang/Character$Subset
+instanceKlass  @bci sun/reflect/annotation/AnnotationParser parseEnumArray (ILjava/lang/Class;Ljava/nio/ByteBuffer;Ljdk/internal/reflect/ConstantPool;Ljava/lang/Class;)Ljava/lang/Object; 16 <appendix> member <vmtarget> ; # sun/reflect/annotation/AnnotationParser$$Lambda+0x00000139da1edf98
+instanceKlass org/apache/commons/lang3/StringUtils
+instanceKlass javax/inject/Named
+instanceKlass javax/inject/Qualifier
+instanceKlass com/google/inject/BindingAnnotation
+instanceKlass javax/inject/Scope
+instanceKlass com/google/inject/ScopeAnnotation
+instanceKlass com/google/inject/internal/Annotations$AnnotationChecker
+instanceKlass java/util/DualPivotQuicksort
+instanceKlass org/apache/commons/lang3/ArraySorter
+instanceKlass com/google/inject/internal/Annotations$TestAnnotation
+instanceKlass org/apache/commons/lang3/text/StrMatcher
+instanceKlass com/google/inject/internal/Annotations$AnnotationToStringConfig
+instanceKlass org/apache/commons/lang3/text/StrSubstitutor
+instanceKlass com/google/common/base/Joiner$MapJoiner
+instanceKlass com/google/common/base/Joiner
+instanceKlass org/apache/commons/lang3/text/StrLookup
+instanceKlass com/google/inject/internal/Annotations
+instanceKlass org/eclipse/sisu/Parameters
+instanceKlass org/eclipse/sisu/wire/ParameterKeys
+instanceKlass org/eclipse/jdt/ls/core/internal/ResourceUtils
+instanceKlass com/google/inject/internal/util/StackTraceElements$InMemoryStackTraceElement
+instanceKlass com/google/inject/internal/util/StackTraceElements
+instanceKlass org/eclipse/sisu/wire/TypeConverterCache
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/Preferences$ReferencedLibraries
+instanceKlass java/util/UUID$Holder
+instanceKlass com/google/inject/internal/Scoping
+instanceKlass com/google/inject/internal/InternalFactory
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/Preferences
+instanceKlass com/google/inject/internal/InternalFlags$1
+instanceKlass com/google/inject/internal/InternalFlags
+instanceKlass com/google/inject/spi/ProviderInstanceBinding
+instanceKlass com/google/inject/spi/ProviderKeyBinding
+instanceKlass com/google/inject/spi/InstanceBinding
+instanceKlass com/google/inject/internal/DelayedInitialize
+instanceKlass com/google/inject/spi/ConstructorBinding
+instanceKlass org/eclipse/jface/text/templates/TemplateContextType
+instanceKlass com/google/inject/spi/HasDependencies
+instanceKlass com/google/inject/spi/LinkedKeyBinding
+instanceKlass com/google/inject/spi/UntargettedBinding
+instanceKlass com/google/inject/internal/BindingImpl
+instanceKlass org/eclipse/jface/text/templates/TemplateVariableResolver
+instanceKlass com/google/inject/Key$AnnotationStrategy
+instanceKlass org/eclipse/sisu/wire/ElementAnalyzer$1
+instanceKlass java/lang/ProcessEnvironment$CheckedEntry
+instanceKlass java/lang/ProcessEnvironment$CheckedEntrySet$1
+instanceKlass java/lang/ProcessEnvironment$EntryComparator
+instanceKlass java/lang/ProcessEnvironment$NameComparator
+instanceKlass com/google/inject/util/Modules$EmptyModule
+instanceKlass com/google/inject/util/Modules$OverriddenModuleBuilder
+instanceKlass com/google/inject/util/Modules
+instanceKlass org/eclipse/jdt/ls/core/internal/Environment
+instanceKlass org/eclipse/jdt/ls/core/internal/JDTEnvironmentUtils
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/LogHandler$1
+instanceKlass  @bci sun/util/locale/provider/JRELocaleProviderAdapter getDateFormatProvider ()Ljava/text/spi/DateFormatProvider; 8 <appendix> member <vmtarget> ; # sun/util/locale/provider/JRELocaleProviderAdapter$$Lambda+0x800000064
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 62 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da3475d8
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/DefaultLogFilter
+instanceKlass org/eclipse/core/runtime/ILogListener
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/LogHandler
+instanceKlass org/eclipse/jdt/internal/core/manipulation/MembersOrderPreferenceCacheCommon
+instanceKlass com/google/common/collect/Ordering
+instanceKlass org/eclipse/jdt/core/manipulation/JavaManipulation
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 38 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da347398
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 33 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da347158
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 20 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da346f18
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 15 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da346cd8
+instanceKlass  @bci com/google/inject/internal/DeclaredMembers getDeclaredMethods (Ljava/lang/Class;)[Ljava/lang/reflect/Method; 7 <appendix> argL0 ; # com/google/inject/internal/DeclaredMembers$$Lambda+0x00000139da346a98
+instanceKlass com/google/inject/internal/DeclaredMembers
+instanceKlass com/google/common/base/ExtraObjectsMethodsForWeb
+instanceKlass org/eclipse/jdt/ls/core/contentassist/ICompletionContributionService
+instanceKlass org/eclipse/jdt/ls/core/internal/managers/ISourceDownloader
+instanceKlass org/eclipse/jdt/internal/core/DeltaProcessor$2
+instanceKlass org/eclipse/core/internal/events/NotificationManager$1
+instanceKlass org/eclipse/text/templates/ContextTypeRegistry
+instanceKlass org/eclipse/jdt/internal/core/ModelUpdater
+instanceKlass com/google/common/collect/ImmutableMap$Builder
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$20$1
+instanceKlass com/google/inject/internal/MoreTypes
+instanceKlass  @bci org/eclipse/jdt/internal/core/search/processing/JobManager reset ()V 38 <appendix> member <vmtarget> ; # org/eclipse/jdt/internal/core/search/processing/JobManager$$Lambda+0x00000139da3420b8
+instanceKlass org/eclipse/jdt/internal/core/ExternalAnnotationTracker$DirectoryNode
+instanceKlass com/google/inject/multibindings/ProvidesIntoOptional
+instanceKlass com/google/inject/multibindings/ProvidesIntoMap
+instanceKlass org/eclipse/jdt/internal/core/ExternalAnnotationTracker
+instanceKlass com/google/inject/multibindings/ProvidesIntoSet
+instanceKlass com/google/inject/Provides
+instanceKlass javax/inject/Singleton
+instanceKlass com/google/inject/spi/ElementSource
+instanceKlass com/google/inject/spi/ScopeBinding
+instanceKlass com/google/inject/Scopes$2
+instanceKlass com/google/inject/Scopes$1
+instanceKlass com/google/inject/internal/SingletonScope
+instanceKlass com/google/inject/Scopes
+instanceKlass com/google/inject/Singleton
+instanceKlass com/google/inject/spi/Elements$ModuleInfo
+instanceKlass com/google/inject/PrivateModule
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction pushModule (Ljava/lang/Class;Lcom/google/inject/spi/ModuleSource;)V 5 <appendix> member <vmtarget> ; # com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction$$Lambda+0x00000139da344690
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction getPermits (Ljava/lang/Class;)Ljava/util/stream/Stream; 43 <appendix> argL0 ; # com/google/inject/spi/BindingSourceRestriction$$Lambda+0x00000139da344440
+instanceKlass  @bci com/google/inject/spi/BindingSourceRestriction getPermits (Ljava/lang/Class;)Ljava/util/stream/Stream; 33 <appendix> argL0 ; # com/google/inject/spi/BindingSourceRestriction$$Lambda+0x00000139da344200
+instanceKlass sun/reflect/annotation/AnnotatedTypeFactory$AnnotatedTypeBaseImpl
+instanceKlass sun/reflect/annotation/AnnotatedTypeFactory
+instanceKlass sun/reflect/annotation/TypeAnnotation$LocationInfo$Location
+instanceKlass sun/reflect/annotation/TypeAnnotation$LocationInfo
+instanceKlass sun/reflect/generics/tree/ClassSignature
+instanceKlass sun/reflect/generics/tree/Signature
+instanceKlass sun/reflect/generics/tree/FormalTypeParameter
+instanceKlass sun/reflect/generics/repository/AbstractRepository
+instanceKlass sun/reflect/annotation/TypeAnnotation
+instanceKlass sun/reflect/annotation/TypeAnnotationParser
+instanceKlass org/eclipse/jdt/internal/core/DeltaProcessor$RootInfo
+instanceKlass com/google/inject/RestrictedBindingSource
+instanceKlass com/google/inject/spi/BindingSourceRestriction
+instanceKlass com/google/inject/spi/ModuleSource
+instanceKlass org/eclipse/jdt/internal/core/JavaProject$ResolvedClasspath
+instanceKlass com/google/inject/internal/ProviderMethodsModule
+instanceKlass org/eclipse/jdt/internal/core/ClasspathChange
+instanceKlass com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction$PermitMapImpl
+instanceKlass com/google/inject/spi/BindingSourceRestriction$PermitMap
+instanceKlass com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction
+instanceKlass com/google/common/collect/Hashing
+instanceKlass com/google/common/math/IntMath$1
+instanceKlass com/google/common/math/MathPreconditions
+instanceKlass com/google/common/math/IntMath
+instanceKlass com/google/inject/internal/AbstractBindingBuilder
+instanceKlass com/google/inject/binder/ConstantBindingBuilder
+instanceKlass com/google/inject/binder/AnnotatedElementBuilder
+instanceKlass com/google/inject/spi/Elements$RecordingBinder
+instanceKlass com/google/inject/Binding
+instanceKlass com/google/inject/spi/DefaultBindingTargetVisitor
+instanceKlass  @bci jdk/xml/internal/SecuritySupport getResourceBundle (Ljava/lang/String;Ljava/util/Locale;)Ljava/util/ResourceBundle; 2 <appendix> member <vmtarget> ; # jdk/xml/internal/SecuritySupport$$Lambda+0x00000139da1e92f0
+instanceKlass com/google/inject/spi/BindingTargetVisitor
+instanceKlass com/sun/org/apache/xerces/internal/dom/DOMMessageFormatter
+instanceKlass com/google/inject/spi/Elements
+instanceKlass com/google/inject/internal/InjectorShell$RootModule
+instanceKlass com/google/common/collect/ListMultimap
+instanceKlass com/google/inject/internal/InjectorBindingData
+instanceKlass org/w3c/dom/Attr
+instanceKlass com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl
+instanceKlass org/w3c/dom/NamedNodeMap
+instanceKlass  @bci com/google/inject/internal/WeakKeySet <init> (Ljava/lang/Object;)V 12 <appendix> member <vmtarget> ; # com/google/inject/internal/WeakKeySet$$Lambda+0x00000139da338d00
+instanceKlass com/sun/org/apache/xerces/internal/dom/CharacterDataImpl$1
+instanceKlass org/w3c/dom/Text
+instanceKlass com/google/inject/internal/WeakKeySet
+instanceKlass org/w3c/dom/CharacterData
+instanceKlass com/sun/org/apache/xerces/internal/dom/DeepNodeListImpl
+instanceKlass com/google/common/collect/Sets
+instanceKlass com/google/inject/internal/InjectorJitBindingData
+instanceKlass com/google/inject/internal/ProcessedBindingData
+instanceKlass com/google/inject/spi/DefaultElementVisitor
+instanceKlass com/sun/org/apache/xerces/internal/dom/DeferredDocumentImpl$RefCount
+instanceKlass com/sun/org/apache/xerces/internal/dom/NodeListCache
+instanceKlass org/w3c/dom/TypeInfo
+instanceKlass org/w3c/dom/ElementTraversal
+instanceKlass org/w3c/dom/Element
+instanceKlass com/google/inject/internal/InjectorShell$Builder
+instanceKlass org/w3c/dom/DocumentType
+instanceKlass com/sun/org/apache/xerces/internal/dom/NodeImpl
+instanceKlass org/w3c/dom/events/EventTarget
+instanceKlass org/w3c/dom/NodeList
+instanceKlass com/google/common/collect/Lists
+instanceKlass org/w3c/dom/Document
+instanceKlass com/google/common/collect/CollectPreconditions
+instanceKlass org/w3c/dom/ranges/DocumentRange
+instanceKlass org/w3c/dom/events/DocumentEvent
+instanceKlass com/google/common/collect/LinkedHashMultimap$MultimapIterationChain
+instanceKlass org/w3c/dom/traversal/DocumentTraversal
+instanceKlass com/sun/org/apache/xerces/internal/dom/DeferredNode
+instanceKlass com/google/common/collect/Platform
+instanceKlass com/google/common/collect/Multiset
+instanceKlass com/google/common/collect/AbstractMultimap
+instanceKlass sun/nio/ch/Util$BufferCache
+instanceKlass com/google/common/collect/SetMultimap
+instanceKlass sun/nio/ch/Util
+instanceKlass sun/nio/ch/IOStatus
+instanceKlass com/google/common/collect/ImmutableMap
+instanceKlass java/nio/channels/NetworkChannel
+instanceKlass sun/nio/ch/SelChImpl
+instanceKlass sun/nio/ch/Streams
+instanceKlass java/nio/channels/Channels
+instanceKlass com/google/common/base/Converter
+instanceKlass sun/nio/fs/WindowsSecurityDescriptor
+instanceKlass com/google/common/collect/BiMap
+instanceKlass com/google/common/collect/SortedMapDifference
+instanceKlass org/eclipse/jdt/internal/core/util/Util
+instanceKlass com/google/common/collect/MapDifference
+instanceKlass com/google/common/collect/Maps
+instanceKlass com/google/inject/internal/CycleDetectingLock
+instanceKlass com/google/common/collect/Multimap
+instanceKlass com/google/inject/internal/CycleDetectingLock$CycleDetectingLockFactory
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$SecondaryTypes
+instanceKlass com/google/inject/internal/Initializable
+instanceKlass com/google/inject/internal/Initializer
+instanceKlass com/google/common/collect/PeekingIterator
+instanceKlass com/google/common/collect/UnmodifiableIterator
+instanceKlass com/google/common/collect/Iterators
+instanceKlass com/google/common/collect/ImmutableCollection$Builder
+instanceKlass com/google/common/collect/ImmutableSet$SetBuilderImpl
+instanceKlass org/eclipse/jdt/core/IJavaModelStatusConstants
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da329400
+instanceKlass com/google/inject/internal/util/SourceProvider
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da329000
+instanceKlass org/eclipse/jdt/internal/compiler/ast/TypeOrLambda
+instanceKlass com/google/inject/spi/ErrorDetail
+instanceKlass com/google/inject/internal/Errors
+instanceKlass org/eclipse/jdt/internal/compiler/CompilationResult
+instanceKlass com/google/common/base/Stopwatch
+instanceKlass com/google/inject/internal/util/ContinuousStopwatch
+instanceKlass lombok/eclipse/agent/PatchDelegate$BindingTuple
+instanceKlass com/google/inject/Injector
+instanceKlass com/google/inject/internal/InternalInjectorCreator
+instanceKlass com/google/inject/Guice
+instanceKlass org/eclipse/sisu/wire/Wiring
+instanceKlass org/eclipse/sisu/wire/WireModule$Strategy$1
+instanceKlass org/eclipse/sisu/wire/WireModule$Strategy
+instanceKlass org/eclipse/sisu/wire/AbstractTypeConverter
+instanceKlass com/google/inject/spi/ElementVisitor
+instanceKlass org/eclipse/sisu/wire/WireModule
+instanceKlass org/eclipse/sisu/bean/BeanBinder
+instanceKlass org/eclipse/sisu/plexus/PlexusBindingModule
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$BootModule
+instanceKlass org/codehaus/plexus/component/annotations/Configuration
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedMetadata
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanMetadata
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedBeanModule$PlexusAnnotatedBeanSource
+instanceKlass org/eclipse/sisu/space/SpaceModule$2
+instanceKlass org/eclipse/sisu/space/SpaceModule$Strategy$2
+instanceKlass org/eclipse/sisu/space/SpaceModule$Strategy$1
+instanceKlass org/eclipse/sisu/space/DefaultClassFinder
+instanceKlass org/objectweb/asm/ClassVisitor
+instanceKlass org/eclipse/sisu/space/SpaceScanner
+instanceKlass org/eclipse/sisu/space/IndexedClassFinder
+instanceKlass org/eclipse/sisu/space/ClassFinder
+instanceKlass org/eclipse/sisu/space/SpaceModule
+instanceKlass org/eclipse/sisu/space/SpaceVisitor
+instanceKlass org/eclipse/sisu/plexus/PlexusTypeListener
+instanceKlass org/eclipse/sisu/space/QualifiedTypeListener
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedBeanModule$1
+instanceKlass org/eclipse/sisu/space/SpaceModule$Strategy
+instanceKlass org/eclipse/sisu/plexus/PlexusAnnotatedBeanModule
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanSource
+instanceKlass org/eclipse/sisu/plexus/PlexusXmlBeanModule
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanModule
+instanceKlass org/eclipse/sisu/space/URLClassSpace
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$SLF4JLoggerFactoryProvider
+instanceKlass com/google/inject/util/Providers$ConstantProvider
+instanceKlass com/google/inject/util/Providers
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Disposable
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Startable
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Initializable
+instanceKlass org/codehaus/plexus/personality/plexus/lifecycle/phase/Contextualizable
+instanceKlass org/codehaus/plexus/logging/LogEnabled
+instanceKlass org/eclipse/sisu/bean/PropertyBinding
+instanceKlass javax/annotation/PreDestroy
+instanceKlass javax/annotation/PostConstruct
+instanceKlass org/eclipse/sisu/bean/LifecycleBuilder
+instanceKlass org/eclipse/sisu/bean/BeanScheduler$1
+instanceKlass com/google/inject/spi/DefaultBindingScopingVisitor
+instanceKlass com/google/inject/spi/BindingScopingVisitor
+instanceKlass org/eclipse/sisu/bean/BeanScheduler$CycleActivator
+instanceKlass com/google/inject/binder/AnnotatedConstantBindingBuilder
+instanceKlass com/google/inject/spi/TypeListener
+instanceKlass org/aopalliance/intercept/MethodInterceptor
+instanceKlass org/aopalliance/intercept/Interceptor
+instanceKlass org/aopalliance/aop/Advice
+instanceKlass com/google/inject/MembersInjector
+instanceKlass com/google/inject/Scope
+instanceKlass com/google/inject/spi/ModuleAnnotatedMethodScanner
+instanceKlass com/google/inject/spi/Message
+instanceKlass com/google/inject/spi/Element
+instanceKlass org/eclipse/jdt/internal/compiler/ast/Invocation
+instanceKlass com/google/inject/PrivateBinder
+instanceKlass com/google/inject/spi/Dependency
+instanceKlass org/eclipse/jdt/internal/compiler/ast/IPolyExpression
+instanceKlass com/google/inject/TypeLiteral
+instanceKlass com/google/inject/Key
+instanceKlass com/google/inject/binder/AnnotatedBindingBuilder
+instanceKlass com/google/inject/binder/LinkedBindingBuilder
+instanceKlass com/google/inject/binder/ScopedBindingBuilder
+instanceKlass com/google/inject/spi/ProvisionListener
+instanceKlass com/google/inject/Binder
+instanceKlass org/eclipse/sisu/bean/BeanScheduler
+instanceKlass org/eclipse/sisu/plexus/DefaultPlexusBeanLocator
+instanceKlass org/eclipse/sisu/plexus/RealmManager
+instanceKlass org/codehaus/plexus/context/ContextMapAdapter
+instanceKlass org/codehaus/plexus/context/DefaultContext
+instanceKlass org/codehaus/plexus/logging/AbstractLogger
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$LoggerProvider
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$DefaultsModule
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$ContainerModule
+instanceKlass org/eclipse/sisu/inject/ImplicitBindings
+instanceKlass org/eclipse/sisu/inject/MildValues$InverseMapping
+instanceKlass org/eclipse/sisu/inject/MildValues
+instanceKlass java/util/concurrent/atomic/AtomicReferenceFieldUpdater$AtomicReferenceFieldUpdaterImpl$1
+instanceKlass java/util/concurrent/atomic/AtomicReferenceFieldUpdater
+instanceKlass org/eclipse/sisu/inject/RankedSequence$Content
+instanceKlass org/eclipse/sisu/inject/RankedSequence
+instanceKlass org/eclipse/sisu/inject/BindingSubscriber
+instanceKlass org/eclipse/sisu/inject/DefaultBeanLocator
+instanceKlass org/eclipse/sisu/inject/DeferredClass
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer$LoggerManagerProvider
+instanceKlass org/eclipse/sisu/inject/DeferredProvider
+instanceKlass com/google/inject/Provider
+instanceKlass org/eclipse/m2e/core/internal/embedder/IMavenComponentContributor$IMavenComponentBinder
+instanceKlass com/google/inject/AbstractModule
+instanceKlass org/codehaus/plexus/context/Context
+instanceKlass org/eclipse/sisu/inject/BindingPublisher
+instanceKlass org/eclipse/sisu/inject/RankingFunction
+instanceKlass org/eclipse/sisu/space/ClassSpace
+instanceKlass javax/inject/Provider
+instanceKlass org/eclipse/sisu/bean/BeanManager
+instanceKlass org/eclipse/sisu/plexus/PlexusBeanLocator
+instanceKlass org/eclipse/sisu/inject/MutableBeanLocator
+instanceKlass org/eclipse/sisu/inject/BeanLocator
+instanceKlass org/codehaus/plexus/DefaultPlexusContainer
+instanceKlass org/codehaus/plexus/MutablePlexusContainer
+instanceKlass  @bci java/util/function/Function andThen (Ljava/util/function/Function;)Ljava/util/function/Function; 7 <appendix> member <vmtarget> ; # java/util/function/Function$$Lambda+0x00000139da1dc4e8
+instanceKlass  @cpi java/util/function/Function 58 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da311000
+instanceKlass  @bci org/apache/maven/extension/internal/CoreExports <init> (Lorg/codehaus/plexus/classworlds/realm/ClassRealm;Ljava/util/Set;Ljava/util/Set;)V 38 <appendix> argL0 ; # org/apache/maven/extension/internal/CoreExports$$Lambda+0x00000139da3167d8
+instanceKlass  @bci java/util/stream/Collectors uniqKeysMapMerger ()Ljava/util/function/BinaryOperator; 0 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x00000139da1dc2a0
+instanceKlass  @bci java/util/stream/Collectors uniqKeysMapAccumulator (Ljava/util/function/Function;Ljava/util/function/Function;)Ljava/util/function/BiConsumer; 2 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x00000139da1dc068
+instanceKlass  @bci java/util/stream/Collectors toMap (Ljava/util/function/Function;Ljava/util/function/Function;)Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x00000139da1dbe48
+instanceKlass  @bci org/apache/maven/extension/internal/CoreExports <init> (Lorg/codehaus/plexus/classworlds/realm/ClassRealm;Ljava/util/Set;Ljava/util/Set;)V 30 <appendix> member <vmtarget> ; # org/apache/maven/extension/internal/CoreExports$$Lambda+0x00000139da316590
+instanceKlass lombok/eclipse/agent/PatchDelegate
+instanceKlass  @bci java/util/function/Function identity ()Ljava/util/function/Function; 0 <appendix> argL0 ; # java/util/function/Function$$Lambda+0x00000139da1dbc08
+instanceKlass org/apache/maven/extension/internal/CoreExports
+instanceKlass org/codehaus/plexus/DefaultContainerConfiguration
+instanceKlass org/codehaus/plexus/ContainerConfiguration
+instanceKlass org/eclipse/m2e/internal/maven/compat/PlexusContainerFacade
+instanceKlass lombok/eclipse/agent/PatchDelegatePortal
+instanceKlass  @bci org/eclipse/m2e/core/internal/embedder/PlexusContainerManager newPlexusContainer (Ljava/io/File;Lorg/codehaus/plexus/logging/LoggerManager;Lorg/eclipse/m2e/core/embedder/IMavenConfiguration;)Lorg/eclipse/m2e/core/internal/embedder/IMavenPlexusContainer; 39 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/embedder/PlexusContainerManager$$Lambda+0x00000139da292740
+instanceKlass org/eclipse/m2e/internal/maven/compat/PlexusContainerFacade$MavenExecutionRequesFactory
+instanceKlass org/codehaus/plexus/util/BaseIOUtil
+instanceKlass org/codehaus/plexus/util/xml/XMLWriter
+instanceKlass lombok/core/LombokNode
+instanceKlass lombok/core/DiagnosticsReceiver
+instanceKlass org/codehaus/plexus/util/xml/Xpp3Dom
+instanceKlass org/codehaus/plexus/util/xml/pull/MXParser
+instanceKlass org/codehaus/plexus/util/xml/pull/XmlPullParser
+instanceKlass org/codehaus/plexus/util/xml/Xpp3DomBuilder
+instanceKlass  @bci java/util/regex/Pattern union (Ljava/util/regex/Pattern$CharPredicate;Ljava/util/regex/Pattern$CharPredicate;Z)Ljava/util/regex/Pattern$CharPredicate; 14 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x00000139da1db6e8
+instanceKlass org/codehaus/plexus/util/ReaderFactory
+instanceKlass lombok/launch/PatchFixesHider$Util
+instanceKlass org/apache/maven/project/ExtensionDescriptor
+instanceKlass lombok/launch/PatchFixesHider$Delegate
+instanceKlass org/apache/maven/project/ExtensionDescriptorBuilder
+instanceKlass org/apache/maven/extension/internal/CoreExtensionEntry
+instanceKlass org/eclipse/jdt/internal/core/DeltaProcessingState$RootInfos
+instanceKlass org/codehaus/plexus/classworlds/strategy/AbstractStrategy
+instanceKlass org/codehaus/plexus/classworlds/strategy/Strategy
+instanceKlass org/codehaus/plexus/classworlds/strategy/StrategyFactory
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$PersistedClasspathContainer
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations equals (Ljava/lang/Object;)Z 2 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da30cc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da30c800
+instanceKlass org/eclipse/jdt/internal/core/ClasspathAttribute
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations equals (Ljava/lang/Object;)Z 2 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da30c400
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations equals (Ljava/lang/Object;)Z 2 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da30c000
+instanceKlass  @bci org/eclipse/m2e/core/internal/embedder/PlexusContainerManager cleanup ()V 16 <appendix> argL0 ; # org/eclipse/m2e/core/internal/embedder/PlexusContainerManager$$Lambda+0x00000139da2924f0
+instanceKlass org/apache/maven/settings/building/SettingsBuilder
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations equals (Ljava/lang/Object;)Z 2 <appendix> form names 9 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da30bc00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da30b800
+instanceKlass org/eclipse/jdt/internal/core/ClasspathEntry
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da30b400
+instanceKlass org/eclipse/m2e/core/internal/M2EUtils
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da30b000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da30ac00
+instanceKlass org/apache/maven/settings/building/DefaultSettingsBuildingRequest
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations equals (Ljava/lang/Object;)Z 2 <appendix> form names 7 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da30a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da30a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da30a000
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations hashCode ()I 1 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da309800
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations hashCode ()I 1 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da309000
+instanceKlass org/eclipse/jdt/core/eval/IEvaluationContext
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da308800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da308400
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations hashCode ()I 1 <appendix> form names 7 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da306800
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations hashCode ()I 1 <appendix> argL2 argL2 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da306000
+# instanceKlass java/lang/runtime/ObjectMethods$$Lambda+0x00000139da1daea0
+instanceKlass  @bci java/lang/runtime/ObjectMethods bootstrap (Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object; 37 <appendix> argL0 ; # java/lang/runtime/ObjectMethods$$Lambda+0x00000139da1dac70
+instanceKlass org/eclipse/jdt/internal/compiler/env/IModulePathEntry
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da305c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da305800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da305400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da305000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da304c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da304800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da304400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da304000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da303c00
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$PerProjectInfo
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da303800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da303400
+instanceKlass java/lang/runtime/ObjectMethods$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da303000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da302800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da302400
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$VariablesAndContainersLoadHelper
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da301c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da301000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da300800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da300000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da2f9800
+instanceKlass java/lang/invoke/MethodHandleImpl$Makers$2
+instanceKlass java/lang/invoke/MethodHandleImpl$Makers$1
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$19
+instanceKlass java/lang/invoke/MethodHandleImpl$Makers
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$18
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$13
+instanceKlass  @bci java/lang/invoke/BootstrapMethodInvoker invoke (Ljava/lang/Class;Ljava/lang/invoke/MethodHandle;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object; 862 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da2f9400
+instanceKlass org/eclipse/m2e/core/MavenPlugin
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$12
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da2f9000
+instanceKlass org/eclipse/aether/DefaultRepositoryCache
+instanceKlass java/lang/runtime/ObjectMethods
+instanceKlass org/eclipse/aether/RepositoryCache
+instanceKlass  @bci org/eclipse/m2e/core/internal/embedder/MavenImpl getSettings (Lorg/eclipse/m2e/core/embedder/MavenSettingsLocations;)Lorg/apache/maven/settings/Settings; 6 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/embedder/MavenImpl$$Lambda+0x00000139da291e98
+instanceKlass org/apache/maven/execution/DefaultMavenExecutionRequest
+instanceKlass org/apache/maven/building/Source
+instanceKlass org/apache/maven/cli/configuration/SettingsXmlConfigurationProcessor
+instanceKlass org/apache/maven/cli/configuration/ConfigurationProcessor
+instanceKlass  @bci org/eclipse/m2e/core/internal/embedder/MavenExecutionContext newExecutionRequest ()Lorg/apache/maven/execution/MavenExecutionRequest; 125 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/embedder/MavenExecutionContext$$Lambda+0x00000139da291c70
+instanceKlass  @bci org/eclipse/m2e/core/internal/embedder/MavenExecutionContext newExecutionRequest ()Lorg/apache/maven/execution/MavenExecutionRequest; 111 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/embedder/MavenExecutionContext$$Lambda+0x00000139da291a28
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator getService (Ljava/lang/Class;)Ljava/lang/Object; 18 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/MavenPluginActivator$$Lambda+0x00000139da2917e0
+instanceKlass  @bci org/eclipse/m2e/core/internal/project/registry/ProjectRegistryRefreshJob run (Lorg/eclipse/core/runtime/IProgressMonitor;)Lorg/eclipse/core/runtime/IStatus; 74 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/project/registry/ProjectRegistryRefreshJob$$Lambda+0x00000139da2915b8
+instanceKlass org/apache/maven/cli/MavenCli
+instanceKlass org/eclipse/aether/transfer/TransferListener
+instanceKlass  @bci org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry copy (Ljava/util/Map;Ljava/util/Map;)V 2 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry$$Lambda+0x00000139da291380
+instanceKlass org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions
+instanceKlass org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants
+instanceKlass org/eclipse/jdt/internal/compiler/util/Util
+instanceKlass org/eclipse/jdt/internal/compiler/impl/IrritantSet
+instanceKlass org/eclipse/jdt/internal/core/util/ICacheEnumeration
+instanceKlass org/eclipse/jdt/internal/formatter/TokenTraverser
+instanceKlass org/eclipse/text/edits/TextEdit
+instanceKlass org/eclipse/jdt/core/formatter/CodeFormatter
+instanceKlass lombok/patcher/scripts/WrapperMethodDescriptor
+instanceKlass lombok/patcher/scripts/SetSymbolDuringMethodCallScript$1
+instanceKlass org/eclipse/jdt/core/SourceRange
+instanceKlass org/eclipse/jdt/internal/compiler/util/JRTUtil$JrtFileVisitor
+instanceKlass org/eclipse/jdt/core/IOrdinaryClassFile
+instanceKlass org/eclipse/jdt/internal/core/util/ReferenceInfoAdapter
+instanceKlass org/eclipse/jdt/internal/compiler/ISourceElementRequestor
+instanceKlass org/eclipse/jdt/core/search/TypeNameMatchRequestor
+instanceKlass org/eclipse/jdt/internal/compiler/env/ISourceType
+instanceKlass org/eclipse/jdt/internal/compiler/env/IGenericType
+instanceKlass org/eclipse/jdt/internal/compiler/problem/ProblemHandler
+instanceKlass org/eclipse/jdt/core/search/MethodNameMatch
+instanceKlass org/eclipse/jdt/core/search/SearchParticipant
+instanceKlass org/eclipse/jdt/core/search/IJavaSearchScope
+instanceKlass org/eclipse/jdt/internal/compiler/ASTVisitor
+instanceKlass org/eclipse/jdt/core/search/TypeNameMatch
+instanceKlass org/eclipse/jdt/internal/core/search/IndexQueryRequestor
+instanceKlass org/eclipse/jdt/core/search/SearchPattern
+instanceKlass org/eclipse/jdt/core/search/IParallelizable
+instanceKlass org/eclipse/jdt/internal/core/search/BasicSearchEngine
+instanceKlass org/eclipse/jdt/core/ITypeParameter
+instanceKlass org/eclipse/jdt/core/ISourceRange
+instanceKlass org/eclipse/jdt/core/IAnnotation
+instanceKlass org/eclipse/jdt/internal/core/AbstractModule
+instanceKlass org/eclipse/jdt/core/IModuleDescription
+instanceKlass org/eclipse/jdt/internal/core/NameLookup
+instanceKlass org/eclipse/jface/text/IDocument
+instanceKlass org/eclipse/jdt/internal/core/JavaModelCache$1
+instanceKlass org/eclipse/jdt/internal/compiler/env/IBinaryInfo
+instanceKlass org/eclipse/jdt/internal/core/JavaModelCache
+instanceKlass org/eclipse/jdt/core/IType
+instanceKlass org/eclipse/jdt/core/IAnnotatable
+instanceKlass org/eclipse/jdt/core/IMember
+instanceKlass org/eclipse/jdt/internal/core/hierarchy/HierarchyBuilder
+instanceKlass org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy
+instanceKlass org/eclipse/jdt/core/ITypeHierarchy
+instanceKlass org/eclipse/jdt/core/dom/ASTNode
+instanceKlass org/eclipse/jdt/core/dom/StructuralPropertyDescriptor
+instanceKlass org/eclipse/jdt/internal/core/dom/rewrite/RewriteEvent
+instanceKlass org/eclipse/jdt/internal/core/dom/rewrite/RewriteEventStore
+instanceKlass org/eclipse/jdt/core/dom/ASTVisitor
+instanceKlass org/eclipse/jdt/internal/core/DeltaProcessor
+instanceKlass org/eclipse/jdt/internal/codeassist/CompletionEngine$1
+instanceKlass  @bci org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding <clinit> ()V 58 <appendix> argL0 ; # org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding$$Lambda+0x00000139da2d6120
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/ParameterNonNullDefaultProvider
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding$3
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding$2
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/ReductionResult
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/ElementValuePair
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/AnnotationBinding
+instanceKlass org/eclipse/jdt/internal/compiler/env/IUpdatableModule
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/TypeBindingVisitor
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/HotSwappable
+instanceKlass org/eclipse/jdt/internal/compiler/parser/ScannerHelper
+instanceKlass org/eclipse/jdt/core/Signature
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/TypeConstants$CloseMethodRecord
+instanceKlass org/eclipse/jdt/internal/core/INamingRequestor
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/Substitution
+instanceKlass org/eclipse/jdt/internal/core/IJavaElementRequestor
+instanceKlass org/eclipse/jdt/internal/codeassist/MissingTypesGuesser$GuessedTypeRequestor
+instanceKlass org/eclipse/jdt/core/CompletionRequestor
+instanceKlass org/eclipse/jdt/core/search/SearchRequestor
+instanceKlass org/eclipse/jdt/internal/codeassist/UnresolvedReferenceNameFinder$UnresolvedReferenceNameRequestor
+instanceKlass lombok/patcher/scripts/ReplaceMethodCallScript$1
+instanceKlass org/eclipse/jdt/internal/codeassist/complete/CompletionNode
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/Binding
+instanceKlass org/eclipse/jdt/core/CompletionProposal
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/Scope
+instanceKlass org/eclipse/jdt/core/compiler/IProblem
+instanceKlass org/eclipse/jdt/core/CompletionContext
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/InvocationSite
+instanceKlass org/eclipse/jdt/internal/compiler/ast/ASTNode
+instanceKlass org/eclipse/jdt/internal/compiler/ast/Location
+instanceKlass org/eclipse/jdt/internal/codeassist/impl/Engine
+instanceKlass org/eclipse/jdt/internal/codeassist/ICompletionEngine
+instanceKlass org/eclipse/jdt/internal/codeassist/RelevanceConstants
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/TypeConstants
+instanceKlass org/eclipse/jdt/internal/codeassist/ISearchRequestor
+instanceKlass org/eclipse/jdt/internal/compiler/impl/ReferenceContext
+instanceKlass org/eclipse/jdt/internal/compiler/ICompilerRequestor
+instanceKlass org/eclipse/jdt/internal/compiler/Compiler
+instanceKlass org/eclipse/jdt/internal/compiler/problem/ProblemSeverities
+instanceKlass org/eclipse/jdt/internal/compiler/impl/ITypeRequestor
+instanceKlass org/eclipse/jdt/internal/core/builder/ClasspathLocation
+instanceKlass org/eclipse/jdt/internal/compiler/env/INameEnvironment
+instanceKlass org/eclipse/jdt/core/IBuffer
+instanceKlass org/eclipse/jdt/core/IBufferFactory
+instanceKlass org/eclipse/jdt/internal/core/BufferManager
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$8
+instanceKlass  @bci org/eclipse/jdt/internal/core/JavaModelManager <clinit> ()V 139 <appendix> argL0 ; # org/eclipse/jdt/internal/core/JavaModelManager$$Lambda+0x00000139da2b4450
+instanceKlass  @bci org/eclipse/jdt/internal/core/search/indexing/IndexNamesRegistry <init> (Ljava/io/File;Lorg/eclipse/core/runtime/IPath;)V 24 <appendix> member <vmtarget> ; # org/eclipse/jdt/internal/core/search/indexing/IndexNamesRegistry$$Lambda+0x00000139da2b4228
+instanceKlass org/eclipse/jdt/internal/core/search/indexing/IndexNamesRegistry
+instanceKlass org/eclipse/jdt/internal/compiler/util/SimpleLookupTable
+instanceKlass org/eclipse/jdt/internal/compiler/parser/Parser
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/TypeIds
+instanceKlass org/eclipse/jdt/internal/compiler/ast/OperatorIds
+instanceKlass org/eclipse/jdt/internal/compiler/parser/ConflictedParser
+instanceKlass org/eclipse/jdt/internal/compiler/parser/ParserBasicInformation
+instanceKlass org/eclipse/jdt/internal/compiler/IProblemFactory
+instanceKlass org/eclipse/jdt/internal/core/search/indexing/IndexRequest
+instanceKlass org/eclipse/jdt/internal/core/index/IndexLocation
+instanceKlass org/eclipse/jdt/internal/core/search/processing/JobManager
+instanceKlass org/eclipse/jdt/internal/core/search/indexing/IIndexConstants
+instanceKlass  @bci org/eclipse/jdt/internal/core/JavaModelManager <init> ()V 404 <appendix> argL0 ; # org/eclipse/jdt/internal/core/JavaModelManager$$Lambda+0x00000139da2aa4b8
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$3
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$2
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$EclipsePreferencesListener
+instanceKlass org/eclipse/jdt/core/IElementChangedListener
+instanceKlass org/eclipse/jdt/internal/core/DeltaProcessingState
+instanceKlass org/eclipse/core/internal/jobs/JobQueue$2
+instanceKlass org/eclipse/jdt/internal/core/ExternalFoldersManager
+instanceKlass org/eclipse/jdt/internal/core/util/Util$Comparer
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$CompilationParticipants
+instanceKlass org/eclipse/jdt/internal/core/BatchInitializationMonitor
+instanceKlass org/eclipse/jdt/internal/core/JavaModelOperation
+instanceKlass org/eclipse/jdt/internal/codeassist/ISelectionRequestor
+instanceKlass org/eclipse/jdt/internal/core/JavaElementInfo
+instanceKlass org/eclipse/jdt/internal/compiler/env/IElementInfo
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$1
+instanceKlass org/eclipse/jdt/internal/core/search/IRestrictedAccessTypeRequestor
+instanceKlass org/eclipse/jdt/internal/core/util/LRUCache
+instanceKlass org/eclipse/jdt/core/IPackageFragmentRoot
+instanceKlass org/eclipse/jdt/core/IJavaElementDelta
+instanceKlass org/eclipse/jdt/core/IBufferChangedListener
+instanceKlass org/eclipse/jdt/internal/compiler/util/SuffixConstants
+instanceKlass org/eclipse/jdt/internal/compiler/env/ICompilationUnit
+instanceKlass org/eclipse/jdt/internal/compiler/env/IDependent
+instanceKlass org/eclipse/jdt/core/ICompilationUnit
+instanceKlass org/lombokweb/asm/Handle
+instanceKlass org/eclipse/jdt/core/IClassFile
+instanceKlass org/eclipse/jdt/core/ITypeRoot
+instanceKlass org/eclipse/jdt/core/ICodeAssist
+instanceKlass org/eclipse/jdt/core/ISourceReference
+instanceKlass org/eclipse/jdt/core/IPackageFragment
+instanceKlass org/eclipse/jdt/core/ISourceManipulation
+instanceKlass org/eclipse/jdt/internal/compiler/util/Util$Displayable
+instanceKlass org/eclipse/jdt/core/IJavaModelStatus
+instanceKlass org/eclipse/jdt/internal/core/search/processing/IJob
+instanceKlass org/eclipse/jdt/core/IAccessRule
+instanceKlass org/eclipse/jdt/core/IJavaProject
+instanceKlass org/eclipse/jdt/core/IClasspathContainer
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager
+instanceKlass  @bci java/util/Comparator comparingDouble (Ljava/util/function/ToDoubleFunction;)Ljava/util/Comparator; 6 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x00000139da1d7a30
+instanceKlass  @bci org/eclipse/jdt/core/JavaCore <clinit> ()V 207 <appendix> argL0 ; # org/eclipse/jdt/core/JavaCore$$Lambda+0x00000139da29ce80
+instanceKlass  @cpi org/eclipse/jdt/core/JavaCore 2477 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da29b400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da29b000
+instanceKlass java/util/function/ToDoubleFunction
+instanceKlass org/eclipse/jdt/core/compiler/CharOperation
+instanceKlass org/eclipse/jdt/internal/compiler/impl/CompilerOptions
+instanceKlass org/eclipse/jdt/core/IClasspathAttribute
+instanceKlass org/eclipse/jdt/internal/compiler/env/IModule
+instanceKlass org/eclipse/jdt/core/IWorkingCopy
+instanceKlass org/eclipse/jdt/core/IRegion
+instanceKlass org/eclipse/jdt/core/IClasspathEntry
+instanceKlass org/eclipse/jdt/core/search/TypeNameRequestor
+instanceKlass org/eclipse/jdt/core/IJavaModel
+instanceKlass org/eclipse/jdt/core/IParent
+instanceKlass org/eclipse/jdt/core/IOpenable
+instanceKlass org/eclipse/jdt/core/IJavaElement
+instanceKlass org/eclipse/core/resources/IWorkspaceRunnable
+instanceKlass org/eclipse/jdt/core/WorkingCopyOwner
+instanceKlass java/net/Authenticator
+instanceKlass java/nio/channels/AsynchronousByteChannel
+instanceKlass java/nio/channels/AsynchronousChannel
+instanceKlass java/net/SocketAddress
+instanceKlass org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions
+instanceKlass org/eclipse/jdt/ls/core/internal/syntaxserver/IExtendedProtocol
+instanceKlass org/eclipse/lsp4j/services/WorkspaceService
+instanceKlass org/eclipse/lsp4j/services/TextDocumentService
+instanceKlass org/eclipse/lsp4j/services/LanguageServer
+instanceKlass org/eclipse/core/internal/events/NodeIDMap
+instanceKlass org/eclipse/core/internal/events/ResourceDeltaInfo
+instanceKlass org/eclipse/core/internal/dtree/NodeComparison
+instanceKlass org/eclipse/core/internal/events/ResourceComparator
+instanceKlass org/eclipse/jdt/ls/core/internal/BaseJDTLanguageServer
+instanceKlass org/eclipse/core/internal/events/ResourceDeltaFactory
+instanceKlass org/eclipse/core/resources/IMarkerDelta
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager
+instanceKlass org/eclipse/core/runtime/SubMonitor$RootInfo
+instanceKlass org/eclipse/core/resources/team/ResourceRuleFactory
+instanceKlass org/eclipse/m2e/core/internal/repository/IRepositoryDiscoverer
+instanceKlass org/eclipse/m2e/core/internal/repository/IRepositoryIndexer
+instanceKlass org/apache/maven/wagon/authentication/AuthenticationInfo
+instanceKlass org/eclipse/m2e/core/internal/repository/RepositoryInfo
+instanceKlass org/eclipse/m2e/core/repository/IRepository
+instanceKlass org/eclipse/m2e/core/internal/repository/RepositoryRegistry
+instanceKlass org/eclipse/m2e/core/repository/IRepositoryRegistry
+instanceKlass org/eclipse/m2e/core/internal/project/WorkspaceStateWriter
+instanceKlass  @bci org/eclipse/core/internal/runtime/AdapterManager registerFactory (Lorg/eclipse/core/runtime/IAdapterFactory;Ljava/lang/String;)V 5 <appendix> argL0 ; # org/eclipse/core/internal/runtime/AdapterManager$$Lambda+0x00000139da1b4ba8
+instanceKlass org/eclipse/m2e/core/project/configurator/ILifecycleMapping
+instanceKlass org/eclipse/m2e/core/project/ResolverConfiguration
+instanceKlass org/eclipse/m2e/core/project/IProjectCreationListener
+instanceKlass org/eclipse/m2e/core/project/ProjectImportConfiguration
+instanceKlass org/eclipse/m2e/core/project/MavenProjectInfo
+instanceKlass org/eclipse/aether/graph/DependencyNode
+instanceKlass ch/qos/logback/classic/spi/EventArgUtil
+instanceKlass ch/qos/logback/classic/spi/IThrowableProxy
+instanceKlass ch/qos/logback/classic/spi/LoggingEvent
+instanceKlass org/eclipse/m2e/core/internal/project/registry/MavenProjectManager
+instanceKlass org/eclipse/m2e/core/project/IMavenProjectRegistry
+instanceKlass javax/xml/transform/Source
+instanceKlass javax/xml/transform/Result
+instanceKlass org/w3c/dom/Node
+instanceKlass org/eclipse/aether/graph/DependencyVisitor
+instanceKlass org/eclipse/aether/graph/DependencyFilter
+instanceKlass org/eclipse/aether/collection/DependencyGraphTransformer
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$VersionSelector
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ScopeSelector
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$OptionalitySelector
+instanceKlass org/eclipse/aether/util/graph/transformer/ConflictResolver$ScopeDeriver
+instanceKlass org/eclipse/m2e/core/embedder/MavenModelManager
+instanceKlass org/eclipse/m2e/core/project/configurator/ILifecycleMappingConfiguration
+instanceKlass org/eclipse/m2e/core/internal/project/ProjectConfigurationManager
+instanceKlass org/eclipse/m2e/core/project/IProjectConfigurationManager
+instanceKlass org/eclipse/core/runtime/jobs/IJobFunction
+instanceKlass org/eclipse/m2e/core/project/MavenUpdateRequest
+instanceKlass org/eclipse/m2e/core/internal/project/registry/ProjectRegistryReader$MavenProjectManagerImplReplace
+instanceKlass org/eclipse/m2e/core/internal/project/registry/ProjectRegistryReader$IFileReplace
+instanceKlass org/eclipse/m2e/core/internal/project/registry/ProjectRegistryReader$IPathReplace
+instanceKlass java/util/HashMap$UnsafeHolder
+instanceKlass java/io/SerialCallbackContext
+instanceKlass java/io/ObjectInputStream$GetField
+instanceKlass java/io/ObjectStreamClass$ClassDataSlot
+instanceKlass java/io/ObjectStreamClass$FieldReflector
+instanceKlass java/io/ObjectStreamClass$FieldReflectorKey
+instanceKlass jdk/internal/reflect/ClassDefiner$1
+instanceKlass jdk/internal/reflect/ClassDefiner
+instanceKlass jdk/internal/reflect/MethodAccessorGenerator$1
+instanceKlass jdk/internal/reflect/Label$PatchInfo
+instanceKlass jdk/internal/reflect/Label
+instanceKlass jdk/internal/reflect/UTF8
+instanceKlass jdk/internal/reflect/ClassFileAssembler
+instanceKlass jdk/internal/reflect/ByteVectorImpl
+instanceKlass jdk/internal/reflect/ByteVector
+instanceKlass jdk/internal/reflect/ByteVectorFactory
+instanceKlass jdk/internal/reflect/AccessorGenerator
+instanceKlass jdk/internal/reflect/ClassFileConstants
+instanceKlass  @bci jdk/internal/reflect/MethodHandleLongFieldAccessorImpl getLong (Ljava/lang/Object;)J 11 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da28c000
+instanceKlass java/io/ObjectStreamClass$2
+instanceKlass java/io/ClassCache
+instanceKlass java/io/ObjectStreamClass$Caches
+instanceKlass sun/reflect/misc/ReflectUtil
+instanceKlass java/io/ObjectStreamClass
+instanceKlass  @bci java/io/ObjectInputFilter$Config <clinit> ()V 368 <appendix> argL0 ; # java/io/ObjectInputFilter$Config$$Lambda+0x00000139da1d1d58
+instanceKlass jdk/internal/access/JavaObjectInputFilterAccess
+instanceKlass java/io/ObjectInputFilter$Config$BuiltinFilterFactory
+instanceKlass  @bci java/io/ObjectInputFilter$Config <clinit> ()V 80 <appendix> argL0 ; # java/io/ObjectInputFilter$Config$$Lambda+0x00000139da1d16f0
+instanceKlass  @bci java/io/ObjectInputFilter$Config <clinit> ()V 56 <appendix> argL0 ; # java/io/ObjectInputFilter$Config$$Lambda+0x00000139da1d14d0
+instanceKlass java/io/ObjectInputFilter
+instanceKlass java/io/ObjectInputFilter$Config
+instanceKlass java/io/ObjectInputStream$ValidationList
+instanceKlass java/io/ObjectInputStream$HandleTable$HandleList
+instanceKlass java/io/ObjectInputStream$HandleTable
+instanceKlass  @bci java/io/ObjectInputStream <clinit> ()V 100 <appendix> argL0 ; # java/io/ObjectInputStream$$Lambda+0x00000139da1cff50
+instanceKlass jdk/internal/access/JavaObjectInputStreamReadString
+instanceKlass  @bci java/io/ObjectInputStream <clinit> ()V 92 <appendix> argL0 ; # java/io/ObjectInputStream$$Lambda+0x00000139da1cfb30
+instanceKlass jdk/internal/access/JavaObjectInputStreamAccess
+instanceKlass org/eclipse/m2e/core/project/IMavenProjectChangedListener
+instanceKlass org/eclipse/core/runtime/SubMonitor
+instanceKlass org/eclipse/m2e/core/internal/project/registry/DependencyResolutionContext
+instanceKlass org/apache/maven/project/ProjectBuildingResult
+instanceKlass org/eclipse/m2e/core/internal/project/registry/MavenProjectFacade
+instanceKlass com/google/common/cache/LocalCache$AbstractReferenceEntry
+instanceKlass java/util/concurrent/atomic/AtomicReferenceArray
+instanceKlass com/google/common/cache/LocalCache$LoadingValueReference
+instanceKlass com/google/common/cache/Weigher
+instanceKlass com/google/common/base/Predicate
+instanceKlass com/google/common/base/Equivalence
+instanceKlass java/util/function/BiPredicate
+instanceKlass com/google/common/base/MoreObjects
+instanceKlass com/google/common/cache/LocalCache$1
+instanceKlass com/google/common/cache/ReferenceEntry
+instanceKlass com/google/common/cache/LocalCache$ValueReference
+instanceKlass com/google/common/cache/LocalCache$LocalManualCache
+instanceKlass com/google/common/cache/CacheLoader
+instanceKlass  @bci org/eclipse/m2e/core/internal/project/registry/MavenProjectCache <init> ()V 25 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/project/registry/MavenProjectCache$$Lambda+0x00000139da263bf0
+instanceKlass org/eclipse/m2e/core/internal/project/registry/MavenProjectCache$CacheLine
+instanceKlass  @bci org/eclipse/m2e/core/internal/project/registry/MavenProjectCache <init> ()V 16 <appendix> member <vmtarget> ; # org/eclipse/m2e/core/internal/project/registry/MavenProjectCache$$Lambda+0x00000139da2637b8
+instanceKlass com/google/common/cache/RemovalListener
+instanceKlass com/google/common/cache/CacheBuilder$2
+instanceKlass com/google/common/base/Preconditions
+instanceKlass com/google/common/cache/CacheStats
+instanceKlass com/google/common/base/Suppliers$SupplierOfInstance
+instanceKlass com/google/common/base/Suppliers
+instanceKlass com/google/common/cache/CacheBuilder$1
+instanceKlass com/google/common/cache/AbstractCache$StatsCounter
+instanceKlass com/google/common/base/Ticker
+instanceKlass com/google/common/base/Supplier
+instanceKlass com/google/common/cache/CacheBuilder
+instanceKlass com/google/common/cache/LoadingCache
+instanceKlass com/google/common/base/Function
+instanceKlass com/google/common/cache/Cache
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da27c000
+instanceKlass org/apache/maven/model/ModelBase
+instanceKlass org/apache/maven/wagon/proxy/ProxyInfo
+instanceKlass org/eclipse/m2e/core/internal/preferences/MavenPreferenceConstants
+instanceKlass org/apache/maven/project/ProjectBuildingRequest
+instanceKlass org/apache/maven/execution/MavenSession
+instanceKlass org/eclipse/m2e/core/embedder/ILocalRepositoryListener
+instanceKlass org/apache/maven/lifecycle/MavenExecutionPlan
+instanceKlass org/apache/maven/settings/TrackableBase
+instanceKlass org/eclipse/m2e/core/internal/embedder/MavenImpl$MavenSettings
+instanceKlass org/apache/maven/model/ConfigurationContainer
+instanceKlass org/apache/maven/model/InputLocationTracker
+instanceKlass org/apache/maven/plugin/MojoExecution
+instanceKlass org/apache/maven/model/building/ModelProblemCollectorRequest
+instanceKlass org/eclipse/m2e/core/internal/embedder/MavenExecutionContext
+instanceKlass org/eclipse/m2e/core/embedder/ICallable
+instanceKlass org/apache/maven/artifact/Artifact
+instanceKlass org/eclipse/m2e/core/embedder/ISettingsChangeListener
+instanceKlass org/eclipse/sisu/inject/MildKeys
+instanceKlass org/eclipse/sisu/inject/Weak
+instanceKlass java/util/stream/Nodes$ArrayNode
+instanceKlass  @bci sun/util/locale/provider/LocaleProviderAdapter toLocaleArray (Ljava/util/Set;)[Ljava/util/Locale; 16 <appendix> argL0 ; # sun/util/locale/provider/LocaleProviderAdapter$$Lambda+0x800000069
+instanceKlass  @bci sun/util/locale/provider/LocaleProviderAdapter toLocaleArray (Ljava/util/Set;)[Ljava/util/Locale; 6 <appendix> argL0 ; # sun/util/locale/provider/LocaleProviderAdapter$$Lambda+0x800000068
+instanceKlass  @bci sun/util/cldr/CLDRLocaleProviderAdapter getCalendarDataProvider ()Ljava/util/spi/CalendarDataProvider; 8 <appendix> member <vmtarget> ; # sun/util/cldr/CLDRLocaleProviderAdapter$$Lambda+0x800000062
+instanceKlass sun/util/locale/provider/CalendarDataUtility$CalendarWeekParameterGetter
+instanceKlass sun/util/locale/provider/LocaleServiceProviderPool$LocalizedObjectGetter
+instanceKlass sun/util/locale/provider/LocaleServiceProviderPool
+instanceKlass java/util/Calendar$Builder
+instanceKlass  @bci sun/util/locale/provider/JRELocaleProviderAdapter getCalendarProvider ()Lsun/util/spi/CalendarProvider; 8 <appendix> member <vmtarget> ; # sun/util/locale/provider/JRELocaleProviderAdapter$$Lambda+0x800000063
+instanceKlass com/google/inject/matcher/AbstractMatcher
+instanceKlass com/google/inject/matcher/Matcher
+instanceKlass com/google/inject/Module
+instanceKlass com/google/inject/spi/TypeConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/ParameterizedConfigurationConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/AbstractConfigurationConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/ConfigurationConverter
+instanceKlass org/codehaus/plexus/component/configurator/converters/lookup/DefaultConverterLookup
+instanceKlass org/eclipse/m2e/core/internal/markers/MavenProblemInfo
+instanceKlass org/apache/maven/project/MavenProject
+instanceKlass org/eclipse/m2e/core/internal/markers/SourceLocation
+instanceKlass org/eclipse/aether/artifact/Artifact
+instanceKlass org/eclipse/m2e/core/internal/markers/MavenMarkerManager
+instanceKlass org/apache/maven/execution/MavenExecutionRequest
+instanceKlass org/eclipse/m2e/core/internal/embedder/MavenProperties
+instanceKlass org/apache/felix/scr/impl/ComponentRegistry$2
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences fireNodeEvent (Lorg/eclipse/core/runtime/preferences/IEclipsePreferences$NodeChangeEvent;Z)V 26 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da26a800
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences fireNodeEvent (Lorg/eclipse/core/runtime/preferences/IEclipsePreferences$NodeChangeEvent;Z)V 26 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da26a400
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences fireNodeEvent (Lorg/eclipse/core/runtime/preferences/IEclipsePreferences$NodeChangeEvent;Z)V 26 <appendix> member <vmtarget> ; # org/eclipse/core/internal/preferences/EclipsePreferences$$Lambda+0x00000139da1ab470
+instanceKlass  @cpi org/eclipse/core/internal/preferences/EclipsePreferences 1057 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da26a000
+instanceKlass org/eclipse/m2e/core/internal/preferences/MavenConfigurationImpl$1
+instanceKlass org/eclipse/core/runtime/preferences/IPreferenceFilter
+instanceKlass org/apache/felix/scr/impl/ComponentRegistry$Entry
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogEntryImpl
+instanceKlass org/eclipse/equinox/log/ExtendedLogEntry
+instanceKlass org/eclipse/osgi/internal/log/Arguments
+instanceKlass java/lang/StackTraceElement$HashedModules
+instanceKlass org/eclipse/m2e/core/internal/embedder/EclipseLogger
+instanceKlass org/codehaus/plexus/logging/Logger
+instanceKlass org/codehaus/plexus/logging/AbstractLoggerManager
+instanceKlass org/codehaus/plexus/logging/LoggerManager
+instanceKlass org/eclipse/m2e/core/internal/embedder/IMavenPlexusContainer
+instanceKlass org/codehaus/plexus/classworlds/ClassWorldListener
+instanceKlass org/codehaus/plexus/PlexusContainer
+instanceKlass org/codehaus/plexus/classworlds/ClassWorld
+instanceKlass org/apache/maven/model/building/ModelBuildingRequest
+instanceKlass org/apache/maven/settings/crypto/SettingsDecryptionRequest
+instanceKlass org/apache/maven/execution/MavenExecutionResult
+instanceKlass org/apache/maven/settings/building/SettingsBuildingRequest
+instanceKlass org/apache/maven/plugin/version/PluginVersionRequest
+instanceKlass org/codehaus/plexus/component/configurator/expression/ExpressionEvaluator
+instanceKlass org/codehaus/plexus/configuration/PlexusConfiguration
+instanceKlass org/eclipse/aether/RepositorySystemSession
+instanceKlass org/codehaus/plexus/component/configurator/converters/lookup/ConverterLookup
+instanceKlass org/eclipse/m2e/core/internal/embedder/MavenImpl
+instanceKlass org/eclipse/m2e/core/embedder/IMavenConfigurationChangeListener
+instanceKlass org/eclipse/m2e/core/internal/preferences/MavenConfigurationImpl
+instanceKlass org/eclipse/m2e/core/internal/project/registry/MavenProjectCache
+instanceKlass org/eclipse/m2e/core/internal/project/registry/ProjectRegistryReader
+instanceKlass org/eclipse/m2e/core/internal/embedder/PlexusContainerManager
+instanceKlass org/eclipse/m2e/core/internal/markers/IMavenMarkerManager
+instanceKlass org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry
+instanceKlass org/apache/maven/artifact/repository/MavenArtifactRepository
+instanceKlass org/apache/maven/artifact/repository/ArtifactRepository
+instanceKlass org/eclipse/m2e/core/project/IProjectConfiguration
+instanceKlass org/eclipse/aether/repository/WorkspaceReader
+instanceKlass org/eclipse/m2e/core/internal/project/registry/AbstractMavenDependencyResolver
+instanceKlass org/eclipse/m2e/core/embedder/IMavenExecutionContext
+instanceKlass org/eclipse/m2e/core/internal/project/registry/IProjectRegistry
+instanceKlass org/eclipse/m2e/core/internal/project/registry/Capability
+instanceKlass org/eclipse/m2e/core/project/IMavenProjectFacade
+instanceKlass org/eclipse/m2e/core/embedder/IMavenExecutableLocation
+instanceKlass org/eclipse/m2e/core/embedder/IMaven
+instanceKlass org/eclipse/m2e/core/embedder/IComponentLookup
+instanceKlass org/eclipse/m2e/core/embedder/IMavenConfiguration
+instanceKlass org/eclipse/m2e/core/internal/project/registry/ProjectRegistryManager
+instanceKlass ch/qos/logback/classic/util/LoggerNameUtil
+instanceKlass org/slf4j/helpers/Reporter
+instanceKlass ch/qos/logback/core/util/CachingDateFormatter$CacheTuple
+instanceKlass ch/qos/logback/core/util/CachingDateFormatter
+instanceKlass ch/qos/logback/core/util/StatusPrinter2
+instanceKlass ch/qos/logback/core/util/StatusPrinter
+instanceKlass ch/qos/logback/core/status/StatusUtil
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da25b400
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da25b000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da25ac00
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> form names 8 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da25a800
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da25a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da25a000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da259c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da259800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da259400
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> form names 12 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da259000
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da258c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da258800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da258400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da258000
+instanceKlass ch/qos/logback/core/Appender
+instanceKlass ch/qos/logback/core/spi/FilterAttachable
+instanceKlass ch/qos/logback/core/spi/ContextAwareBase
+instanceKlass ch/qos/logback/core/status/StatusListener
+instanceKlass ch/qos/logback/core/util/StatusListenerConfigHelper
+instanceKlass ch/qos/logback/core/status/StatusBase
+instanceKlass ch/qos/logback/core/util/EnvUtil
+instanceKlass ch/qos/logback/classic/util/ClassicEnvUtil
+instanceKlass ch/qos/logback/core/util/OptionHelper
+instanceKlass ch/qos/logback/core/util/Loader
+instanceKlass ch/qos/logback/classic/spi/Configurator
+instanceKlass ch/qos/logback/core/spi/ContextAwareImpl
+instanceKlass ch/qos/logback/classic/util/ContextInitializer$1
+instanceKlass ch/qos/logback/core/spi/ContextAware
+instanceKlass ch/qos/logback/classic/util/ContextInitializer
+instanceKlass org/slf4j/MDC
+instanceKlass ch/qos/logback/classic/util/LogbackMDCAdapter
+instanceKlass ch/qos/logback/classic/Level
+instanceKlass ch/qos/logback/classic/spi/ILoggingEvent
+instanceKlass ch/qos/logback/core/spi/DeferredProcessingAware
+instanceKlass org/slf4j/spi/LoggingEventBuilder
+instanceKlass ch/qos/logback/classic/Logger
+instanceKlass ch/qos/logback/core/spi/AppenderAttachable
+instanceKlass org/slf4j/spi/LoggingEventAware
+instanceKlass org/slf4j/spi/LocationAwareLogger
+instanceKlass ch/qos/logback/classic/spi/LoggerContextVO
+instanceKlass ch/qos/logback/core/spi/LogbackLock
+instanceKlass ch/qos/logback/core/helpers/CyclicBuffer
+instanceKlass ch/qos/logback/core/BasicStatusManager
+instanceKlass ch/qos/logback/core/status/Status
+instanceKlass ch/qos/logback/core/status/StatusManager
+instanceKlass ch/qos/logback/core/ContextBase
+instanceKlass ch/qos/logback/core/spi/LifeCycle
+instanceKlass ch/qos/logback/core/Context
+instanceKlass ch/qos/logback/core/spi/PropertyContainer
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da250000
+instanceKlass org/apache/aries/spifly/Util$7
+instanceKlass org/apache/aries/spifly/Util$5
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$Builder$1
+instanceKlass org/apache/felix/resolver/WireImpl
+instanceKlass org/apache/felix/resolver/util/ArrayMap$1$1
+instanceKlass org/apache/felix/resolver/UsedBlames
+instanceKlass org/apache/felix/resolver/PackageSpaces$4
+instanceKlass org/apache/felix/resolver/PackageSpaces$3
+instanceKlass org/apache/felix/resolver/PackageSpaces$2
+instanceKlass org/apache/felix/resolver/Blame
+instanceKlass org/apache/felix/resolver/PackageSpaces$1
+instanceKlass org/apache/felix/resolver/Packages
+instanceKlass org/apache/felix/resolver/WrappedRequirement
+instanceKlass org/apache/felix/resolver/WireCandidate
+instanceKlass org/apache/felix/resolver/EnhancedExecutor$1
+instanceKlass org/apache/felix/resolver/PackageSpaces$1Computer
+instanceKlass org/apache/felix/resolver/WrappedResource
+instanceKlass  @bci org/apache/felix/resolver/util/CandidateSelector calculate (Lorg/osgi/resource/Requirement;)V 15 <appendix> member <vmtarget> ; # org/apache/felix/resolver/util/CandidateSelector$$Lambda+0x00000139da24c418
+instanceKlass org/apache/felix/resolver/util/CopyOnWriteSet
+instanceKlass org/apache/felix/resolver/DumbExecutor
+instanceKlass org/slf4j/helpers/Util
+instanceKlass org/slf4j/helpers/NOPMDCAdapter
+instanceKlass org/slf4j/helpers/NOPLoggerFactory
+instanceKlass org/slf4j/helpers/NOP_FallbackServiceProvider
+instanceKlass org/slf4j/helpers/ThreadLocalMapOfStacks
+instanceKlass org/objectweb/asm/tree/ParameterNode
+instanceKlass org/slf4j/helpers/BasicMDCAdapter
+instanceKlass org/slf4j/Marker
+instanceKlass org/slf4j/helpers/BasicMarkerFactory
+instanceKlass org/slf4j/Logger
+instanceKlass org/slf4j/helpers/SubstituteLoggerFactory
+instanceKlass org/slf4j/ILoggerFactory
+instanceKlass org/slf4j/spi/MDCAdapter
+instanceKlass org/slf4j/IMarkerFactory
+instanceKlass org/slf4j/helpers/SubstituteServiceProvider
+instanceKlass org/slf4j/event/LoggingEvent
+instanceKlass org/slf4j/LoggerFactory
+instanceKlass  @bci org/eclipse/osgi/container/ModuleWiring lambda$1 (Lorg/eclipse/osgi/internal/container/NamespaceList$Builder;)V 26 <appendix> argL0 ; # org/eclipse/osgi/container/ModuleWiring$$Lambda+0x00000139da1533d0
+instanceKlass java/util/function/UnaryOperator
+instanceKlass  @bci org/eclipse/osgi/container/ModuleWiring addDynamicImports (Lorg/eclipse/osgi/container/ModuleRevisionBuilder;)V 39 <appendix> member <vmtarget> ; # org/eclipse/osgi/container/ModuleWiring$$Lambda+0x00000139da1531a8
+instanceKlass  @bci org/eclipse/osgi/container/ModuleWiring addDynamicImports (Lorg/eclipse/osgi/container/ModuleRevisionBuilder;)V 7 <appendix> member <vmtarget> ; # org/eclipse/osgi/container/ModuleWiring$$Lambda+0x00000139da152f60
+instanceKlass org/eclipse/osgi/container/builders/OSGiManifestBuilderFactory
+instanceKlass  @bci sun/net/www/protocol/jrt/JavaRuntimeURLConnection <clinit> ()V 0 <appendix> argL0 ; # sun/net/www/protocol/jrt/JavaRuntimeURLConnection$$Lambda+0x00000139da1cd0e0
+instanceKlass org/objectweb/asm/Handler
+instanceKlass org/objectweb/asm/tree/TryCatchBlockNode
+instanceKlass org/objectweb/asm/Handle
+instanceKlass org/objectweb/asm/Edge
+instanceKlass org/objectweb/asm/tree/LocalVariableNode
+instanceKlass java/util/BitSet
+instanceKlass org/objectweb/asm/tree/InsnList
+instanceKlass org/objectweb/asm/tree/Util
+instanceKlass org/objectweb/asm/tree/AbstractInsnNode
+instanceKlass org/objectweb/asm/commons/Method
+instanceKlass org/objectweb/asm/Label
+instanceKlass org/objectweb/asm/Frame
+instanceKlass org/objectweb/asm/Context
+instanceKlass org/objectweb/asm/Attribute
+instanceKlass org/objectweb/asm/Type
+instanceKlass org/objectweb/asm/ByteVector
+instanceKlass org/objectweb/asm/Symbol
+instanceKlass org/objectweb/asm/SymbolTable
+instanceKlass org/objectweb/asm/FieldVisitor
+instanceKlass org/objectweb/asm/MethodVisitor
+instanceKlass org/objectweb/asm/AnnotationVisitor
+instanceKlass org/objectweb/asm/ModuleVisitor
+instanceKlass org/objectweb/asm/RecordComponentVisitor
+instanceKlass org/objectweb/asm/ClassReader
+instanceKlass org/eclipse/m2e/core/internal/URLConnectionCaches
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da234800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da234400
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da234000
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <appendix> form names 5 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da233c00
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da233800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da233400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da233000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da232c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da232800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da232400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da232000
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <appendix> form names 9 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da231c00
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da231800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da231400
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator start (Lorg/osgi/framework/BundleContext;)V 31 <appendix> argL1 argL0 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da231000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da230c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da230800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da230400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da230000
+instanceKlass  @bci org/eclipse/m2e/core/internal/MavenPluginActivator <init> ()V 16 <appendix> argL0 ; # org/eclipse/m2e/core/internal/MavenPluginActivator$$Lambda+0x00000139da22bc58
+instanceKlass org/eclipse/m2e/core/internal/jobs/IBackgroundProcessingQueue
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da22ac00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da22a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da22a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da22a000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da229c00
+instanceKlass org/eclipse/core/resources/IResourceChangeEvent
+instanceKlass java/util/concurrent/atomic/Striped64$1
+instanceKlass jdk/internal/util/random/RandomSupport
+instanceKlass  @bci org/apache/felix/scr/impl/manager/ComponentContextImpl createNewFieldHandlerMap ()Ljava/util/Map; 4 <appendix> argL0 ; # org/apache/felix/scr/impl/manager/ComponentContextImpl$$Lambda+0x00000139da16b850
+instanceKlass  @bci org/eclipse/core/internal/runtime/InternalPlatform getLog (Lorg/osgi/framework/Bundle;)Lorg/eclipse/core/runtime/ILog; 13 <appendix> member <vmtarget> ; # org/eclipse/core/internal/runtime/InternalPlatform$$Lambda+0x00000139da1a7d98
+instanceKlass org/eclipse/core/internal/runtime/Log
+instanceKlass org/eclipse/core/internal/preferences/BundleStateScope
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler$Resolved
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldUtils$FieldSearchResult
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldUtils$1
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldUtils
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler$1
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler$ReferenceMethodImpl
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler$NotResolved
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler$State
+instanceKlass org/apache/felix/scr/impl/inject/InitReferenceMethod
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldMethods
+instanceKlass org/eclipse/core/internal/resources/CheckMissingNaturesListener
+instanceKlass org/eclipse/core/internal/resources/Rules
+instanceKlass org/eclipse/core/internal/resources/ResourceChangeListenerRegistrar
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager startJob (Lorg/eclipse/core/internal/jobs/Worker;)Lorg/eclipse/core/runtime/jobs/Job; 45 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da2266f0
+instanceKlass  @cpi org/eclipse/core/internal/jobs/JobManager 1541 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da229800
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager endJob (Lorg/eclipse/core/internal/jobs/InternalJob;Lorg/eclipse/core/runtime/IStatus;ZZ)V 14 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da229400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da229000
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager endJob (Lorg/eclipse/core/internal/jobs/InternalJob;Lorg/eclipse/core/runtime/IStatus;ZZ)V 14 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da228c00
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager endJob (Lorg/eclipse/core/internal/jobs/InternalJob;Lorg/eclipse/core/runtime/IStatus;ZZ)V 14 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da2264a8
+instanceKlass  @cpi org/eclipse/core/internal/jobs/JobManager 1497 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da228800
+instanceKlass  @bci org/eclipse/core/internal/resources/AliasManager buildAliasedProjectsSet ()V 30 <appendix> member <vmtarget> ; # org/eclipse/core/internal/resources/AliasManager$$Lambda+0x00000139da22c6b8
+instanceKlass org/eclipse/core/internal/filesystem/FileStoreUtil
+instanceKlass  @bci org/eclipse/core/internal/resources/AliasManager$HashMapWithSortedKeys <init> ()V 9 <appendix> argL0 ; # org/eclipse/core/internal/resources/AliasManager$HashMapWithSortedKeys$$Lambda+0x00000139da22c420
+instanceKlass org/eclipse/core/internal/resources/AliasManager$HashMapWithSortedKeys
+instanceKlass org/eclipse/core/internal/resources/AliasManager$LocationMap
+instanceKlass org/eclipse/core/internal/resources/AliasManager
+instanceKlass org/eclipse/core/resources/refresh/IRefreshMonitor
+instanceKlass org/eclipse/core/internal/refresh/MonitorManager
+instanceKlass org/eclipse/core/resources/IResourceDeltaVisitor
+instanceKlass org/eclipse/core/resources/IPathVariableChangeListener
+instanceKlass org/eclipse/core/internal/refresh/RefreshManager
+instanceKlass org/eclipse/core/resources/refresh/IRefreshResult
+instanceKlass  @bci org/eclipse/core/internal/resources/ContentDescriptionManager getCurrentPlatformState ()Ljava/lang/String; 39 <appendix> argL0 ; # org/eclipse/core/internal/resources/ContentDescriptionManager$$Lambda+0x00000139da222528
+instanceKlass  @bci org/eclipse/core/internal/properties/PropertyBucket$PropertyEntry <clinit> ()V 0 <appendix> argL0 ; # org/eclipse/core/internal/properties/PropertyBucket$PropertyEntry$$Lambda+0x00000139da221f00
+instanceKlass  @cpi org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding 1599 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da228400
+instanceKlass org/eclipse/core/internal/resources/ProjectContentTypes
+instanceKlass org/eclipse/core/internal/utils/Cache
+instanceKlass org/eclipse/core/internal/resources/ContentDescriptionManager
+instanceKlass  @bci org/eclipse/core/internal/resources/CharsetManager initPreferenceChangeListener ()V 2 <appendix> member <vmtarget> ; # org/eclipse/core/internal/resources/CharsetManager$$Lambda+0x00000139da221300
+instanceKlass  @bci org/eclipse/core/internal/jobs/Worker <init> (Lorg/eclipse/core/internal/jobs/WorkerPool;)V 10 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da228000
+instanceKlass  @bci org/eclipse/core/internal/jobs/Worker <init> (Lorg/eclipse/core/internal/jobs/WorkerPool;)V 10 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da225c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da225800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da225400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da225000
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager now ()J 5 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da226260
+instanceKlass java/util/function/LongUnaryOperator
+instanceKlass org/eclipse/core/internal/jobs/JobChangeEvent
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager schedule (Lorg/eclipse/core/internal/jobs/InternalJob;J)V 5 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da224c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da224800
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager schedule (Lorg/eclipse/core/internal/jobs/InternalJob;J)V 5 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da224400
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager schedule (Lorg/eclipse/core/internal/jobs/InternalJob;J)V 5 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da18fc48
+instanceKlass  @cpi org/eclipse/core/internal/jobs/JobManager 1514 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da224000
+instanceKlass org/eclipse/core/internal/resources/CharsetDeltaJob$ICharsetListenerFilter
+instanceKlass  @bci org/osgi/framework/FrameworkUtil lambda$4 (Ljava/lang/Class;)Lorg/osgi/framework/Bundle; 29 <appendix> argL0 ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da152b18
+instanceKlass  @bci org/osgi/framework/FrameworkUtil lambda$4 (Ljava/lang/Class;)Lorg/osgi/framework/Bundle; 19 <appendix> argL0 ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da1528c8
+instanceKlass  @bci org/osgi/framework/FrameworkUtil lambda$4 (Ljava/lang/Class;)Lorg/osgi/framework/Bundle; 9 <appendix> member <vmtarget> ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da152680
+instanceKlass org/eclipse/core/runtime/PerformanceStats
+instanceKlass org/eclipse/core/internal/events/ResourceStats
+instanceKlass org/eclipse/core/internal/events/ResourceChangeListenerList$ListenerEntry
+instanceKlass org/eclipse/core/internal/resources/CharsetManager$ResourceChangeListener
+instanceKlass org/eclipse/core/resources/IResourceChangeListener
+instanceKlass org/eclipse/core/internal/resources/CharsetManager
+instanceKlass org/eclipse/core/internal/localstore/Bucket$Entry
+instanceKlass org/eclipse/core/internal/localstore/BucketTree
+instanceKlass org/eclipse/core/internal/localstore/Bucket$Visitor
+instanceKlass org/eclipse/core/internal/localstore/Bucket
+instanceKlass org/eclipse/core/internal/properties/PropertyManager2
+instanceKlass org/eclipse/core/internal/events/LifecycleEvent
+instanceKlass  @bci com/sun/jna/Structure$FFIType storeTypeInfo (Ljava/lang/Class;ILcom/sun/jna/Structure$FFIType;)V 13 <appendix> argL0 ; # com/sun/jna/Structure$FFIType$$Lambda+0x00000139da21f728
+instanceKlass  @bci jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl setBoolean (Ljava/lang/Object;Z)V 41 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da21a000
+instanceKlass java/lang/Short$ShortCache
+instanceKlass com/sun/jna/NativeMappedConverter
+instanceKlass com/sun/jna/Klass
+instanceKlass com/sun/jna/Native$Buffers
+instanceKlass com/sun/jna/VarArgsChecker
+instanceKlass com/sun/jna/NativeLibrary$NativeLibraryDisposer
+instanceKlass com/sun/jna/NativeLibrary$1
+instanceKlass com/sun/jna/SymbolProvider
+instanceKlass com/sun/jna/NativeLibrary
+instanceKlass org/eclipse/core/internal/filesystem/local/Win32Handler$FileAPIh
+instanceKlass com/sun/jna/Memory$MemoryDisposer
+instanceKlass com/sun/jna/internal/Cleaner$Cleanable
+instanceKlass com/sun/jna/internal/Cleaner
+instanceKlass com/sun/jna/WeakMemoryHolder
+instanceKlass org/eclipse/core/filesystem/provider/FileInfo
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da219c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da219800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da219400
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations hashCode ()I 1 <appendix> argL1 argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da219000
+instanceKlass  @bci jdk/internal/reflect/MethodHandleBooleanFieldAccessorImpl getBoolean (Ljava/lang/Object;)Z 20 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da218c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da218800
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x00000139da218400
+instanceKlass  @cpi java/io/ObjectInputStream 1214 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da218000
+instanceKlass com/sun/jna/Structure$StructField
+instanceKlass com/sun/jna/Structure$LayoutInfo
+instanceKlass java/lang/Class$AnnotationData
+instanceKlass java/lang/annotation/Documented
+instanceKlass com/sun/jna/Structure$FieldOrder
+instanceKlass  @bci com/sun/jna/Structure fieldOrder ()Ljava/util/List; 84 <appendix> member <vmtarget> ; # com/sun/jna/Structure$$Lambda+0x00000139da2160b0
+instanceKlass  @bci com/sun/jna/Structure getFieldList ()Ljava/util/List; 84 <appendix> member <vmtarget> ; # com/sun/jna/Structure$$Lambda+0x00000139da215e68
+instanceKlass  @bci com/sun/jna/Structure validateFields ()V 75 <appendix> member <vmtarget> ; # com/sun/jna/Structure$$Lambda+0x00000139da215c20
+instanceKlass com/sun/jna/platform/win32/WinBase
+instanceKlass com/sun/jna/platform/win32/BaseTSD
+instanceKlass com/sun/jna/platform/win32/WinDef
+instanceKlass com/sun/jna/Library
+instanceKlass com/sun/jna/win32/W32APITypeMapper$2
+instanceKlass com/sun/jna/DefaultTypeMapper$Entry
+instanceKlass com/sun/jna/win32/W32APITypeMapper$1
+instanceKlass com/sun/jna/TypeConverter
+instanceKlass com/sun/jna/DefaultTypeMapper
+instanceKlass com/sun/jna/TypeMapper
+instanceKlass com/sun/jna/Structure$ByReference
+instanceKlass com/sun/jna/Native$2
+instanceKlass com/sun/jna/Structure$FFIType$FFITypes
+instanceKlass com/sun/jna/Native$ffi_callback
+instanceKlass com/sun/jna/JNIEnv
+instanceKlass com/sun/jna/PointerType
+instanceKlass com/sun/jna/NativeMapped
+instanceKlass com/sun/jna/WString
+instanceKlass com/sun/jna/win32/DLLCallback
+instanceKlass com/sun/jna/CallbackProxy
+instanceKlass com/sun/jna/Callback
+instanceKlass com/sun/jna/Structure$ByValue
+instanceKlass jdk/internal/loader/NativeLibraries$Unloader
+instanceKlass java/io/FileOutputStream$1
+instanceKlass sun/security/provider/AbstractDrbg$NonceProvider
+instanceKlass  @bci sun/security/provider/AbstractDrbg$SeederHolder <clinit> ()V 42 <appendix> member <vmtarget> ; # sun/security/provider/AbstractDrbg$SeederHolder$$Lambda+0x00000139da1c9700
+instanceKlass  @cpi sun/security/provider/AbstractDrbg$SeederHolder 91 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da212c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da212800
+instanceKlass sun/nio/fs/BasicFileAttributesHolder
+instanceKlass sun/nio/fs/WindowsDirectoryStream$WindowsDirectoryIterator
+instanceKlass sun/nio/fs/WindowsDirectoryStream
+instanceKlass java/nio/file/DirectoryStream
+instanceKlass java/nio/file/Files$AcceptAllFilter
+instanceKlass java/nio/file/DirectoryStream$Filter
+instanceKlass java/net/NetworkInterface$1
+instanceKlass java/net/DefaultInterface
+instanceKlass java/net/Inet6Address$Inet6AddressHolder
+instanceKlass java/net/InetAddress$PlatformResolver
+instanceKlass java/net/spi/InetAddressResolver
+instanceKlass java/net/spi/InetAddressResolver$LookupPolicy
+instanceKlass java/net/Inet4AddressImpl
+instanceKlass java/net/Inet6AddressImpl
+instanceKlass java/net/InetAddressImpl
+instanceKlass java/util/concurrent/ConcurrentSkipListMap$Node
+instanceKlass java/util/concurrent/ConcurrentSkipListMap$Index
+instanceKlass java/util/concurrent/ConcurrentNavigableMap
+instanceKlass java/net/InetAddress$InetAddressHolder
+instanceKlass java/net/InetAddress$1
+instanceKlass jdk/internal/access/JavaNetInetAddressAccess
+instanceKlass java/net/InterfaceAddress
+instanceKlass java/net/NetworkInterface
+instanceKlass sun/security/provider/SeedGenerator$1
+instanceKlass sun/security/provider/SeedGenerator
+instanceKlass sun/security/provider/AbstractDrbg$SeederHolder
+instanceKlass java/security/DrbgParameters$NextBytes
+instanceKlass  @bci sun/security/provider/AbstractDrbg <clinit> ()V 12 <appendix> argL0 ; # sun/security/provider/AbstractDrbg$$Lambda+0x00000139da1c6d58
+instanceKlass  @cpi sun/security/provider/AbstractDrbg 383 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da212400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da212000
+instanceKlass sun/security/provider/EntropySource
+instanceKlass sun/security/provider/AbstractDrbg
+instanceKlass java/security/DrbgParameters$Instantiation
+instanceKlass java/security/DrbgParameters
+instanceKlass sun/security/provider/MoreDrbgParameters
+instanceKlass  @bci sun/security/provider/DRBG <init> (Ljava/security/SecureRandomParameters;)V 26 <appendix> argL0 ; # sun/security/provider/DRBG$$Lambda+0x00000139da1c57f8
+instanceKlass java/security/SecureRandomSpi
+instanceKlass java/io/File$TempDirectory
+instanceKlass com/sun/jna/Native$5
+instanceKlass com/sun/jna/Platform
+instanceKlass com/sun/jna/Native$1
+instanceKlass com/sun/jna/Callback$UncaughtExceptionHandler
+instanceKlass com/sun/jna/Native
+instanceKlass com/sun/jna/Version
+instanceKlass com/sun/jna/ToNativeContext
+instanceKlass com/sun/jna/FromNativeContext
+instanceKlass com/sun/jna/FromNativeConverter
+instanceKlass com/sun/jna/ToNativeConverter
+instanceKlass com/sun/jna/Structure
+instanceKlass com/sun/jna/Pointer
+instanceKlass org/eclipse/core/internal/filesystem/local/NativeHandler
+instanceKlass org/eclipse/core/internal/filesystem/local/LocalFileNativesManager
+instanceKlass org/eclipse/core/internal/resources/VariableDescription
+instanceKlass org/eclipse/core/resources/FileInfoMatcherDescription
+instanceKlass org/eclipse/core/internal/resources/FilterDescription
+instanceKlass javax/xml/parsers/DocumentBuilder
+instanceKlass jdk/xml/internal/XMLSecurityManager
+instanceKlass javax/xml/parsers/DocumentBuilderFactory
+instanceKlass org/eclipse/core/internal/runtime/XmlProcessorFactory
+instanceKlass org/eclipse/core/filesystem/URIUtil
+instanceKlass java/util/AbstractMap$2$1
+instanceKlass  @bci org/eclipse/core/internal/resources/ProjectVariableProviderManager <clinit> ()V 14 <appendix> argL0 ; # org/eclipse/core/internal/resources/ProjectVariableProviderManager$$Lambda+0x00000139da202ea0
+instanceKlass  @cpi org/eclipse/core/internal/resources/ProjectVariableProviderManager 171 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da207000
+instanceKlass org/eclipse/core/resources/variableresolvers/PathVariableResolver
+instanceKlass org/eclipse/core/internal/resources/ProjectVariableProviderManager$Descriptor
+instanceKlass org/eclipse/core/internal/resources/ProjectVariableProviderManager
+instanceKlass org/eclipse/core/internal/resources/ProjectPathVariableManager
+instanceKlass  @bci org/eclipse/core/internal/filesystem/local/LocalFile createExecutor (I)Ljava/util/concurrent/ForkJoinPool; 15 <appendix> argL0 ; # org/eclipse/core/internal/filesystem/local/LocalFile$$Lambda+0x00000139da206bd0
+instanceKlass  @bci org/eclipse/core/internal/filesystem/local/LocalFile createExecutor (I)Ljava/util/concurrent/ForkJoinPool; 5 <appendix> argL0 ; # org/eclipse/core/internal/filesystem/local/LocalFile$$Lambda+0x00000139da2069b0
+instanceKlass org/eclipse/jdt/ls/core/internal/filesystem/JLSFsUtils
+instanceKlass sun/nio/fs/WindowsUriSupport
+instanceKlass org/eclipse/core/filesystem/IFileStore
+instanceKlass org/eclipse/jdt/ls/core/internal/filesystem/JDTLSFilesystemActivator$1
+instanceKlass org/eclipse/jdt/ls/core/internal/filesystem/JDTLSFilesystemActivator
+instanceKlass org/eclipse/core/filesystem/IFileSystem
+instanceKlass org/eclipse/core/internal/filesystem/InternalFileSystemCore
+instanceKlass org/eclipse/core/filesystem/EFS
+instanceKlass org/eclipse/core/internal/localstore/FileStoreRoot
+instanceKlass org/eclipse/core/filesystem/IFileInfo
+instanceKlass org/eclipse/core/internal/resources/IModelObjectConstants
+instanceKlass org/eclipse/core/internal/resources/MarkerAttributeMap
+instanceKlass org/eclipse/core/internal/resources/MarkerSet
+instanceKlass org/eclipse/core/internal/resources/MarkerReader
+instanceKlass org/eclipse/core/internal/dtree/DataTreeLookup
+instanceKlass org/eclipse/core/internal/watson/ElementTree$ChildIDsCache
+instanceKlass  @bci org/eclipse/core/internal/resources/SaveManager initSnap (Lorg/eclipse/core/runtime/IProgressMonitor;)V 67 <appendix> argL0 ; # org/eclipse/core/internal/resources/SaveManager$$Lambda+0x00000139da1bb320
+instanceKlass java/io/FilenameFilter
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager cancel (Lorg/eclipse/core/internal/jobs/InternalJob;)Z 15 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da1bec00
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager cancel (Lorg/eclipse/core/internal/jobs/InternalJob;)Z 15 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da18fa00
+instanceKlass org/eclipse/core/internal/dtree/DataTreeReader
+instanceKlass org/eclipse/core/internal/watson/ElementTreeReader$1
+instanceKlass org/eclipse/core/internal/dtree/IDataFlattener
+instanceKlass org/eclipse/core/internal/watson/ElementTreeReader
+instanceKlass  @bci org/eclipse/core/internal/resources/LocalMetaArea getSafeTableLocationFor (Ljava/lang/String;)Lorg/eclipse/core/runtime/IPath; 44 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da1be800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1be400
+instanceKlass  @bci org/eclipse/core/internal/resources/LocalMetaArea getSafeTableLocationFor (Ljava/lang/String;)Lorg/eclipse/core/runtime/IPath; 44 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da1be000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bdc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bd800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bd400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bd000
+instanceKlass  @bci org/eclipse/core/internal/resources/LocalMetaArea getSafeTableLocationFor (Ljava/lang/String;)Lorg/eclipse/core/runtime/IPath; 44 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da1bcc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bc800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bc400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1bc000
+instanceKlass org/eclipse/core/internal/resources/SafeFileTable
+instanceKlass org/eclipse/core/internal/resources/SavedState
+instanceKlass org/eclipse/core/internal/resources/SyncInfoReader
+instanceKlass org/eclipse/core/internal/resources/WorkspaceTreeReader
+instanceKlass org/eclipse/core/resources/ISavedState
+instanceKlass org/eclipse/core/resources/ISaveContext
+instanceKlass org/eclipse/core/internal/resources/SaveManager
+instanceKlass org/eclipse/core/internal/watson/IElementInfoFlattener
+instanceKlass org/eclipse/core/internal/resources/SyncInfoWriter
+instanceKlass org/eclipse/core/internal/resources/Synchronizer
+instanceKlass org/eclipse/core/internal/resources/MarkerWriter
+instanceKlass org/eclipse/core/internal/resources/MarkerDeltaManager
+instanceKlass org/eclipse/core/internal/resources/MarkerTypeDefinitionCache$MarkerTypeDefinition
+instanceKlass org/eclipse/core/internal/resources/MarkerTypeDefinitionCache
+instanceKlass org/eclipse/core/internal/resources/MarkerInfo
+instanceKlass org/eclipse/core/internal/resources/IMarkerSetElement
+instanceKlass org/eclipse/core/internal/resources/MarkerManager
+instanceKlass  @bci org/eclipse/core/internal/events/NotificationManager$NotifyJob <init> (Lorg/eclipse/core/internal/events/NotificationManager;)V 13 <appendix> argL0 ; # org/eclipse/core/internal/events/NotificationManager$NotifyJob$$Lambda+0x00000139da1b19c0
+instanceKlass org/eclipse/core/internal/events/ResourceChangeListenerList
+instanceKlass org/eclipse/core/internal/events/NotificationManager
+instanceKlass java/util/stream/SortedOps
+instanceKlass  @bci org/eclipse/core/internal/runtime/InternalPlatform getBundles0 (Ljava/lang/String;Ljava/lang/String;)Ljava/util/stream/Stream; 90 <appendix> argL0 ; # org/eclipse/core/internal/runtime/InternalPlatform$$Lambda+0x00000139da1a73c0
+instanceKlass  @bci org/eclipse/core/internal/runtime/InternalPlatform getBundles0 (Ljava/lang/String;Ljava/lang/String;)Ljava/util/stream/Stream; 80 <appendix> argL0 ; # org/eclipse/core/internal/runtime/InternalPlatform$$Lambda+0x00000139da1a7180
+instanceKlass org/eclipse/core/internal/events/BuildManager$DeltaCache
+instanceKlass org/eclipse/core/resources/ICommand
+instanceKlass org/eclipse/core/internal/events/InternalBuilder
+instanceKlass org/eclipse/core/resources/IResourceDelta
+instanceKlass org/eclipse/core/resources/IBuildContext
+instanceKlass org/eclipse/core/internal/events/BuildManager
+instanceKlass org/eclipse/core/internal/resources/FilterTypeManager$1
+instanceKlass org/eclipse/core/internal/resources/FilterDescriptor
+instanceKlass org/eclipse/core/resources/IFilterMatcherDescriptor
+instanceKlass org/eclipse/core/internal/resources/FilterTypeManager
+instanceKlass org/eclipse/core/resources/IProjectNatureDescriptor
+instanceKlass org/eclipse/core/internal/resources/NatureManager
+instanceKlass org/eclipse/core/internal/events/ILifecycleListener
+instanceKlass org/eclipse/core/internal/resources/PathVariableManager
+instanceKlass  @bci org/eclipse/core/internal/resources/WorkspaceRoot getProject (Ljava/lang/String;)Lorg/eclipse/core/resources/IProject; 95 <appendix> member <vmtarget> ; # org/eclipse/core/internal/resources/WorkspaceRoot$$Lambda+0x00000139da1aef78
+instanceKlass java/text/AttributedCharacterIterator$Attribute
+instanceKlass java/text/FieldPosition$Delegate
+instanceKlass java/text/Format$FieldDelegate
+instanceKlass java/text/DigitList
+instanceKlass  @bci sun/util/locale/provider/JRELocaleProviderAdapter getNumberFormatProvider ()Ljava/text/spi/NumberFormatProvider; 8 <appendix> member <vmtarget> ; # sun/util/locale/provider/JRELocaleProviderAdapter$$Lambda+0x800000067
+instanceKlass java/text/FieldPosition
+instanceKlass java/text/Format
+instanceKlass org/eclipse/core/internal/preferences/PreferencesService$1
+instanceKlass  @bci org/eclipse/core/internal/preferences/PreferencesService getLookupOrder (Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String; 29 <appendix> argL0 ; # org/eclipse/core/internal/preferences/PreferencesService$$Lambda+0x00000139da1aa588
+instanceKlass  @bci org/eclipse/core/internal/localstore/FileSystemResourceManager <init> (Lorg/eclipse/core/internal/resources/Workspace;)V 6 <appendix> member <vmtarget> ; # org/eclipse/core/internal/localstore/FileSystemResourceManager$$Lambda+0x00000139da1adb88
+instanceKlass org/eclipse/core/internal/localstore/IHistoryStore
+instanceKlass org/eclipse/core/internal/localstore/RefreshLocalVisitor
+instanceKlass org/eclipse/core/internal/localstore/ILocalStoreConstants
+instanceKlass org/eclipse/core/internal/localstore/IUnifiedTreeVisitor
+instanceKlass org/eclipse/core/internal/localstore/FileSystemResourceManager
+instanceKlass org/eclipse/core/runtime/jobs/MultiRule
+instanceKlass org/eclipse/core/internal/jobs/OrderedLock
+instanceKlass java/lang/invoke/DirectMethodHandle$1
+instanceKlass org/eclipse/core/internal/runtime/LocalizationUtils
+instanceKlass org/eclipse/core/runtime/Status
+instanceKlass org/eclipse/core/internal/resources/WorkManager$NotifyRule
+instanceKlass org/eclipse/core/internal/resources/WorkManager
+instanceKlass org/eclipse/core/runtime/NullProgressMonitor
+instanceKlass org/eclipse/core/runtime/preferences/IExportedPreferences
+instanceKlass  @bci org/eclipse/core/internal/resources/WorkspacePreferences <init> ()V 189 <appendix> member <vmtarget> ; # org/eclipse/core/internal/resources/WorkspacePreferences$$Lambda+0x00000139da19fc80
+instanceKlass org/eclipse/core/runtime/Preferences$IPropertyChangeListener
+instanceKlass org/eclipse/core/runtime/preferences/IEclipsePreferences$INodeChangeListener
+instanceKlass org/eclipse/core/runtime/preferences/IEclipsePreferences$IPreferenceChangeListener
+instanceKlass  @bci org/eclipse/core/runtime/Plugin getPluginPreferences ()Lorg/eclipse/core/runtime/Preferences; 65 <appendix> member <vmtarget> ; # org/eclipse/core/runtime/Plugin$$Lambda+0x00000139da1a67a8
+instanceKlass org/eclipse/core/runtime/Preferences
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a8000
+instanceKlass lombok/eclipse/agent/PatchFixesShadowLoaded
+instanceKlass lombok/core/LombokNode
+instanceKlass lombok/core/DiagnosticsReceiver
+instanceKlass lombok/launch/PatchFixesHider$Util
+instanceKlass lombok/launch/PatchFixesHider$LombokDeps
+instanceKlass lombok/launch/ClassFileMetaData
+instanceKlass  @bci jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl set (Ljava/lang/Object;Ljava/lang/Object;)V 41 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da1a4000
+instanceKlass lombok/launch/PackageShader
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a3c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a3800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a3400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a3000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da1a2c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a1000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a0c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da1a0800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da1a0400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19bc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19b800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19b400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19b000
+instanceKlass jdk/internal/vm/annotation/ForceInline
+instanceKlass java/lang/constant/ClassDesc
+instanceKlass java/io/ObjectOutput
+instanceKlass java/io/ObjectStreamConstants
+instanceKlass java/io/ObjectInput
+instanceKlass java/lang/foreign/ValueLayout
+instanceKlass java/lang/foreign/MemoryLayout
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19ac00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da19a000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da199c00
+instanceKlass org/eclipse/core/internal/runtime/Product
+instanceKlass org/eclipse/core/runtime/IProduct
+instanceKlass lombok/patcher/scripts/WrapReturnValuesScript$1
+instanceKlass org/eclipse/equinox/internal/app/ProductExtensionBranding
+instanceKlass org/eclipse/core/internal/runtime/FindSupport
+instanceKlass org/eclipse/core/runtime/FileLocator
+instanceKlass  @bci org/eclipse/osgi/internal/framework/legacy/PackageAdminImpl getBundles (Ljava/lang/String;Ljava/lang/String;)[Lorg/osgi/framework/Bundle; 281 <appendix> argL0 ; # org/eclipse/osgi/internal/framework/legacy/PackageAdminImpl$$Lambda+0x00000139da152440
+instanceKlass org/eclipse/core/runtime/SafeRunner
+instanceKlass  @bci org/eclipse/core/internal/preferences/PreferenceServiceRegistryHelper runInitializer (Lorg/eclipse/core/runtime/IConfigurationElement;)V 18 <appendix> member <vmtarget> ; # org/eclipse/core/internal/preferences/PreferenceServiceRegistryHelper$$Lambda+0x00000139da173408
+instanceKlass org/eclipse/core/runtime/IExecutableExtensionFactory
+instanceKlass org/eclipse/core/runtime/IExecutableExtension
+instanceKlass org/eclipse/core/runtime/preferences/AbstractPreferenceInitializer
+instanceKlass org/eclipse/core/internal/dtree/AbstractDataTree
+instanceKlass org/eclipse/core/internal/dtree/AbstractDataTreeNode
+instanceKlass org/eclipse/core/internal/watson/ElementTree
+instanceKlass org/eclipse/core/internal/runtime/DataArea
+instanceKlass org/eclipse/core/internal/runtime/MetaDataKeeper
+instanceKlass org/eclipse/core/internal/resources/LocalMetaArea
+instanceKlass org/eclipse/core/internal/resources/LocationValidator
+instanceKlass org/eclipse/core/runtime/Platform$OS
+instanceKlass org/eclipse/core/internal/utils/FileUtil
+instanceKlass org/eclipse/core/internal/watson/IElementContentVisitor
+instanceKlass org/eclipse/core/resources/IResourceFilterDescription
+instanceKlass org/eclipse/core/resources/team/IResourceTree
+instanceKlass org/eclipse/core/resources/IMarker
+instanceKlass org/eclipse/core/resources/IResourceProxy
+instanceKlass  @bci jdk/internal/reflect/MethodHandleObjectFieldAccessorImpl set (Ljava/lang/Object;Ljava/lang/Object;)V 29 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da199800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da199400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da199000
+instanceKlass  @bci org/eclipse/osgi/util/NLS <clinit> ()V 7 <appendix> argL0 ; # org/eclipse/osgi/util/NLS$$Lambda+0x00000139da151db8
+instanceKlass org/eclipse/osgi/util/NLS
+instanceKlass org/eclipse/core/runtime/Platform
+instanceKlass org/eclipse/core/resources/team/FileModificationValidationContext
+instanceKlass org/eclipse/core/resources/team/IMoveDeleteHook
+instanceKlass org/eclipse/core/resources/IProject
+instanceKlass org/eclipse/core/internal/resources/ModelObject
+instanceKlass org/eclipse/core/resources/IPathVariableManager
+instanceKlass org/eclipse/core/resources/IProjectDescription
+instanceKlass org/eclipse/core/internal/resources/InternalTeamHook
+instanceKlass org/eclipse/core/internal/watson/IElementComparator
+instanceKlass org/eclipse/core/internal/dtree/IComparator
+instanceKlass org/eclipse/core/resources/IResourceRuleFactory
+instanceKlass org/eclipse/core/resources/IBuildConfiguration
+instanceKlass org/eclipse/core/resources/ISynchronizer
+instanceKlass org/eclipse/core/internal/properties/IPropertyManager
+instanceKlass org/eclipse/core/internal/resources/IManager
+instanceKlass org/eclipse/core/resources/IWorkspaceDescription
+instanceKlass org/eclipse/core/resources/IFile
+instanceKlass org/eclipse/core/resources/IEncodedStorage
+instanceKlass org/eclipse/core/resources/IStorage
+instanceKlass org/eclipse/core/resources/IFolder
+instanceKlass org/eclipse/core/internal/watson/IPathRequestor
+instanceKlass org/eclipse/core/internal/resources/ResourceInfo
+instanceKlass org/eclipse/core/internal/utils/IStringPoolParticipant
+instanceKlass org/eclipse/core/runtime/ICoreRunnable
+instanceKlass org/eclipse/core/internal/watson/IElementTreeData
+instanceKlass org/eclipse/core/internal/jobs/WorkerPool
+instanceKlass org/eclipse/core/internal/jobs/JobQueue
+instanceKlass org/eclipse/core/internal/jobs/DeadlockDetector
+instanceKlass org/eclipse/core/internal/jobs/LockManager
+instanceKlass org/eclipse/core/runtime/jobs/JobChangeAdapter
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager <init> ()V 52 <appendix> member <vmtarget> ; # org/eclipse/core/internal/jobs/JobManager$$Lambda+0x00000139da18d318
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobListeners <init> ()V 50 <appendix> argL0 ; # org/eclipse/core/internal/jobs/JobListeners$$Lambda+0x00000139da18d0f8
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobListeners <init> ()V 41 <appendix> argL0 ; # org/eclipse/core/internal/jobs/JobListeners$$Lambda+0x00000139da18ced8
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobListeners <init> ()V 32 <appendix> argL0 ; # org/eclipse/core/internal/jobs/JobListeners$$Lambda+0x00000139da18ccb8
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobListeners <init> ()V 23 <appendix> argL0 ; # org/eclipse/core/internal/jobs/JobListeners$$Lambda+0x00000139da18ca98
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobListeners <init> ()V 14 <appendix> argL0 ; # org/eclipse/core/internal/jobs/JobListeners$$Lambda+0x00000139da18c878
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobListeners <init> ()V 5 <appendix> argL0 ; # org/eclipse/core/internal/jobs/JobListeners$$Lambda+0x00000139da18c658
+instanceKlass org/eclipse/core/internal/jobs/JobListeners$IListenerDoit
+instanceKlass org/eclipse/core/runtime/jobs/IJobChangeEvent
+instanceKlass org/eclipse/core/internal/jobs/JobListeners
+instanceKlass org/eclipse/core/internal/jobs/ImplicitJobs
+instanceKlass org/eclipse/core/internal/jobs/JobManager$1
+instanceKlass org/eclipse/core/runtime/ProgressMonitorWrapper
+instanceKlass org/eclipse/core/runtime/IProgressMonitorWithBlocking
+instanceKlass org/eclipse/core/internal/jobs/InternalJobGroup
+instanceKlass org/eclipse/core/runtime/jobs/ILock
+instanceKlass org/eclipse/core/runtime/jobs/IJobChangeListener
+instanceKlass org/eclipse/core/internal/jobs/JobManager
+instanceKlass org/eclipse/core/runtime/jobs/IJobManager
+instanceKlass org/eclipse/core/internal/jobs/JobOSGiUtils
+instanceKlass org/eclipse/core/internal/jobs/JobActivator
+instanceKlass org/eclipse/core/resources/IWorkspaceRoot
+instanceKlass org/eclipse/core/resources/IContainer
+instanceKlass org/eclipse/core/resources/IResource
+instanceKlass org/eclipse/core/runtime/jobs/ISchedulingRule
+instanceKlass org/eclipse/core/runtime/PlatformObject
+instanceKlass org/eclipse/core/internal/resources/ICoreConstants
+instanceKlass  @bci java/time/format/DateTimeFormatter <clinit> ()V 1075 <appendix> argL0 ; # java/time/format/DateTimeFormatter$$Lambda+0x80000000e
+instanceKlass  @bci java/time/format/DateTimeFormatter <clinit> ()V 1067 <appendix> argL0 ; # java/time/format/DateTimeFormatter$$Lambda+0x80000000d
+instanceKlass java/time/Period
+instanceKlass java/time/chrono/ChronoPeriod
+instanceKlass java/time/format/DateTimeFormatterBuilder$TextPrinterParser
+instanceKlass java/time/format/DateTimeTextProvider$1
+instanceKlass java/time/format/DateTimeTextProvider
+instanceKlass java/time/format/DateTimeTextProvider$LocaleStore
+instanceKlass java/time/format/DateTimeFormatterBuilder$InstantPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$StringLiteralPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$ZoneIdPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$OffsetIdPrinterParser
+instanceKlass java/time/format/DecimalStyle
+instanceKlass java/time/format/DateTimeFormatterBuilder$CompositePrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$CharLiteralPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$NumberPrinterParser
+instanceKlass java/time/format/DateTimeFormatterBuilder$DateTimePrinterParser
+instanceKlass java/time/temporal/JulianFields
+instanceKlass java/time/temporal/IsoFields
+instanceKlass  @bci java/time/format/DateTimeFormatterBuilder <clinit> ()V 0 <appendix> argL0 ; # java/time/format/DateTimeFormatterBuilder$$Lambda+0x80000000f
+instanceKlass java/time/temporal/TemporalQuery
+instanceKlass java/time/format/DateTimeFormatterBuilder
+instanceKlass java/time/format/DateTimeFormatter
+instanceKlass org/eclipse/osgi/internal/debug/EclipseDebugTrace
+instanceKlass org/eclipse/core/internal/utils/Policy$1
+instanceKlass org/eclipse/core/runtime/IProgressMonitor
+instanceKlass org/eclipse/core/internal/utils/Policy
+instanceKlass org/eclipse/core/resources/ResourcesPlugin$WorkspaceInitCustomizer
+instanceKlass org/eclipse/core/resources/IWorkspace
+instanceKlass org/eclipse/core/runtime/IAdaptable
+instanceKlass org/eclipse/jdt/ls/core/internal/managers/ProjectsManager
+instanceKlass org/eclipse/jdt/ls/core/internal/managers/IProjectsManager
+instanceKlass org/eclipse/core/resources/ISaveParticipant
+instanceKlass org/eclipse/core/internal/runtime/LogServiceFactory
+instanceKlass org/eclipse/equinox/internal/app/AppCommands
+instanceKlass  @bci org/eclipse/equinox/internal/app/EclipseAppDescriptor getInstanceID ()Ljava/lang/String; 31 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da185400
+instanceKlass  @bci org/eclipse/equinox/internal/app/EclipseAppDescriptor getInstanceID ()Ljava/lang/String; 31 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da185000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da184c00
+instanceKlass  @bci org/eclipse/equinox/internal/app/EclipseAppDescriptor getInstanceID ()Ljava/lang/String; 31 <appendix> form names 6 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da184800
+instanceKlass  @bci org/eclipse/equinox/internal/app/EclipseAppDescriptor getInstanceID ()Ljava/lang/String; 31 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da184400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da184000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da183c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da183800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da183400
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> argL1 form names 9 function resolvedHandle form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da183000
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> argL1 argL0 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da182c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da182800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da182400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da182000
+instanceKlass org/eclipse/equinox/internal/app/EclipseAppContainer$RegisterService
+instanceKlass org/eclipse/core/runtime/spi/RegistryContributor
+instanceKlass org/eclipse/equinox/app/IApplicationContext
+instanceKlass org/osgi/service/application/ApplicationHandle
+instanceKlass org/osgi/service/application/ApplicationDescriptor
+instanceKlass org/eclipse/osgi/service/runnable/ApplicationLauncher
+instanceKlass org/eclipse/equinox/internal/app/IBranding
+instanceKlass org/eclipse/osgi/service/runnable/ApplicationRunnable
+instanceKlass org/eclipse/osgi/service/runnable/ParameterizedRunnable
+instanceKlass org/eclipse/equinox/internal/app/EclipseAppContainer
+instanceKlass org/osgi/service/application/ScheduledApplication
+instanceKlass org/eclipse/equinox/internal/app/AppPersistence
+instanceKlass org/eclipse/equinox/internal/app/Activator
+instanceKlass org/eclipse/equinox/internal/app/CommandLineArgs
+instanceKlass org/eclipse/core/internal/preferences/legacy/InitLegacyPreferences
+instanceKlass org/eclipse/core/internal/preferences/legacy/ProductPreferencesService
+instanceKlass org/eclipse/core/internal/preferences/exchange/IProductPreferencesService
+instanceKlass org/eclipse/core/internal/runtime/KeyStoreUtil
+instanceKlass org/eclipse/core/internal/runtime/AuthorizationHandler
+instanceKlass org/eclipse/core/runtime/IBundleGroupProvider
+instanceKlass  @bci org/eclipse/core/internal/runtime/InternalPlatform <clinit> ()V 98 <appendix> argL0 ; # org/eclipse/core/internal/runtime/InternalPlatform$$Lambda+0x00000139da17e8e0
+instanceKlass org/eclipse/core/runtime/ILog
+instanceKlass org/eclipse/core/internal/runtime/InternalPlatform
+instanceKlass org/eclipse/core/runtime/Plugin
+instanceKlass org/eclipse/equinox/internal/frameworkadmin/equinox/Log
+instanceKlass org/eclipse/equinox/internal/provisional/configuratormanipulator/ConfiguratorManipulator
+instanceKlass java/lang/Process
+instanceKlass org/eclipse/equinox/internal/provisional/frameworkadmin/Manipulator
+instanceKlass org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwAdminImpl
+instanceKlass org/eclipse/equinox/internal/provisional/frameworkadmin/FrameworkAdmin
+instanceKlass org/osgi/util/promise/DeferredPromiseImpl$ResolveWith
+instanceKlass  @bci org/osgi/util/promise/PromiseFactory$All run ()V 81 <appendix> member <vmtarget> ; # org/osgi/util/promise/PromiseFactory$All$$Lambda+0x00000139da179200
+instanceKlass  @cpi org/osgi/util/promise/PromiseFactory$All 144 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da17c000
+instanceKlass org/osgi/util/promise/PromiseImpl$Result
+instanceKlass org/osgi/util/promise/PromiseFactory$All
+instanceKlass org/osgi/util/promise/PromiseImpl$InlineCallback
+instanceKlass org/eclipse/core/runtime/QualifiedName
+instanceKlass org/eclipse/core/internal/content/ContentTypeHandler
+instanceKlass org/apache/felix/scr/impl/inject/methods/ActivateMethod$1
+instanceKlass org/apache/felix/scr/impl/inject/MethodResult
+instanceKlass org/eclipse/core/internal/content/ContentTypeManager$ContentTypeRegistryChangeListener
+instanceKlass org/apache/felix/scr/impl/manager/DependencyManager$OpenStatusImpl
+instanceKlass org/apache/felix/scr/impl/manager/SingleComponentManager$1
+instanceKlass org/apache/felix/scr/impl/inject/ReferenceMethod$1
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod$Resolved
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod$MethodInfo
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod$1
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 22 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000043
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 17 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000041
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 12 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x80000003e
+instanceKlass  @bci java/util/stream/Collectors joining (Ljava/lang/CharSequence;Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/util/stream/Collector; 7 <appendix> member <vmtarget> ; # java/util/stream/Collectors$$Lambda+0x800000046
+instanceKlass  @bci java/lang/Class methodToString (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/String; 42 <appendix> argL0 ; # java/lang/Class$$Lambda+0x00000139da0fa108
+instanceKlass org/eclipse/core/runtime/content/IContentTypeManager$IContentTypeChangeListener
+instanceKlass org/eclipse/core/internal/content/BasicDescription
+instanceKlass org/eclipse/core/internal/preferences/BundleStateScopeServiceFactory
+instanceKlass org/eclipse/core/internal/preferences/Activator$1
+instanceKlass  @bci com/sun/org/apache/xml/internal/serializer/ToXMLStream startDocumentInternal ()V 72 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da178c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da178800
+instanceKlass  @bci com/sun/org/apache/xml/internal/serializer/ToXMLStream startDocumentInternal ()V 72 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da178400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da178000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da175c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da175800
+instanceKlass org/eclipse/core/internal/registry/ExtensionRegistry$ListenerInfo
+instanceKlass org/eclipse/core/runtime/IContributor
+instanceKlass org/eclipse/core/internal/preferences/PreferenceServiceRegistryHelper
+instanceKlass  @bci org/eclipse/core/internal/preferences/OSGiPreferencesServiceManager getQualifier (Lorg/osgi/framework/Bundle;)Ljava/lang/String; 6 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da175400
+instanceKlass  @bci org/eclipse/core/internal/preferences/OSGiPreferencesServiceManager getQualifier (Lorg/osgi/framework/Bundle;)Ljava/lang/String; 6 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da175000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da174c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da174800
+instanceKlass  @bci ch/qos/logback/classic/util/ContextInitializer printDuration (JLch/qos/logback/classic/spi/Configurator;Lch/qos/logback/classic/spi/Configurator$ExecutionStatus;)V 31 <appendix> argL1 argL0 argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da174400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da174000
+instanceKlass org/eclipse/core/runtime/ListenerList$ListenerListIterator
+instanceKlass org/eclipse/core/internal/preferences/OSGiPreferencesServiceManager
+instanceKlass org/osgi/service/prefs/PreferencesService
+instanceKlass org/eclipse/core/runtime/preferences/AbstractScope
+instanceKlass org/eclipse/core/runtime/Assert
+instanceKlass org/eclipse/core/runtime/Path
+instanceKlass org/eclipse/core/runtime/Path$Constants
+instanceKlass org/eclipse/core/runtime/IPath
+instanceKlass org/eclipse/core/internal/preferences/ImmutableMap
+instanceKlass org/eclipse/core/internal/preferences/EclipsePreferences
+instanceKlass org/eclipse/core/runtime/preferences/IScope
+instanceKlass org/eclipse/core/runtime/preferences/IEclipsePreferences
+instanceKlass org/eclipse/core/internal/preferences/PreferencesService
+instanceKlass org/eclipse/core/runtime/preferences/IPreferencesService
+instanceKlass org/eclipse/core/internal/preferences/exchange/ILegacyPreferences
+instanceKlass org/eclipse/core/internal/preferences/PreferencesOSGiUtils
+instanceKlass org/eclipse/core/internal/preferences/Activator
+instanceKlass org/eclipse/core/runtime/preferences/IScopeContext
+instanceKlass org/eclipse/core/runtime/content/IContentTypeManager$ISelectionPolicy
+instanceKlass org/eclipse/core/internal/content/ContentTypeBuilder
+instanceKlass org/eclipse/core/internal/content/ContentTypeCatalog
+instanceKlass org/apache/felix/scr/impl/inject/ValueUtils
+instanceKlass org/eclipse/core/internal/content/ILazySource
+instanceKlass org/eclipse/core/internal/adapter/AdapterManagerListener
+instanceKlass org/eclipse/core/internal/runtime/IAdapterManagerProvider
+instanceKlass org/eclipse/core/runtime/IRegistryEventListener
+instanceKlass org/eclipse/core/internal/registry/osgi/RegistryCommandProvider
+instanceKlass org/eclipse/osgi/framework/console/CommandProvider
+instanceKlass org/eclipse/core/internal/registry/RegistryProviderFactory
+instanceKlass org/eclipse/core/internal/registry/osgi/RegistryProviderOSGI
+instanceKlass org/eclipse/core/internal/registry/osgi/EclipseBundleListener
+instanceKlass org/eclipse/core/internal/registry/OffsetTable
+instanceKlass java/util/stream/ReduceOps$8ReducingSink
+instanceKlass java/util/stream/Sink$OfLong
+instanceKlass java/util/function/LongConsumer
+instanceKlass  @bci java/util/stream/LongPipeline sum ()J 2 <appendix> argL0 ; # java/util/stream/LongPipeline$$Lambda+0x00000139da0f8f38
+instanceKlass java/util/function/LongBinaryOperator
+instanceKlass java/util/stream/LongStream
+instanceKlass  @bci org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy getContainerTimestamp ()J 59 <appendix> argL0 ; # org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy$$Lambda+0x00000139da167000
+instanceKlass  @cpi org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy 203 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da166000
+instanceKlass java/util/function/ToLongFunction
+instanceKlass  @bci org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy getContainerTimestamp ()J 49 <appendix> argL0 ; # org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy$$Lambda+0x00000139da165d78
+instanceKlass  @bci org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy getContainerTimestamp ()J 39 <appendix> argL0 ; # org/eclipse/core/internal/registry/osgi/EquinoxRegistryStrategy$$Lambda+0x00000139da165b38
+instanceKlass org/eclipse/core/internal/registry/HashtableOfStringAndInt
+instanceKlass org/eclipse/core/internal/registry/KeyedHashSet
+instanceKlass org/eclipse/core/runtime/IConfigurationElement
+instanceKlass org/eclipse/core/internal/registry/Handle
+instanceKlass org/eclipse/core/internal/registry/RegistryObjectManager
+instanceKlass org/eclipse/core/internal/registry/IObjectManager
+instanceKlass  @bci org/eclipse/core/internal/registry/RegistryProperties getContextProperty (Ljava/lang/String;)Ljava/lang/String; 18 <appendix> member <vmtarget> ; # org/eclipse/core/internal/registry/RegistryProperties$$Lambda+0x00000139da15ed08
+instanceKlass org/eclipse/core/internal/registry/RegistryTimestamp
+instanceKlass org/eclipse/core/internal/registry/TableReader
+instanceKlass org/eclipse/core/runtime/ListenerList
+instanceKlass org/eclipse/core/internal/registry/ReadWriteMonitor
+instanceKlass org/eclipse/core/internal/registry/RegistryObjectFactory
+instanceKlass org/eclipse/core/runtime/ISafeRunnable
+instanceKlass org/eclipse/core/runtime/IExtensionPoint
+instanceKlass org/eclipse/core/runtime/IExtensionDelta
+instanceKlass org/eclipse/core/runtime/IExtension
+instanceKlass org/eclipse/core/internal/registry/RegistryObject
+instanceKlass org/eclipse/core/internal/registry/KeyedElement
+instanceKlass org/eclipse/core/internal/registry/ExtensionRegistry
+instanceKlass org/eclipse/core/runtime/spi/IDynamicExtensionRegistry
+instanceKlass org/eclipse/core/runtime/IExtensionRegistry
+instanceKlass org/eclipse/core/runtime/RegistryFactory
+instanceKlass org/eclipse/core/internal/registry/ReferenceMap$IEntry
+instanceKlass org/eclipse/core/internal/registry/ReferenceMap
+instanceKlass org/eclipse/core/internal/registry/osgi/OSGIUtils
+instanceKlass org/eclipse/core/internal/registry/osgi/EquinoxUtils
+instanceKlass org/eclipse/core/internal/registry/RegistryProperties
+instanceKlass org/eclipse/core/runtime/spi/IRegistryProvider
+instanceKlass org/eclipse/core/runtime/spi/RegistryStrategy
+instanceKlass org/eclipse/core/internal/registry/osgi/Activator
+instanceKlass org/eclipse/core/runtime/IRegistryChangeListener
+instanceKlass org/eclipse/core/runtime/content/IContentType
+instanceKlass org/eclipse/core/runtime/content/IContentTypeSettings
+instanceKlass org/eclipse/core/internal/content/IContentTypeInfo
+instanceKlass org/eclipse/core/runtime/content/IContentDescription
+instanceKlass org/osgi/service/prefs/Preferences
+instanceKlass org/apache/felix/scr/impl/inject/internal/ComponentConstructorImpl
+instanceKlass org/apache/felix/scr/impl/inject/ReferenceMethods$1
+instanceKlass org/apache/felix/scr/impl/inject/ReferenceMethod
+instanceKlass org/apache/felix/scr/impl/inject/methods/BindMethods
+instanceKlass org/apache/felix/scr/impl/inject/ReferenceMethods
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod$NotApplicable
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod$NotResolved
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod$State
+instanceKlass org/apache/felix/scr/impl/inject/BaseParameter
+instanceKlass org/apache/felix/scr/impl/inject/methods/BaseMethod
+instanceKlass org/eclipse/core/internal/content/ContentTypeMatcher
+instanceKlass org/eclipse/core/runtime/content/IContentTypeManager
+instanceKlass org/eclipse/core/runtime/content/IContentTypeMatcher
+instanceKlass org/apache/felix/scr/impl/helper/ComponentServiceObjectsHelper
+instanceKlass org/apache/felix/scr/impl/manager/EdgeInfo
+instanceKlass org/apache/felix/scr/impl/manager/ComponentContextImpl$ComponentInstanceImpl
+instanceKlass org/osgi/service/component/ComponentInstance
+instanceKlass org/apache/felix/scr/impl/manager/ComponentContextImpl
+instanceKlass org/apache/felix/scr/impl/manager/RegistrationManager$RegStateWrapper
+instanceKlass org/apache/felix/scr/impl/BundleComponentActivator$ListenerInfo
+instanceKlass org/apache/felix/scr/impl/manager/ServiceTracker$AbstractTracked
+instanceKlass org/apache/felix/scr/impl/manager/ExtendedServiceListener
+instanceKlass org/apache/felix/scr/impl/manager/ServiceTracker
+instanceKlass org/apache/felix/scr/impl/helper/Coercions
+instanceKlass org/apache/felix/scr/impl/manager/DependencyManager$AbstractCustomizer
+instanceKlass org/apache/felix/scr/impl/manager/DependencyManager$Customizer
+instanceKlass org/apache/felix/scr/impl/manager/ServiceTrackerCustomizer
+instanceKlass org/apache/felix/scr/impl/inject/RefPair
+instanceKlass org/apache/felix/scr/impl/inject/OpenStatus
+instanceKlass org/apache/felix/scr/impl/manager/DependencyManager
+instanceKlass org/apache/felix/scr/impl/manager/ReferenceManager
+instanceKlass org/osgi/util/promise/Deferred
+instanceKlass org/apache/felix/scr/impl/inject/ScrComponentContext
+instanceKlass org/apache/felix/scr/component/ExtComponentContext
+instanceKlass org/apache/felix/scr/impl/manager/SingleComponentManager$SetImplementationObject
+instanceKlass org/apache/felix/scr/impl/manager/RegistrationManager
+instanceKlass org/apache/felix/scr/impl/helper/ConfigAdminTracker$1
+instanceKlass org/apache/felix/scr/impl/helper/ConfigAdminTracker
+instanceKlass org/apache/felix/scr/impl/ComponentRegistry$4
+instanceKlass org/apache/felix/scr/impl/inject/ComponentConstructor
+instanceKlass org/apache/felix/scr/impl/inject/LifecycleMethod
+instanceKlass org/apache/felix/scr/impl/inject/internal/ComponentMethodsImpl
+instanceKlass org/apache/felix/scr/impl/metadata/TargetedPID
+instanceKlass java/util/concurrent/CompletionStage
+instanceKlass org/osgi/util/promise/PromiseImpl
+instanceKlass org/osgi/util/promise/Promise
+instanceKlass org/osgi/util/promise/PromiseFactory
+instanceKlass org/osgi/util/promise/Promises
+instanceKlass org/apache/felix/scr/impl/inject/ComponentMethods
+instanceKlass org/osgi/service/component/ComponentFactory
+instanceKlass org/apache/felix/scr/impl/manager/AbstractComponentManager
+instanceKlass org/apache/felix/scr/impl/manager/ComponentManager
+instanceKlass org/apache/felix/scr/impl/manager/ConfigurableComponentHolder
+instanceKlass org/apache/felix/scr/impl/manager/ComponentContainer
+instanceKlass org/apache/felix/scr/impl/ComponentRegistryKey
+instanceKlass org/apache/felix/scr/impl/metadata/PropertyMetadata
+instanceKlass org/apache/felix/scr/impl/metadata/ReferenceMetadata
+instanceKlass org/apache/felix/scr/impl/metadata/ServiceMetadata
+instanceKlass org/apache/felix/scr/impl/metadata/ComponentMetadata
+instanceKlass org/apache/felix/scr/impl/xml/XmlConstants
+instanceKlass com/sun/org/apache/xerces/internal/impl/Constants$ArrayEnumeration
+instanceKlass com/sun/org/apache/xerces/internal/impl/Constants
+instanceKlass com/sun/org/apache/xerces/internal/parsers/AbstractSAXParser$LocatorProxy
+instanceKlass org/xml/sax/ext/Locator2
+instanceKlass org/xml/sax/Locator
+instanceKlass com/sun/org/apache/xerces/internal/util/XMLSymbols
+instanceKlass com/sun/org/apache/xerces/internal/util/XMLChar
+instanceKlass com/sun/xml/internal/stream/Entity
+instanceKlass com/sun/xml/internal/stream/util/BufferAllocator
+instanceKlass com/sun/xml/internal/stream/util/ThreadLocalBufferAllocator
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLEntityManager$EncodingInfo
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLLimitAnalyzer
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource
+instanceKlass com/sun/org/apache/xerces/internal/util/ErrorHandlerWrapper
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLErrorHandler
+instanceKlass com/sun/org/apache/xerces/internal/impl/ExternalSubsetResolver
+instanceKlass com/sun/org/apache/xerces/internal/util/EntityResolverWrapper
+instanceKlass org/xml/sax/ext/EntityResolver2
+instanceKlass org/xml/sax/InputSource
+instanceKlass com/sun/org/apache/xerces/internal/parsers/AbstractSAXParser$AttributesProxy
+instanceKlass org/xml/sax/ext/Attributes2
+instanceKlass org/xml/sax/Attributes
+instanceKlass org/xml/sax/AttributeList
+instanceKlass com/sun/org/apache/xerces/internal/util/FeatureState
+instanceKlass com/sun/org/apache/xerces/internal/util/PropertyState
+instanceKlass com/sun/org/apache/xerces/internal/impl/msg/XMLMessageFormatter
+instanceKlass com/sun/org/apache/xerces/internal/util/MessageFormatter
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLVersionDetector
+instanceKlass com/sun/org/apache/xerces/internal/impl/validation/ValidationManager
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/NMTOKENDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/NOTATIONDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/ENTITYDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/ListDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/IDREFDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/IDDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/dtd/StringDatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/DatatypeValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/DTDDVFactory
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/DTDGrammarBucket
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLAttributeDecl
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLSimpleType
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLElementDecl
+instanceKlass com/sun/org/apache/xerces/internal/impl/validation/ValidationState
+instanceKlass com/sun/org/apache/xerces/internal/impl/dv/ValidationContext
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLDTDValidator
+instanceKlass com/sun/org/apache/xerces/internal/impl/RevalidationHandler
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLDTDValidatorFilter
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDocumentFilter
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLEntityDecl
+instanceKlass com/sun/org/apache/xerces/internal/impl/dtd/XMLDTDProcessor
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDTDContentModelFilter
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDTDFilter
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDTDScanner
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDTDContentModelSource
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDTDSource
+instanceKlass com/sun/org/apache/xerces/internal/xni/grammars/XMLDTDDescription
+instanceKlass com/sun/org/apache/xerces/internal/xni/grammars/XMLGrammarDescription
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl$TrailingMiscDriver
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl$PrologDriver
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl$XMLDeclDriver
+instanceKlass com/sun/org/apache/xerces/internal/util/NamespaceSupport
+instanceKlass com/sun/org/apache/xerces/internal/xni/NamespaceContext
+instanceKlass com/sun/org/apache/xerces/internal/util/XMLAttributesImpl$Attribute
+instanceKlass com/sun/org/apache/xerces/internal/util/XMLAttributesImpl
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLAttributes
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl$FragmentContentDriver
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl$Driver
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl$ElementStack2
+instanceKlass com/sun/org/apache/xerces/internal/xni/QName
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLDocumentFragmentScannerImpl$ElementStack
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLString
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLScanner
+instanceKlass com/sun/xml/internal/stream/XMLBufferListener
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLEntityHandler
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDocumentScanner
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLDocumentSource
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLErrorReporter
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLEntityScanner
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLLocator
+instanceKlass com/sun/xml/internal/stream/XMLEntityStorage
+instanceKlass com/sun/org/apache/xerces/internal/util/AugmentationsImpl$AugmentationsItemsContainer
+instanceKlass com/sun/org/apache/xerces/internal/util/AugmentationsImpl
+instanceKlass com/sun/org/apache/xerces/internal/xni/Augmentations
+instanceKlass com/sun/org/apache/xerces/internal/util/XMLResourceIdentifierImpl
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLResourceIdentifier
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLEntityManager
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLEntityResolver
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLComponent
+instanceKlass com/sun/org/apache/xerces/internal/util/SymbolTable$Entry
+instanceKlass com/sun/org/apache/xerces/internal/util/SymbolTable
+instanceKlass jdk/xml/internal/JdkConstants
+instanceKlass jdk/xml/internal/JdkXmlUtils
+instanceKlass com/sun/org/apache/xerces/internal/util/ParserConfigurationSettings
+instanceKlass com/sun/org/apache/xerces/internal/parsers/XML11Configurable
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLPullParserConfiguration
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLParserConfiguration
+instanceKlass com/sun/org/apache/xerces/internal/xni/parser/XMLComponentManager
+instanceKlass com/sun/org/apache/xerces/internal/parsers/XMLParser
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLDTDContentModelHandler
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLDTDHandler
+instanceKlass com/sun/org/apache/xerces/internal/xni/XMLDocumentHandler
+instanceKlass org/xml/sax/XMLReader
+instanceKlass org/xml/sax/Parser
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLSecurityManager
+instanceKlass javax/xml/parsers/SAXParser
+instanceKlass com/sun/org/apache/xerces/internal/xs/PSVIProvider
+instanceKlass com/sun/org/apache/xerces/internal/jaxp/JAXPConstants
+instanceKlass  @bci javax/xml/parsers/FactoryFinder newInstance (Ljava/lang/Class;Ljava/lang/String;Ljava/lang/ClassLoader;ZZ)Ljava/lang/Object; 104 <appendix> member <vmtarget> ; # javax/xml/parsers/FactoryFinder$$Lambda+0x00000139da0de858
+instanceKlass  @bci jdk/xml/internal/SecuritySupport getContextClassLoader ()Ljava/lang/ClassLoader; 0 <appendix> argL0 ; # jdk/xml/internal/SecuritySupport$$Lambda+0x00000139da0de3d0
+instanceKlass  @bci javax/xml/parsers/FactoryFinder find (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Object; 104 <appendix> member <vmtarget> ; # javax/xml/parsers/FactoryFinder$$Lambda+0x00000139da0de1a8
+instanceKlass javax/xml/parsers/FactoryFinder$1
+instanceKlass  @bci jdk/xml/internal/SecuritySupport getFileInputStream (Ljava/io/File;)Ljava/io/FileInputStream; 1 <appendix> member <vmtarget> ; # jdk/xml/internal/SecuritySupport$$Lambda+0x00000139da0ddd50
+instanceKlass  @bci jdk/xml/internal/SecuritySupport doesFileExist (Ljava/io/File;)Z 1 <appendix> member <vmtarget> ; # jdk/xml/internal/SecuritySupport$$Lambda+0x00000139da0ddb28
+instanceKlass  @bci javax/xml/parsers/FactoryFinder find (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Object; 6 <appendix> member <vmtarget> ; # javax/xml/parsers/FactoryFinder$$Lambda+0x00000139da0dd900
+instanceKlass  @bci jdk/xml/internal/SecuritySupport getSystemProperty (Ljava/lang/String;)Ljava/lang/String; 1 <appendix> member <vmtarget> ; # jdk/xml/internal/SecuritySupport$$Lambda+0x00000139da0dd6d8
+instanceKlass jdk/xml/internal/SecuritySupport
+instanceKlass javax/xml/parsers/FactoryFinder
+instanceKlass javax/xml/parsers/SAXParserFactory
+instanceKlass org/xml/sax/helpers/DefaultHandler
+instanceKlass org/xml/sax/ErrorHandler
+instanceKlass org/xml/sax/ContentHandler
+instanceKlass org/xml/sax/DTDHandler
+instanceKlass org/xml/sax/EntityResolver
+instanceKlass org/apache/felix/scr/impl/BundleComponentActivator
+instanceKlass org/apache/felix/scr/impl/manager/ComponentActivator
+instanceKlass org/apache/felix/scr/impl/manager/ExtendedServiceListenerContext
+instanceKlass org/eclipse/core/internal/runtime/IAdapterFactoryExt
+instanceKlass org/eclipse/core/internal/runtime/AdapterFactoryBridge$LazyAdapterFactory
+instanceKlass org/eclipse/core/internal/runtime/AdapterFactoryBridge
+instanceKlass org/eclipse/core/runtime/IAdapterFactory
+instanceKlass org/eclipse/core/internal/runtime/TracingOptions$1
+instanceKlass org/eclipse/core/internal/runtime/TracingOptions
+instanceKlass java/util/AbstractMap$1$1
+instanceKlass org/osgi/service/url/URLStreamHandlerService
+instanceKlass  @bci org/eclipse/core/runtime/ServiceCaller current ()Ljava/util/Optional; 4 <appendix> argL0 ; # org/eclipse/core/runtime/ServiceCaller$$Lambda+0x00000139da143078
+instanceKlass  @bci com/sun/org/apache/xml/internal/serializer/ToXMLStream startDocumentInternal ()V 72 <appendix> argL2 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da144000
+instanceKlass  @bci org/eclipse/core/runtime/ServiceCaller trackCurrent ()Ljava/util/Optional; 19 <appendix> member <vmtarget> ; # org/eclipse/core/runtime/ServiceCaller$$Lambda+0x00000139da142e30
+instanceKlass  @bci org/eclipse/core/runtime/ServiceCaller getCurrent ()Ljava/util/Optional; 12 <appendix> member <vmtarget> ; # org/eclipse/core/runtime/ServiceCaller$$Lambda+0x00000139da142be8
+instanceKlass org/eclipse/core/runtime/ServiceCaller$ReferenceAndService
+instanceKlass org/eclipse/core/internal/runtime/AdapterManager
+instanceKlass org/eclipse/core/runtime/IAdapterManager
+instanceKlass org/eclipse/core/internal/runtime/PlatformURLConverter
+instanceKlass org/eclipse/core/internal/runtime/RuntimeLog
+instanceKlass org/eclipse/core/runtime/IStatus
+instanceKlass org/eclipse/core/internal/runtime/PlatformLogWriter
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogReaderServiceImpl
+instanceKlass  @bci org/eclipse/core/runtime/ServiceCaller <init> (Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/String;)V 39 <appendix> argL0 ; # org/eclipse/core/runtime/ServiceCaller$$Lambda+0x00000139da141000
+instanceKlass  @bci org/osgi/framework/FrameworkUtil getBundle (Ljava/lang/Class;)Lorg/osgi/framework/Bundle; 26 <appendix> member <vmtarget> ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da12f5a0
+instanceKlass  @bci org/osgi/framework/FrameworkUtil getBundle (Ljava/lang/Class;)Lorg/osgi/framework/Bundle; 17 <appendix> argL0 ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da12f360
+instanceKlass  @bci org/osgi/framework/FrameworkUtil getBundle (Ljava/lang/Class;)Lorg/osgi/framework/Bundle; 1 <appendix> member <vmtarget> ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da12f138
+instanceKlass  @bci org/eclipse/core/runtime/ServiceCaller <init> (Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/String;)V 31 <appendix> argL0 ; # org/eclipse/core/runtime/ServiceCaller$$Lambda+0x00000139da140ca8
+instanceKlass org/eclipse/core/runtime/ServiceCaller
+instanceKlass org/eclipse/core/internal/runtime/Activator
+instanceKlass org/apache/felix/scr/impl/config/ScrMetaTypeProviderServiceFactory
+instanceKlass org/apache/felix/scr/impl/config/ScrManagedServiceServiceFactory
+instanceKlass org/apache/felix/scr/impl/ComponentCommands$2
+instanceKlass org/apache/felix/scr/impl/ComponentCommands$1
+instanceKlass org/apache/felix/scr/impl/ComponentCommands
+instanceKlass org/apache/felix/scr/impl/Activator$ScrExtension
+instanceKlass org/apache/felix/scr/impl/runtime/ServiceComponentRuntimeImpl
+instanceKlass org/apache/felix/scr/impl/manager/ComponentHolder
+instanceKlass org/apache/felix/scr/impl/manager/RegionConfigurationSupport
+instanceKlass org/apache/felix/scr/impl/ComponentRegistry
+instanceKlass org/apache/felix/scr/impl/ComponentActorExecutor$1
+instanceKlass org/apache/felix/scr/impl/logger/ScrLogManager$1
+instanceKlass org/apache/felix/scr/impl/logger/LogManager$LogDomain
+instanceKlass org/apache/felix/scr/impl/logger/LogManager$Lock
+instanceKlass org/apache/felix/scr/impl/logger/LogManager$LoggerFacade
+instanceKlass org/apache/felix/scr/impl/logger/BundleLogger
+instanceKlass org/apache/felix/scr/impl/logger/ComponentLogger
+instanceKlass org/apache/felix/scr/impl/logger/ScrLogger
+instanceKlass org/apache/felix/scr/impl/logger/InternalLogger
+instanceKlass org/apache/felix/scr/impl/logger/ScrLoggerFactory
+instanceKlass org/osgi/service/component/ComponentContext
+instanceKlass org/osgi/service/component/ComponentServiceObjects
+instanceKlass org/apache/felix/scr/impl/inject/internal/ClassUtils
+instanceKlass org/apache/felix/scr/impl/config/ScrConfigurationImpl
+instanceKlass org/osgi/service/component/runtime/ServiceComponentRuntime
+instanceKlass org/apache/felix/scr/impl/manager/ScrConfiguration
+instanceKlass org/apache/felix/scr/impl/logger/LogConfiguration
+instanceKlass org/apache/felix/scr/impl/AbstractExtender
+instanceKlass org/eclipse/osgi/internal/loader/buddy/PolicyHandler
+instanceKlass org/apache/aries/spifly/WeavingData
+instanceKlass org/apache/aries/spifly/ConsumerRestriction
+instanceKlass org/apache/aries/spifly/MethodRestriction
+instanceKlass org/apache/aries/spifly/ArgRestrictions
+instanceKlass org/apache/aries/spifly/BundleDescriptor
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator addConsumerWeavingData (Lorg/osgi/framework/Bundle;Ljava/lang/String;)V 177 <appendix> member <vmtarget> ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da132e38
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator addConsumerWeavingData (Lorg/osgi/framework/Bundle;Ljava/lang/String;)V 161 <appendix> member <vmtarget> ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da132be0
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator addConsumerWeavingData (Lorg/osgi/framework/Bundle;Ljava/lang/String;)V 149 <appendix> argL0 ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da1329c0
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator addConsumerWeavingData (Lorg/osgi/framework/Bundle;Ljava/lang/String;)V 141 <appendix> argL0 ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da132780
+instanceKlass org/apache/aries/spifly/ConsumerBundleTrackerCustomizer
+instanceKlass java/util/Formattable
+instanceKlass java/time/LocalTime$1
+instanceKlass sun/util/locale/provider/LocaleResources
+instanceKlass  @bci sun/util/locale/provider/JRELocaleProviderAdapter getDecimalFormatSymbolsProvider ()Ljava/text/spi/DecimalFormatSymbolsProvider; 8 <appendix> member <vmtarget> ; # sun/util/locale/provider/JRELocaleProviderAdapter$$Lambda+0x800000066
+instanceKlass java/text/DecimalFormatSymbols
+instanceKlass sun/util/resources/Bundles$CacheKeyReference
+instanceKlass  @bci sun/util/cldr/CLDRLocaleProviderAdapter applyAliases (Ljava/util/Locale;)Ljava/util/Locale; 4 <appendix> argL0 ; # sun/util/cldr/CLDRLocaleProviderAdapter$$Lambda+0x80000005f
+instanceKlass sun/util/resources/Bundles$CacheKey
+instanceKlass sun/util/resources/Bundles
+instanceKlass sun/util/resources/LocaleData$LocaleDataStrategy
+instanceKlass sun/util/resources/Bundles$Strategy
+instanceKlass sun/util/resources/LocaleData$1
+instanceKlass sun/util/resources/LocaleData
+instanceKlass java/util/Locale$Builder
+instanceKlass sun/util/locale/provider/CalendarDataUtility
+instanceKlass sun/util/locale/provider/AvailableLanguageTags
+instanceKlass  @bci sun/util/locale/provider/JRELocaleProviderAdapter getDateFormatSymbolsProvider ()Ljava/text/spi/DateFormatSymbolsProvider; 8 <appendix> member <vmtarget> ; # sun/util/locale/provider/JRELocaleProviderAdapter$$Lambda+0x800000065
+instanceKlass sun/util/resources/cldr/provider/CLDRLocaleDataMetaInfo
+instanceKlass jdk/internal/module/ModulePatcher$PatchedModuleReader
+instanceKlass  @bci sun/util/cldr/CLDRLocaleProviderAdapter <init> ()V 4 <appendix> argL0 ; # sun/util/cldr/CLDRLocaleProviderAdapter$$Lambda+0x800000061
+instanceKlass sun/util/locale/BaseLocale$Key
+instanceKlass sun/util/locale/InternalLocaleBuilder$CaseInsensitiveChar
+instanceKlass sun/util/locale/InternalLocaleBuilder
+instanceKlass sun/util/locale/StringTokenIterator
+instanceKlass sun/util/locale/ParseStatus
+instanceKlass sun/util/locale/LanguageTag
+instanceKlass sun/util/cldr/CLDRBaseLocaleDataMetaInfo
+instanceKlass sun/util/locale/provider/LocaleDataMetaInfo
+instanceKlass sun/util/locale/provider/ResourceBundleBasedAdapter
+instanceKlass sun/util/locale/provider/LocaleProviderAdapter
+instanceKlass java/util/spi/LocaleServiceProvider
+instanceKlass java/text/DateFormatSymbols
+instanceKlass java/time/ZonedDateTime$1
+instanceKlass java/util/Calendar
+instanceKlass java/util/Formatter$FixedString
+instanceKlass java/util/Formatter$DateTime
+instanceKlass java/util/Formatter$Flags
+instanceKlass java/util/Formatter$FormatSpecifier
+instanceKlass java/util/Formatter$FormatString
+instanceKlass java/util/Formatter$Conversion
+instanceKlass  @bci java/util/regex/Pattern Range (II)Ljava/util/regex/Pattern$CharPredicate; 23 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x80000002a
+instanceKlass java/util/Formatter
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleProviderHelper loadPropertyResourceBundle (Ljava/lang/Module;Ljava/lang/Module;Ljava/lang/String;Ljava/util/Locale;)Ljava/util/ResourceBundle; 14 <appendix> member <vmtarget> ; # java/util/ResourceBundle$ResourceBundleProviderHelper$$Lambda+0x00000139da0da670
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleProviderHelper newResourceBundle (Ljava/lang/Class;)Ljava/util/ResourceBundle; 22 <appendix> member <vmtarget> ; # java/util/ResourceBundle$ResourceBundleProviderHelper$$Lambda+0x800000010
+instanceKlass  @bci java/util/ResourceBundle$ResourceBundleProviderHelper loadResourceBundle (Ljava/lang/Module;Ljava/lang/Module;Ljava/lang/String;Ljava/util/Locale;)Ljava/util/ResourceBundle; 13 <appendix> member <vmtarget> ; # java/util/ResourceBundle$ResourceBundleProviderHelper$$Lambda+0x00000139da0d9f80
+instanceKlass java/util/ResourceBundle$ResourceBundleProviderHelper
+instanceKlass java/util/ResourceBundle$3
+instanceKlass  @bci java/util/ResourceBundle getLoader (Ljava/lang/Module;)Ljava/lang/ClassLoader; 6 <appendix> member <vmtarget> ; # java/util/ResourceBundle$$Lambda+0x00000139da0d9b20
+instanceKlass java/util/ResourceBundle$CacheKeyReference
+instanceKlass java/util/ResourceBundle$CacheKey
+instanceKlass sun/util/locale/LocaleObjectCache
+instanceKlass java/util/ResourceBundle$Control
+instanceKlass java/util/logging/Level$RbAccess
+instanceKlass  @bci java/util/logging/LogRecord inferCaller ()V 18 <appendix> member <vmtarget> ; # java/util/logging/LogRecord$$Lambda+0x00000139da0d9060
+instanceKlass java/lang/StackStreamFactory$FrameBuffer
+instanceKlass java/lang/StackStreamFactory
+instanceKlass  @bci java/util/logging/LogRecord$CallerFinder get ()Ljava/util/Optional; 4 <appendix> member <vmtarget> ; # java/util/logging/LogRecord$CallerFinder$$Lambda+0x00000139da0d7860
+instanceKlass  @bci java/util/logging/LogRecord$CallerFinder <clinit> ()V 0 <appendix> argL0 ; # java/util/logging/LogRecord$CallerFinder$$Lambda+0x00000139da0d7640
+instanceKlass  @bci com/google/common/io/Closer <clinit> ()V 0 <bsm> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da136400
+instanceKlass java/util/logging/LogRecord$CallerFinder
+instanceKlass java/time/chrono/AbstractChronology
+instanceKlass java/time/chrono/Chronology
+instanceKlass java/time/LocalDate$1
+instanceKlass  @bci java/time/temporal/TemporalAdjusters nextOrSame (Ljava/time/DayOfWeek;)Ljava/time/temporal/TemporalAdjuster; 6 <appendix> member <vmtarget> ; # java/time/temporal/TemporalAdjusters$$Lambda+0x00000139da0d71d0
+instanceKlass  @cpi java/time/temporal/TemporalAdjusters 209 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da136000
+instanceKlass java/time/temporal/TemporalAdjusters
+instanceKlass java/time/zone/Ser
+instanceKlass java/io/Externalizable
+instanceKlass java/time/zone/ZoneRulesProvider$1
+instanceKlass java/time/zone/ZoneRulesProvider
+instanceKlass sun/util/calendar/ZoneInfoFile$ZoneOffsetTransitionRule
+instanceKlass sun/util/calendar/ZoneInfoFile$1
+instanceKlass sun/util/calendar/ZoneInfoFile
+instanceKlass java/util/TimeZone
+instanceKlass java/util/logging/LogManager$CloseOnReset
+instanceKlass java/util/logging/StreamHandler$1
+instanceKlass java/util/logging/Handler$1
+instanceKlass java/util/logging/ErrorManager
+instanceKlass jdk/internal/logger/SimpleConsoleLogger$Formatting
+instanceKlass  @bci java/util/logging/SimpleFormatter <init> ()V 5 <appendix> argL0 ; # java/util/logging/SimpleFormatter$$Lambda+0x00000139da0d3e80
+instanceKlass java/util/logging/Formatter
+instanceKlass java/time/Clock
+instanceKlass java/time/InstantSource
+instanceKlass java/util/logging/LogRecord
+instanceKlass org/apache/aries/spifly/ProviderServiceFactory
+instanceKlass ch/qos/logback/classic/spi/LogbackServiceProvider
+instanceKlass org/slf4j/spi/SLF4JServiceProvider
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxBundle$ResolvedModuleClassLoader
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxBundle$1
+instanceKlass org/apache/aries/spifly/ProviderBundleTrackerCustomizer$ServiceDetails
+instanceKlass org/eclipse/osgi/storage/bundlefile/ZipBundleFile$1
+instanceKlass  @bci org/eclipse/osgi/storage/bundlefile/ZipBundleFile getPaths ()Ljava/lang/Iterable; 1 <appendix> member <vmtarget> ; # org/eclipse/osgi/storage/bundlefile/ZipBundleFile$$Lambda+0x00000139da12e230
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator registerProviderBundle (Ljava/lang/String;Lorg/osgi/framework/Bundle;Ljava/util/Map;)V 33 <appendix> member <vmtarget> ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da131e90
+instanceKlass org/apache/aries/spifly/Pair
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator registerProviderBundle (Ljava/lang/String;Lorg/osgi/framework/Bundle;Ljava/util/Map;)V 5 <appendix> argL0 ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da131a30
+instanceKlass  @bci org/osgi/framework/FrameworkUtil <clinit> ()V 27 <appendix> member <vmtarget> ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da12dff8
+instanceKlass org/osgi/framework/connect/FrameworkUtilHelper
+instanceKlass  @bci org/osgi/framework/FrameworkUtil <clinit> ()V 8 <appendix> argL0 ; # org/osgi/framework/FrameworkUtil$$Lambda+0x00000139da12dbd8
+instanceKlass org/osgi/framework/FrameworkUtil
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager startJob (Lorg/eclipse/core/internal/jobs/Worker;)Lorg/eclipse/core/runtime/jobs/Job; 45 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da134c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da134800
+instanceKlass  @bci org/eclipse/core/internal/jobs/JobManager startJob (Lorg/eclipse/core/internal/jobs/Worker;)Lorg/eclipse/core/runtime/jobs/Job; 45 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da134400
+instanceKlass  @bci aQute/bnd/header/Attrs mergeWith (LaQute/bnd/header/Attrs;Z)V 4 <appendix> member <vmtarget> ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da1317f8
+instanceKlass  @cpi aQute/bnd/header/Attrs 639 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da134000
+instanceKlass  @bci org/apache/aries/spifly/ProviderBundleTrackerCustomizer getFromAutoProviderProperty (Lorg/osgi/framework/Bundle;Ljava/util/Map;)Ljava/util/Map$Entry; 58 <appendix> argL0 ; # org/apache/aries/spifly/ProviderBundleTrackerCustomizer$$Lambda+0x00000139da1315d8
+instanceKlass  @bci org/apache/aries/spifly/ProviderBundleTrackerCustomizer getFromAutoProviderProperty (Lorg/osgi/framework/Bundle;Ljava/util/Map;)Ljava/util/Map$Entry; 50 <appendix> member <vmtarget> ; # org/apache/aries/spifly/ProviderBundleTrackerCustomizer$$Lambda+0x00000139da131390
+instanceKlass java/util/AbstractMap$SimpleImmutableEntry
+instanceKlass  @bci aQute/bnd/stream/EntryPipeline values ()Ljava/util/stream/Stream; 4 <appendix> argL0 ; # aQute/bnd/stream/EntryPipeline$$Lambda+0x00000139da131150
+instanceKlass  @bci aQute/bnd/stream/EntryPipeline filterKey (Ljava/util/function/Predicate;)LaQute/bnd/stream/MapStream; 14 <appendix> member <vmtarget> ; # aQute/bnd/stream/EntryPipeline$$Lambda+0x00000139da130ef8
+instanceKlass  @bci org/apache/aries/spifly/ProviderBundleTrackerCustomizer getFromAutoProviderProperty (Lorg/osgi/framework/Bundle;Ljava/util/Map;)Ljava/util/Map$Entry; 27 <appendix> member <vmtarget> ; # org/apache/aries/spifly/ProviderBundleTrackerCustomizer$$Lambda+0x00000139da130ca0
+instanceKlass sun/invoke/util/VerifyAccess$1
+instanceKlass aQute/bnd/stream/EntryPipeline
+instanceKlass  @bci org/apache/aries/spifly/ProviderBundleTrackerCustomizer getFromAutoProviderProperty (Lorg/osgi/framework/Bundle;Ljava/util/Map;)Ljava/util/Map$Entry; 15 <appendix> argL0 ; # org/apache/aries/spifly/ProviderBundleTrackerCustomizer$$Lambda+0x00000139da130640
+instanceKlass  @bci org/apache/aries/spifly/ProviderBundleTrackerCustomizer getFromAutoProviderProperty (Lorg/osgi/framework/Bundle;Ljava/util/Map;)Ljava/util/Map$Entry; 7 <appendix> argL0 ; # org/apache/aries/spifly/ProviderBundleTrackerCustomizer$$Lambda+0x00000139da130400
+instanceKlass aQute/bnd/stream/MapStream
+instanceKlass org/apache/aries/spifly/SpiFlyConstants
+instanceKlass org/apache/aries/spifly/ConsumerHeaderProcessor
+instanceKlass  @bci aQute/bnd/header/OSGiHeader parseHeader (Ljava/lang/String;LaQute/service/reporter/Reporter;LaQute/bnd/header/Parameters;)LaQute/bnd/header/Parameters; 437 <appendix> member <vmtarget> ; # aQute/bnd/header/OSGiHeader$$Lambda+0x00000139da128800
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 72 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12bc10
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 64 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12b9f0
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 56 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12b7d0
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 48 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12b5b0
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 40 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12b390
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 32 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12b170
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 24 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12af50
+instanceKlass  @bci aQute/bnd/header/Attrs <clinit> ()V 16 <appendix> argL0 ; # aQute/bnd/header/Attrs$$Lambda+0x00000139da12ad30
+instanceKlass aQute/bnd/header/Attrs$DataType
+instanceKlass aQute/bnd/header/Attrs
+instanceKlass aQute/libg/qtokens/QuotedTokenizer
+instanceKlass  @bci java/util/regex/Pattern union (Ljava/util/regex/Pattern$CharPredicate;Ljava/util/regex/Pattern$CharPredicate;Z)Ljava/util/regex/Pattern$CharPredicate; 6 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000032
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_WORD ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x00000139da0d2350
+instanceKlass aQute/bnd/header/OSGiHeader
+instanceKlass org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap$CaseInsentiveEntry
+instanceKlass org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap$EntryIterator
+instanceKlass org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap$KeyIterator
+instanceKlass java/util/ResourceBundle$1
+instanceKlass jdk/internal/access/JavaUtilResourceBundleAccess
+instanceKlass java/util/ResourceBundle
+instanceKlass  @bci org/eclipse/osgi/storage/Storage lambda$7 (Ljava/util/List;Ljava/lang/String;)Ljava/util/stream/Stream; 7 <appendix> member <vmtarget> ; # org/eclipse/osgi/storage/Storage$$Lambda+0x00000139da1276e8
+instanceKlass org/eclipse/osgi/internal/container/InternalUtils$1
+instanceKlass  @bci org/eclipse/osgi/storage/Storage findEntries (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;I)Ljava/util/Enumeration; 101 <appendix> argL0 ; # org/eclipse/osgi/storage/Storage$$Lambda+0x00000139da127248
+instanceKlass  @bci org/eclipse/osgi/storage/Storage findEntries (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;I)Ljava/util/Enumeration; 91 <appendix> member <vmtarget> ; # org/eclipse/osgi/storage/Storage$$Lambda+0x00000139da127000
+instanceKlass org/eclipse/osgi/storage/ManifestLocalization$BundleResourceBundle
+instanceKlass org/eclipse/osgi/storage/ManifestLocalization
+instanceKlass org/apache/aries/spifly/ProviderBundleTrackerCustomizer
+instanceKlass org/osgi/util/tracker/BundleTracker
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator start (Lorg/osgi/framework/BundleContext;Ljava/lang/String;)V 46 <appendix> argL0 ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da129668
+instanceKlass  @bci org/apache/aries/spifly/BaseActivator start (Lorg/osgi/framework/BundleContext;Ljava/lang/String;)V 20 <appendix> argL0 ; # org/apache/aries/spifly/BaseActivator$$Lambda+0x00000139da129428
+instanceKlass aQute/bnd/header/Parameters
+instanceKlass java/util/AbstractList$Itr
+instanceKlass  @bci org/eclipse/osgi/internal/weaving/WovenClassImpl notifyWovenClassListeners ()V 1 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/weaving/WovenClassImpl$$Lambda+0x00000139da126458
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistrationImpl$FrameworkHookRegistration getSafeService (Lorg/eclipse/osgi/internal/framework/BundleContextImpl;Lorg/eclipse/osgi/internal/serviceregistry/ServiceConsumer;)Ljava/lang/Object; 17 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/serviceregistry/ServiceRegistrationImpl$FrameworkHookRegistration$$Lambda+0x00000139da126200
+instanceKlass org/apache/aries/spifly/Util
+instanceKlass org/objectweb/asm/Opcodes
+instanceKlass org/objectweb/asm/ClassVisitor
+instanceKlass org/apache/aries/spifly/dynamic/ClientWeavingHook
+instanceKlass java/util/logging/Logger$SystemLoggerHelper$1
+instanceKlass java/util/logging/Logger$SystemLoggerHelper
+instanceKlass java/util/logging/LogManager$4
+instanceKlass jdk/internal/logger/BootstrapLogger$BootstrapExecutors
+instanceKlass jdk/internal/logger/LoggerFinderLoader
+instanceKlass  @bci java/lang/System$LoggerFinder accessProvider ()Ljava/lang/System$LoggerFinder; 8 <appendix> argL0 ; # java/lang/System$LoggerFinder$$Lambda+0x00000139da0d0a00
+instanceKlass  @bci java/util/logging/Level$KnownLevel findByName (Ljava/lang/String;Ljava/util/function/Function;)Ljava/util/Optional; 29 <appendix> argL0 ; # java/util/logging/Level$KnownLevel$$Lambda+0x800000023
+instanceKlass  @bci java/util/logging/Level findLevel (Ljava/lang/String;)Ljava/util/logging/Level; 13 <appendix> argL0 ; # java/util/logging/Level$$Lambda+0x800000011
+instanceKlass java/util/logging/LogManager$LoggerContext$1
+instanceKlass java/util/logging/LogManager$VisitedLoggers
+instanceKlass java/util/logging/LogManager$2
+instanceKlass java/util/logging/LogManager$LoggingProviderAccess
+instanceKlass java/util/logging/LogManager$LogNode
+instanceKlass java/util/logging/LogManager$LoggerContext
+instanceKlass java/util/logging/LogManager$1
+instanceKlass java/util/logging/LogManager
+instanceKlass java/util/logging/Logger$ConfigurationData
+instanceKlass java/util/logging/Logger$LoggerBundle
+instanceKlass  @bci java/util/logging/Level$KnownLevel add (Ljava/util/logging/Level;)V 49 <appendix> argL0 ; # java/util/logging/Level$KnownLevel$$Lambda+0x800000022
+instanceKlass  @bci java/util/logging/Level$KnownLevel add (Ljava/util/logging/Level;)V 19 <appendix> argL0 ; # java/util/logging/Level$KnownLevel$$Lambda+0x800000021
+instanceKlass java/util/logging/Level
+instanceKlass java/util/logging/Handler
+instanceKlass java/util/logging/Logger
+instanceKlass org/osgi/util/tracker/BundleTrackerCustomizer
+instanceKlass org/eclipse/osgi/internal/loader/ModuleClassLoader$DefineClassResult
+instanceKlass org/apache/aries/spifly/BaseActivator
+instanceKlass org/eclipse/osgi/internal/weaving/WeavingHookConfigurator$WovenClassContext
+instanceKlass org/eclipse/osgi/internal/weaving/WovenClassImpl
+instanceKlass org/osgi/framework/hooks/weaving/WovenClass
+instanceKlass org/eclipse/osgi/internal/loader/classpath/ClasspathManager$DefineContext
+instanceKlass org/eclipse/osgi/internal/loader/BundleLoader$3
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ContainerStartLevel$2
+instanceKlass java/util/concurrent/CountDownLatch
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxContainerAdaptor$1$1
+instanceKlass  @bci org/eclipse/osgi/internal/framework/EquinoxEventPublisher notifyEventHooksPrivileged (Lorg/osgi/framework/BundleEvent;Ljava/util/Collection;)V 98 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/framework/EquinoxEventPublisher$$Lambda+0x00000139da1220b8
+instanceKlass org/eclipse/osgi/container/ModuleResolutionReport
+instanceKlass  @bci java/util/stream/StreamSpliterators$WrappingSpliterator forEachRemaining (Ljava/util/function/Consumer;)V 33 <appendix> member <vmtarget> ; # java/util/stream/StreamSpliterators$WrappingSpliterator$$Lambda+0x00000139da0cfb00
+instanceKlass  @cpi org/eclipse/core/internal/jobs/JobListeners 385 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da124000
+instanceKlass  @bci java/util/stream/Collectors toList ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x00000139da0cf8b8
+instanceKlass  @bci java/util/stream/Collectors toList ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x00000139da0cf688
+instanceKlass  @bci java/util/stream/Collectors toList ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x00000139da0cf468
+instanceKlass  @bci org/apache/felix/resolver/Candidates$FaultyResourcesReport getUnresolvedRequirements ()Ljava/util/Collection; 38 <appendix> argL0 ; # org/apache/felix/resolver/Candidates$FaultyResourcesReport$$Lambda+0x00000139da121118
+instanceKlass  @bci org/apache/felix/resolver/Candidates$FaultyResourcesReport getUnresolvedRequirements ()Ljava/util/Collection; 14 <appendix> argL0 ; # org/apache/felix/resolver/Candidates$FaultyResourcesReport$$Lambda+0x00000139da120ed8
+instanceKlass java/util/concurrent/ConcurrentLinkedQueue$Node
+instanceKlass org/apache/felix/resolver/EnhancedExecutor
+instanceKlass org/apache/felix/resolver/PackageSpaces
+instanceKlass org/apache/felix/resolver/Backlog
+instanceKlass  @bci org/apache/felix/resolver/Candidates prepare ()Lorg/apache/felix/resolver/ResolutionError; 924 <appendix> argL0 ; # org/apache/felix/resolver/Candidates$$Lambda+0x00000139da11bae8
+instanceKlass org/apache/felix/resolver/util/CandidateSelector
+instanceKlass org/apache/felix/resolver/util/OpenHashMap$MapEntry
+instanceKlass org/apache/felix/resolver/util/OpenHashMap$MapIterator
+instanceKlass org/apache/felix/resolver/util/OpenHashMap$1
+instanceKlass org/eclipse/osgi/container/ModuleResolutionReport$EntryImpl
+instanceKlass org/eclipse/osgi/report/resolution/ResolutionReport$Entry
+instanceKlass  @bci org/eclipse/osgi/internal/framework/FilterImpl$Equal compare_Version (Lorg/osgi/framework/Version;)Z 3 <appendix> argL0 ; # org/eclipse/osgi/internal/framework/FilterImpl$Equal$$Lambda+0x00000139da11a210
+instanceKlass org/apache/felix/resolver/Candidates$PopulateResult
+instanceKlass org/apache/felix/resolver/util/OpenHashMap
+instanceKlass org/osgi/service/resolver/HostedCapability
+instanceKlass org/apache/felix/resolver/Candidates
+instanceKlass org/apache/felix/resolver/Util
+instanceKlass org/apache/felix/resolver/ResolveSession
+instanceKlass org/eclipse/osgi/container/ModuleResolver$ResolveProcess$DynamicFragments
+instanceKlass  @bci org/eclipse/osgi/container/ModuleResolver$ResolveProcess removeSubstituted (Ljava/util/List;)V 2 <appendix> member <vmtarget> ; # org/eclipse/osgi/container/ModuleResolver$ResolveProcess$$Lambda+0x00000139da11d1f8
+instanceKlass  @bci org/eclipse/osgi/container/ModuleResolver removeNonEffectiveCapabilities (Ljava/util/Collection;)V 2 <appendix> member <vmtarget> ; # org/eclipse/osgi/container/ModuleResolver$$Lambda+0x00000139da11cfa0
+instanceKlass  @bci org/eclipse/osgi/container/ModuleResolver$ResolveProcess filterDisabled (Ljava/util/List;)V 2 <appendix> member <vmtarget> ; # org/eclipse/osgi/container/ModuleResolver$ResolveProcess$$Lambda+0x00000139da11cd48
+instanceKlass java/util/Collections$ReverseComparator2
+instanceKlass java/util/Collections$ReverseComparator
+instanceKlass  @bci org/eclipse/osgi/container/ModuleResolver$ResolveProcess resolveNonPayLoadFragments ()Ljava/util/Map; 84 <appendix> argL0 ; # org/eclipse/osgi/container/ModuleResolver$ResolveProcess$$Lambda+0x00000139da11cb08
+instanceKlass org/eclipse/osgi/internal/framework/OSGiFrameworkHooks$CoreResolverHookFactory$CoreResolverHook
+instanceKlass org/eclipse/osgi/report/resolution/ResolutionReport$Listener
+instanceKlass  @bci org/eclipse/osgi/internal/framework/OSGiFrameworkHooks$CoreResolverHookFactory getHookReferences (Lorg/eclipse/osgi/internal/serviceregistry/ServiceRegistry;Lorg/eclipse/osgi/internal/framework/BundleContextImpl;)[Lorg/eclipse/osgi/internal/serviceregistry/ServiceReferenceImpl; 2 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/framework/OSGiFrameworkHooks$CoreResolverHookFactory$$Lambda+0x00000139da11c220
+instanceKlass org/eclipse/osgi/container/ModuleResolutionReport$Builder
+instanceKlass org/osgi/service/resolver/ResolveContext
+instanceKlass org/eclipse/osgi/container/ModuleDatabase$1
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ResolutionLock$Permits
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da118400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da118000
+instanceKlass org/eclipse/osgi/framework/eventmgr/EventManager$EventThread$Queued
+instanceKlass  @bci org/eclipse/osgi/framework/eventmgr/EventManager getEventThread ()Lorg/eclipse/osgi/framework/eventmgr/EventManager$EventThread; 24 <appendix> member <vmtarget> ; # org/eclipse/osgi/framework/eventmgr/EventManager$$Lambda+0x00000139da116d30
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ContainerWiring$1
+instanceKlass org/osgi/dto/DTO
+instanceKlass  @bci org/eclipse/osgi/internal/framework/BundleContextImpl notifyFindHooksPriviledged (Lorg/eclipse/osgi/internal/framework/BundleContextImpl;Ljava/util/Collection;)V 73 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/framework/BundleContextImpl$$Lambda+0x00000139da114b50
+instanceKlass org/eclipse/osgi/framework/util/FilePath
+instanceKlass sun/nio/ch/FileChannelImpl$Closer
+instanceKlass sun/nio/fs/WindowsChannelFactory$Flags
+instanceKlass sun/nio/fs/WindowsChannelFactory$1
+instanceKlass sun/nio/fs/WindowsChannelFactory
+instanceKlass org/eclipse/core/runtime/internal/adaptor/ConsoleManager
+instanceKlass org/eclipse/core/runtime/internal/adaptor/DefaultStartupMonitor
+instanceKlass org/eclipse/osgi/service/runnable/StartupMonitor
+instanceKlass java/lang/Thread$Builder$OfVirtual
+instanceKlass java/lang/Thread$Builder$OfPlatform
+instanceKlass java/lang/Thread$Builder
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceFactoryUse$1
+instanceKlass java/util/LinkedList$ListItr
+instanceKlass java/util/LinkedList$Node
+instanceKlass org/eclipse/osgi/service/resolver/NativeCodeSpecification
+instanceKlass org/eclipse/osgi/service/resolver/ExportPackageDescription
+instanceKlass org/eclipse/osgi/service/resolver/NativeCodeDescription
+instanceKlass org/eclipse/osgi/service/resolver/ImportPackageSpecification
+instanceKlass org/eclipse/osgi/service/resolver/HostSpecification
+instanceKlass org/eclipse/osgi/service/resolver/GenericSpecification
+instanceKlass org/eclipse/osgi/service/resolver/GenericDescription
+instanceKlass org/eclipse/osgi/service/resolver/BundleSpecification
+instanceKlass org/eclipse/osgi/service/resolver/VersionConstraint
+instanceKlass org/eclipse/osgi/service/resolver/BundleDescription
+instanceKlass org/eclipse/osgi/service/resolver/BaseDescription
+instanceKlass org/eclipse/osgi/internal/resolver/StateImpl
+instanceKlass org/eclipse/osgi/internal/resolver/StateObjectFactoryImpl
+instanceKlass org/eclipse/osgi/service/resolver/Resolver
+instanceKlass org/eclipse/osgi/service/resolver/State
+instanceKlass org/eclipse/osgi/service/resolver/StateObjectFactory
+instanceKlass org/eclipse/osgi/compatibility/state/PlatformAdminImpl
+instanceKlass org/eclipse/osgi/service/resolver/PlatformAdmin
+instanceKlass org/eclipse/osgi/compatibility/state/Activator
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceConsumer$2
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceConsumer$1
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceConsumer
+instanceKlass org/eclipse/osgi/service/security/TrustEngine
+instanceKlass org/eclipse/osgi/internal/signedcontent/SignedContentConstants
+instanceKlass org/eclipse/osgi/internal/signedcontent/SignedBundleHook$1
+instanceKlass org/eclipse/osgi/internal/framework/XMLParsingServiceFactory
+instanceKlass org/eclipse/osgi/storage/BundleLocalizationImpl
+instanceKlass org/eclipse/osgi/service/localization/BundleLocalization
+instanceKlass org/eclipse/osgi/storage/url/BundleURLConverter
+instanceKlass org/eclipse/osgi/service/urlconversion/URLConverter
+instanceKlass org/apache/felix/resolver/Logger
+instanceKlass org/apache/felix/resolver/ResolutionError
+instanceKlass org/apache/felix/resolver/ResolverImpl
+instanceKlass org/osgi/service/resolver/Resolver
+instanceKlass org/eclipse/osgi/internal/framework/legacy/StartLevelImpl
+instanceKlass org/eclipse/osgi/internal/framework/legacy/PackageAdminImpl
+instanceKlass org/osgi/service/condition/ConditionImpl
+instanceKlass org/osgi/service/condition/Condition
+instanceKlass  @bci org/eclipse/equinox/plurl/impl/PlurlImpl add (Ljava/net/ContentHandlerFactory;)V 13 <appendix> argL0 ; # org/eclipse/equinox/plurl/impl/PlurlImpl$$Lambda+0x00000139da10f970
+instanceKlass  @bci org/eclipse/equinox/plurl/impl/PlurlImpl$5 getContent ()Ljava/util/function/Consumer; 155 <appendix> member <vmtarget> ; # org/eclipse/equinox/plurl/impl/PlurlImpl$5$$Lambda+0x00000139da10f4d8
+instanceKlass  @bci org/eclipse/equinox/plurl/impl/PlurlImpl add (Ljava/net/URLStreamHandlerFactory;)V 13 <appendix> argL0 ; # org/eclipse/equinox/plurl/impl/PlurlImpl$$Lambda+0x00000139da10f288
+instanceKlass org/eclipse/equinox/plurl/impl/PlurlImpl$PlurlFactoryHolder
+instanceKlass  @bci org/eclipse/equinox/plurl/impl/PlurlImpl$5 getContent ()Ljava/util/function/Consumer; 141 <appendix> member <vmtarget> ; # org/eclipse/equinox/plurl/impl/PlurlImpl$5$$Lambda+0x00000139da10eba0
+instanceKlass org/eclipse/osgi/internal/url/ContentHandlerFactoryImpl
+instanceKlass org/eclipse/osgi/internal/url/URLStreamHandlerFactoryImpl
+instanceKlass org/eclipse/equinox/plurl/impl/PlurlImpl$PlurlContentHandlerFactory
+instanceKlass org/eclipse/equinox/plurl/impl/PlurlImpl$LegacyFactory
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da108800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da108400
+instanceKlass org/eclipse/equinox/plurl/impl/StackWalkerCallStack
+instanceKlass org/eclipse/equinox/plurl/impl/URLToHandler
+instanceKlass java/net/UrlDeserializedState
+instanceKlass java/net/InetAddress
+instanceKlass org/eclipse/equinox/plurl/PlurlStreamHandler$PlurlSetter
+instanceKlass java/net/ContentHandler
+instanceKlass org/eclipse/equinox/plurl/impl/CallStack
+instanceKlass org/eclipse/equinox/plurl/impl/PlurlImpl
+instanceKlass org/eclipse/osgi/internal/log/ConfigAdminListener
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyFindHooksPrivileged (Lorg/eclipse/osgi/internal/framework/BundleContextImpl;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Collection;)V 101 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da108000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da100c00
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyFindHooksPrivileged (Lorg/eclipse/osgi/internal/framework/BundleContextImpl;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Collection;)V 101 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da100800
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyFindHooksPrivileged (Lorg/eclipse/osgi/internal/framework/BundleContextImpl;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Collection;)V 101 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/serviceregistry/ServiceRegistry$$Lambda+0x00000139da101d88
+instanceKlass  @cpi org/eclipse/osgi/internal/serviceregistry/ServiceRegistry 1105 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da100400
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ShrinkableCollection
+instanceKlass org/eclipse/osgi/internal/framework/FilterImpl$Parser
+instanceKlass org/eclipse/osgi/internal/framework/FilterImpl
+instanceKlass org/osgi/util/tracker/AbstractTracked
+instanceKlass org/osgi/util/tracker/ServiceTracker
+instanceKlass org/eclipse/osgi/internal/log/EventAdminAdapter
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceRegistry$2
+instanceKlass org/eclipse/osgi/framework/eventmgr/CopyOnWriteIdentityMap$Snapshot$SnapshotIterator
+instanceKlass org/eclipse/osgi/framework/eventmgr/ListenerQueue
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyEventListenerHooksPrivileged (Lorg/osgi/framework/ServiceEvent;Ljava/util/Map;)V 77 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/serviceregistry/ServiceRegistry$$Lambda+0x00000139da1069f8
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyEventHooksPrivileged (Lorg/osgi/framework/ServiceEvent;Ljava/util/Collection;)V 77 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/serviceregistry/ServiceRegistry$$Lambda+0x00000139da106410
+instanceKlass org/eclipse/osgi/framework/eventmgr/CopyOnWriteIdentityMap$Snapshot
+instanceKlass org/osgi/framework/PrototypeServiceFactory
+instanceKlass org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap$CaseInsensitiveKey
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceReferenceImpl
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceUse
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyListenerHooksPrivileged (Ljava/util/Collection;Z)V 106 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da100000
+instanceKlass  @bci org/eclipse/osgi/internal/serviceregistry/ServiceRegistry notifyListenerHooksPrivileged (Ljava/util/Collection;Z)V 106 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/serviceregistry/ServiceRegistry$$Lambda+0x00000139da0bda80
+instanceKlass  @cpi org/eclipse/osgi/internal/serviceregistry/ServiceRegistry 1128 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da0bcc00
+instanceKlass org/eclipse/osgi/internal/serviceregistry/HookContext
+instanceKlass org/osgi/framework/UnfilteredServiceListener
+instanceKlass org/eclipse/osgi/internal/serviceregistry/FilteredServiceListener
+instanceKlass org/osgi/framework/hooks/service/ListenerHook$ListenerInfo
+instanceKlass org/eclipse/osgi/framework/eventmgr/CopyOnWriteIdentityMap$Entry
+instanceKlass org/eclipse/osgi/framework/eventmgr/CopyOnWriteIdentityMap
+instanceKlass org/eclipse/osgi/internal/log/OrderedExecutor
+instanceKlass org/eclipse/osgi/internal/framework/BundleContextImpl$2
+instanceKlass org/osgi/service/startlevel/StartLevel
+instanceKlass org/osgi/service/packageadmin/PackageAdmin
+instanceKlass org/eclipse/equinox/plurl/PlurlContentHandlerFactory
+instanceKlass java/net/ContentHandlerFactory
+instanceKlass org/eclipse/equinox/plurl/PlurlStreamHandlerFactory
+instanceKlass org/eclipse/equinox/plurl/PlurlFactory
+instanceKlass org/eclipse/equinox/plurl/Plurl
+instanceKlass org/eclipse/osgi/internal/framework/SystemBundleActivator
+instanceKlass org/eclipse/osgi/internal/loader/classpath/TitleVersionVendor
+instanceKlass org/eclipse/osgi/internal/loader/classpath/ManifestPackageAttributes
+instanceKlass org/eclipse/osgi/internal/loader/classpath/ClasspathEntry$PDEData
+instanceKlass org/eclipse/osgi/internal/loader/classpath/ClasspathEntry
+instanceKlass org/eclipse/osgi/internal/loader/classpath/FragmentClasspath
+instanceKlass org/eclipse/osgi/internal/loader/classpath/ClasspathManager
+instanceKlass org/eclipse/osgi/internal/loader/ModuleClassLoader$ClassNameLock$1
+instanceKlass org/eclipse/osgi/internal/loader/ModuleClassLoader$ClassNameLock
+instanceKlass org/eclipse/osgi/internal/container/KeyBasedLockStore
+instanceKlass org/eclipse/osgi/internal/loader/BundleLoaderSources
+instanceKlass org/eclipse/osgi/internal/loader/BundleLoader$1
+instanceKlass org/eclipse/osgi/internal/loader/sources/PackageSource
+instanceKlass java/util/concurrent/ForkJoinPool$2
+instanceKlass jdk/internal/access/JavaUtilConcurrentFJPAccess
+instanceKlass java/util/concurrent/ForkJoinPool$DefaultForkJoinWorkerThreadFactory
+instanceKlass java/util/concurrent/ForkJoinPool$WorkQueue
+instanceKlass java/lang/ApplicationShutdownHooks$1
+instanceKlass java/lang/ApplicationShutdownHooks
+instanceKlass java/util/concurrent/ForkJoinPool$ForkJoinWorkerThreadFactory
+instanceKlass org/eclipse/osgi/internal/framework/StorageSaver$StorageSaverTask
+instanceKlass org/eclipse/osgi/internal/framework/StorageSaver
+instanceKlass java/util/concurrent/Executors$RunnableAdapter
+instanceKlass java/util/concurrent/FutureTask$WaitNode
+instanceKlass java/util/concurrent/FutureTask
+instanceKlass jdk/internal/vm/ThreadContainers
+instanceKlass jdk/internal/vm/StackableScope
+instanceKlass java/util/concurrent/RunnableScheduledFuture
+instanceKlass java/util/concurrent/ScheduledFuture
+instanceKlass java/util/concurrent/Delayed
+instanceKlass java/util/concurrent/RunnableFuture
+instanceKlass java/util/concurrent/Future
+instanceKlass java/util/concurrent/ThreadPoolExecutor$AbortPolicy
+instanceKlass java/util/concurrent/AbstractExecutorService
+instanceKlass java/util/concurrent/ScheduledExecutorService
+instanceKlass java/util/concurrent/ExecutorService
+instanceKlass java/util/concurrent/Executors
+instanceKlass java/util/HashMap$HashMapSpliterator
+instanceKlass  @bci java/lang/SecurityManager nonExportedPkgs (Ljava/lang/module/ModuleDescriptor;)Ljava/util/Set; 92 <appendix> member <vmtarget> ; # java/lang/SecurityManager$$Lambda+0x00000139da0c5ed0
+instanceKlass  @bci java/lang/SecurityManager nonExportedPkgs (Ljava/lang/module/ModuleDescriptor;)Ljava/util/Set; 76 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c5c90
+instanceKlass  @bci java/lang/SecurityManager nonExportedPkgs (Ljava/lang/module/ModuleDescriptor;)Ljava/util/Set; 66 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c5a40
+instanceKlass  @bci java/lang/SecurityManager nonExportedPkgs (Ljava/lang/module/ModuleDescriptor;)Ljava/util/Set; 47 <appendix> member <vmtarget> ; # java/lang/SecurityManager$$Lambda+0x00000139da0c5808
+instanceKlass  @bci java/lang/SecurityManager nonExportedPkgs (Ljava/lang/module/ModuleDescriptor;)Ljava/util/Set; 31 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c55c8
+instanceKlass  @bci java/lang/SecurityManager nonExportedPkgs (Ljava/lang/module/ModuleDescriptor;)Ljava/util/Set; 21 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c5378
+instanceKlass  @cpi com/google/inject/internal/KotlinSupport$KotlinUnsupported 71 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da0bc800
+instanceKlass  @bci java/lang/SecurityManager addNonExportedPackages (Ljava/lang/ModuleLayer;)V 59 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c5148
+instanceKlass  @cpi org/eclipse/core/internal/net/Policy 113 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da0bc400
+instanceKlass  @bci java/lang/SecurityManager addNonExportedPackages (Ljava/lang/ModuleLayer;)V 49 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c4f08
+instanceKlass  @bci java/lang/SecurityManager addNonExportedPackages (Ljava/lang/ModuleLayer;)V 39 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c4cc8
+instanceKlass  @bci java/lang/SecurityManager addNonExportedPackages (Ljava/lang/ModuleLayer;)V 29 <appendix> member <vmtarget> ; # java/lang/SecurityManager$$Lambda+0x00000139da0c4a70
+instanceKlass  @cpi java/lang/SecurityManager 518 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da0bc000
+instanceKlass  @bci java/lang/SecurityManager addNonExportedPackages (Ljava/lang/ModuleLayer;)V 17 <appendix> argL0 ; # java/lang/SecurityManager$$Lambda+0x00000139da0c4830
+instanceKlass org/eclipse/osgi/internal/framework/ContextFinder$1
+instanceKlass org/osgi/framework/ServiceObjects
+instanceKlass org/eclipse/osgi/internal/framework/BundleContextImpl
+instanceKlass org/osgi/framework/hooks/weaving/WovenClassListener
+instanceKlass org/osgi/framework/hooks/weaving/WeavingHook
+instanceKlass org/osgi/framework/hooks/service/FindHook
+instanceKlass org/osgi/framework/hooks/service/EventListenerHook
+instanceKlass org/osgi/framework/hooks/service/EventHook
+instanceKlass org/osgi/framework/hooks/bundle/FindHook
+instanceKlass org/osgi/framework/hooks/bundle/EventHook
+instanceKlass org/osgi/framework/hooks/bundle/CollisionHook
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceRegistry$FrameworkHookHolder
+instanceKlass org/osgi/framework/hooks/service/ListenerHook
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceRegistrationImpl
+instanceKlass org/osgi/framework/ServiceRegistration
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ServiceRegistry
+instanceKlass org/eclipse/osgi/framework/eventmgr/EventManager
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxEventPublisher
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da0b5c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da0b5800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da0b5400
+instanceKlass org/eclipse/osgi/storage/bundlefile/BundleEntry
+instanceKlass org/eclipse/osgi/container/ModuleDatabase$2
+instanceKlass java/util/ArrayList$SubList$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da0b5000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da0b4c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da0b4800
+instanceKlass  @bci org/eclipse/m2e/core/embedder/MavenSettingsLocations hashCode ()I 1 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da0b4400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da0b4000
+instanceKlass java/lang/reflect/AnnotatedType
+instanceKlass java/lang/reflect/TypeVariable
+instanceKlass org/eclipse/osgi/container/ModuleWiring$LoaderInitializer
+instanceKlass org/eclipse/osgi/container/ModuleWiring
+instanceKlass org/eclipse/osgi/container/ModuleWire
+instanceKlass org/osgi/framework/wiring/BundleWire
+instanceKlass java/util/Collections$UnmodifiableMap$UnmodifiableEntrySet$UnmodifiableEntry
+instanceKlass java/util/Collections$UnmodifiableMap$UnmodifiableEntrySet$1
+instanceKlass org/eclipse/osgi/internal/container/Capabilities$NamespaceSet
+instanceKlass org/eclipse/osgi/container/ModuleRequirement
+instanceKlass org/osgi/framework/wiring/BundleRequirement
+instanceKlass org/eclipse/osgi/container/ModuleRevision$2
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$Builder$8
+instanceKlass org/eclipse/osgi/container/ModuleCapability
+instanceKlass org/osgi/framework/wiring/BundleCapability
+instanceKlass org/osgi/resource/Capability
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$3
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$2
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$1
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList
+instanceKlass org/eclipse/osgi/container/ModuleRevision$1
+instanceKlass org/osgi/framework/wiring/BundleWiring
+instanceKlass org/osgi/resource/Wiring
+instanceKlass org/eclipse/osgi/container/ModuleRevision
+instanceKlass org/eclipse/osgi/container/ModuleRevisions
+instanceKlass org/osgi/framework/wiring/BundleRevisions
+instanceKlass org/lombokweb/asm/Opcodes
+instanceKlass org/lombokweb/asm/Handler
+instanceKlass lombok/patcher/MethodLogistics
+instanceKlass org/lombokweb/asm/Label
+instanceKlass org/lombokweb/asm/Type
+instanceKlass org/lombokweb/asm/Frame
+instanceKlass org/lombokweb/asm/Context
+instanceKlass org/lombokweb/asm/Attribute
+instanceKlass lombok/patcher/scripts/ExitFromMethodEarlyScript$1
+instanceKlass org/lombokweb/asm/ByteVector
+instanceKlass org/lombokweb/asm/Symbol
+instanceKlass org/lombokweb/asm/SymbolTable
+instanceKlass org/lombokweb/asm/FieldVisitor
+instanceKlass org/lombokweb/asm/MethodVisitor
+instanceKlass org/lombokweb/asm/AnnotationVisitor
+instanceKlass org/lombokweb/asm/ModuleVisitor
+instanceKlass org/lombokweb/asm/RecordComponentVisitor
+instanceKlass org/lombokweb/asm/ClassReader
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxBundle
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$Builder$2
+instanceKlass org/eclipse/osgi/container/ModuleRevisionBuilder$GenericInfo$1
+instanceKlass org/eclipse/osgi/container/ModuleRevisionBuilder$GenericInfo
+instanceKlass org/eclipse/osgi/container/ModuleRevisionBuilder
+instanceKlass org/osgi/resource/Wire
+instanceKlass org/eclipse/osgi/container/ModuleDatabase$Persistence
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ContainerStartLevel
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ContainerWiring
+instanceKlass org/eclipse/osgi/container/ModuleResolver
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ResolutionLock
+instanceKlass org/eclipse/osgi/internal/container/LockSet
+instanceKlass org/osgi/framework/startlevel/FrameworkStartLevel
+instanceKlass org/osgi/resource/Requirement
+instanceKlass org/osgi/framework/wiring/FrameworkWiring
+instanceKlass org/eclipse/osgi/report/resolution/ResolutionReport
+instanceKlass org/eclipse/osgi/container/ModuleContainer
+instanceKlass org/eclipse/osgi/internal/container/Capabilities
+instanceKlass org/eclipse/osgi/container/Module
+instanceKlass org/osgi/framework/startlevel/BundleStartLevel
+instanceKlass org/eclipse/osgi/container/ModuleDatabase
+instanceKlass java/util/concurrent/LinkedBlockingQueue$Node
+instanceKlass java/util/concurrent/RejectedExecutionHandler
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxContainerAdaptor$1
+instanceKlass java/util/concurrent/LinkedTransferQueue$DualNode
+instanceKlass java/util/concurrent/TransferQueue
+instanceKlass java/util/concurrent/atomic/AtomicReference
+instanceKlass org/eclipse/osgi/internal/container/AtomicLazyInitializer
+instanceKlass org/eclipse/osgi/internal/framework/OSGiFrameworkHooks$BundleCollisionHook
+instanceKlass org/osgi/framework/ServiceReference
+instanceKlass org/osgi/framework/hooks/resolver/ResolverHook
+instanceKlass org/eclipse/osgi/internal/framework/OSGiFrameworkHooks$CoreResolverHookFactory
+instanceKlass org/osgi/framework/hooks/resolver/ResolverHookFactory
+instanceKlass org/eclipse/osgi/container/ModuleCollisionHook
+instanceKlass org/eclipse/osgi/internal/framework/OSGiFrameworkHooks
+instanceKlass org/eclipse/osgi/container/ModuleContainerAdaptor$1
+instanceKlass java/util/concurrent/Callable
+instanceKlass org/eclipse/osgi/container/ModuleLoader
+instanceKlass java/util/concurrent/BlockingQueue
+instanceKlass java/util/concurrent/Executor
+instanceKlass org/eclipse/osgi/internal/permadmin/SecurityRow
+instanceKlass org/eclipse/osgi/internal/permadmin/PermissionAdminTable
+instanceKlass org/osgi/service/permissionadmin/PermissionInfo
+instanceKlass org/osgi/service/condpermadmin/ConditionalPermissionUpdate
+instanceKlass org/osgi/service/condpermadmin/ConditionalPermissionInfo
+instanceKlass org/eclipse/osgi/internal/permadmin/SecurityAdmin
+instanceKlass org/osgi/service/condpermadmin/ConditionalPermissionAdmin
+instanceKlass org/osgi/service/permissionadmin/PermissionAdmin
+instanceKlass org/eclipse/osgi/storage/PermissionData
+instanceKlass  @bci org/eclipse/osgi/storage/Storage connectPersistentBundles (Ljava/util/List;)V 2 <appendix> member <vmtarget> ; # org/eclipse/osgi/storage/Storage$$Lambda+0x00000139da0a0938
+instanceKlass  @cpi com/google/inject/internal/WeakKeySet 135 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da0a4000
+instanceKlass org/eclipse/osgi/storage/BundleInfo$Generation
+instanceKlass org/eclipse/osgi/storage/BundleInfo
+instanceKlass org/eclipse/osgi/framework/util/ObjectPool
+instanceKlass jdk/internal/util/ByteArray
+instanceKlass org/eclipse/osgi/storagemanager/StorageManager$Entry
+instanceKlass org/eclipse/osgi/framework/internal/reliablefile/ReliableFile$CacheInfo
+instanceKlass java/util/ComparableTimSort
+instanceKlass java/lang/Shutdown$Lock
+instanceKlass java/lang/Shutdown
+instanceKlass java/io/DeleteOnExitHook$1
+instanceKlass java/io/DeleteOnExitHook
+instanceKlass  @bci org/eclipse/osgi/framework/internal/reliablefile/ReliableFile createTempFile (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/io/File; 61 <appendix> argL0 ; # org/eclipse/osgi/framework/internal/reliablefile/ReliableFile$$Lambda+0x00000139da099000
+instanceKlass org/eclipse/osgi/framework/internal/reliablefile/ReliableFile
+instanceKlass sun/nio/ch/FileKey
+instanceKlass sun/nio/ch/FileLockTable
+instanceKlass sun/nio/ch/NativeThread
+instanceKlass java/nio/channels/FileLock
+instanceKlass sun/nio/ch/NativeThreadSet
+instanceKlass sun/nio/ch/IOUtil
+instanceKlass sun/nio/ch/NativeDispatcher
+instanceKlass java/nio/file/attribute/FileAttribute
+instanceKlass java/nio/channels/spi/AbstractInterruptibleChannel
+instanceKlass java/nio/channels/InterruptibleChannel
+instanceKlass java/nio/channels/ScatteringByteChannel
+instanceKlass java/nio/channels/GatheringByteChannel
+instanceKlass java/nio/channels/SeekableByteChannel
+instanceKlass java/nio/channels/ByteChannel
+instanceKlass java/nio/channels/WritableByteChannel
+instanceKlass java/nio/channels/ReadableByteChannel
+instanceKlass java/nio/channels/Channel
+instanceKlass org/eclipse/osgi/internal/location/Locker_JavaNio
+instanceKlass org/eclipse/osgi/storagemanager/StorageManager
+instanceKlass org/eclipse/osgi/storage/FrameworkExtensionInstaller
+instanceKlass org/eclipse/osgi/storage/bundlefile/MRUBundleFileList
+instanceKlass org/eclipse/osgi/framework/eventmgr/EventDispatcher
+instanceKlass org/osgi/framework/Filter
+instanceKlass org/eclipse/osgi/storage/ContentProvider
+instanceKlass org/eclipse/osgi/storage/bundlefile/BundleFile
+instanceKlass org/eclipse/osgi/container/ModuleContainerAdaptor
+instanceKlass org/eclipse/osgi/storage/Storage
+instanceKlass  @bci org/eclipse/osgi/internal/cds/CDSHookConfigurator addHooks (Lorg/eclipse/osgi/internal/hookregistry/HookRegistry;)V 77 <appendix> argL0 ; # org/eclipse/osgi/internal/cds/CDSHookConfigurator$$Lambda+0x00000139da09def8
+instanceKlass org/eclipse/osgi/signedcontent/SignedContent
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da098400
+instanceKlass java/lang/invoke/MethodHandle$1
+instanceKlass org/eclipse/osgi/internal/hookregistry/StorageHookFactory$StorageHook
+instanceKlass org/eclipse/osgi/internal/hookregistry/StorageHookFactory
+instanceKlass org/osgi/framework/BundleActivator
+instanceKlass org/eclipse/osgi/internal/cds/CDSHookConfigurator
+instanceKlass org/eclipse/osgi/internal/signedcontent/SignedBundleHook
+instanceKlass org/eclipse/osgi/signedcontent/SignedContentFactory
+instanceKlass org/eclipse/osgi/internal/hookregistry/ActivatorHookFactory
+instanceKlass org/osgi/framework/wiring/BundleRevision
+instanceKlass org/osgi/resource/Resource
+instanceKlass org/eclipse/osgi/internal/connect/ConnectHookConfigurator
+instanceKlass org/eclipse/osgi/internal/hookregistry/HookConfigurator
+instanceKlass java/net/URLClassLoader$3$1
+instanceKlass java/net/URLClassLoader$3
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxContainer$ConnectModules
+instanceKlass  @bci org/eclipse/osgi/internal/log/ExtendedLogServiceImpl applyLogLevels (Lorg/eclipse/osgi/internal/log/ExtendedLogServiceFactory$EquinoxLoggerContext;)V 20 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/log/ExtendedLogServiceImpl$$Lambda+0x00000139da097518
+instanceKlass  @bci org/eclipse/osgi/internal/log/ExtendedLogServiceImpl applyLogLevels (Lorg/eclipse/osgi/internal/log/ExtendedLogServiceFactory$EquinoxLoggerContext;)V 5 <appendix> member <vmtarget> ; # org/eclipse/osgi/internal/log/ExtendedLogServiceImpl$$Lambda+0x00000139da0972e0
+instanceKlass  @cpi org/eclipse/m2e/core/internal/project/registry/BasicProjectRegistry 236 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da098000
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogServiceFactory$EquinoxLoggerContext
+instanceKlass org/eclipse/osgi/internal/log/EquinoxLogFactory$1
+instanceKlass org/eclipse/osgi/framework/log/FrameworkLog
+instanceKlass org/eclipse/osgi/internal/log/EquinoxLogFactory
+instanceKlass org/osgi/service/log/FormatterLogger
+instanceKlass org/eclipse/osgi/internal/log/LoggerImpl
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogServiceImpl
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogServiceFactory$EquinoxLoggerAdmin
+instanceKlass org/osgi/service/log/admin/LoggerContext
+instanceKlass org/eclipse/osgi/internal/log/LoggerContextTargetMap
+instanceKlass org/eclipse/osgi/internal/log/LogServiceManager$MockSystemBundle
+instanceKlass org/osgi/service/log/admin/LoggerAdmin
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogServiceFactory
+instanceKlass org/eclipse/osgi/framework/util/ArrayMap
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock$WriteLock
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock$ReadLock
+instanceKlass java/util/concurrent/locks/ReentrantReadWriteLock
+instanceKlass java/util/concurrent/locks/ReadWriteLock
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogReaderServiceFactory$1
+instanceKlass org/osgi/service/log/LogEntry
+instanceKlass org/eclipse/osgi/internal/log/ExtendedLogReaderServiceFactory
+instanceKlass org/osgi/framework/ServiceFactory
+instanceKlass org/eclipse/equinox/log/ExtendedLogReaderService
+instanceKlass org/osgi/service/log/LogReaderService
+instanceKlass org/eclipse/equinox/log/ExtendedLogService
+instanceKlass org/eclipse/equinox/log/Logger
+instanceKlass org/osgi/service/log/Logger
+instanceKlass org/osgi/service/log/LogService
+instanceKlass org/osgi/service/log/LoggerFactory
+instanceKlass org/eclipse/osgi/internal/log/LogServiceManager
+instanceKlass org/osgi/framework/AllServiceListener
+instanceKlass org/osgi/framework/ServiceListener
+instanceKlass org/eclipse/osgi/internal/log/EquinoxLogWriter
+instanceKlass org/eclipse/equinox/log/LogFilter
+instanceKlass org/eclipse/equinox/log/SynchronousLogListener
+instanceKlass org/osgi/service/log/LogListener
+instanceKlass org/eclipse/osgi/internal/log/EquinoxLogServices
+instanceKlass org/eclipse/osgi/util/ManifestElement
+instanceKlass org/eclipse/osgi/internal/debug/Debug
+instanceKlass org/eclipse/osgi/service/debug/DebugOptionsListener
+instanceKlass org/eclipse/osgi/service/debug/DebugTrace
+instanceKlass org/eclipse/osgi/internal/debug/FrameworkDebugOptions
+instanceKlass org/osgi/util/tracker/ServiceTrackerCustomizer
+instanceKlass java/nio/file/FileVisitor
+instanceKlass org/eclipse/osgi/storage/StorageUtil
+instanceKlass org/eclipse/osgi/internal/location/BasicLocation
+instanceKlass org/eclipse/osgi/internal/location/EquinoxLocations
+instanceKlass java/util/concurrent/atomic/AtomicBoolean
+instanceKlass java/util/UUID
+instanceKlass java/util/Random
+instanceKlass java/util/random/RandomGenerator
+instanceKlass org/eclipse/osgi/internal/container/InternalUtils
+instanceKlass org/osgi/framework/Version
+instanceKlass org/eclipse/osgi/internal/location/Locker
+instanceKlass org/eclipse/osgi/internal/location/LocationHelper
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxConfiguration$ConfigValues
+instanceKlass org/eclipse/osgi/internal/util/Tokenizer
+instanceKlass java/nio/charset/CoderResult
+instanceKlass sun/util/logging/PlatformLogger
+instanceKlass sun/util/logging/PlatformLogger$ConfigurableBridge$LoggerConfiguration
+instanceKlass jdk/internal/logger/BootstrapLogger$RedirectedLoggers
+instanceKlass jdk/internal/logger/LazyLoggers$LazyLoggerAccessor
+instanceKlass jdk/internal/logger/LazyLoggers$LoggerAccessor
+instanceKlass jdk/internal/logger/AbstractLoggerWrapper
+instanceKlass java/util/ServiceLoader$ProviderImpl
+instanceKlass java/util/ServiceLoader$Provider
+instanceKlass java/util/ServiceLoader$1
+instanceKlass sun/util/logging/internal/LoggingProviderImpl$LogManagerAccess
+instanceKlass java/util/concurrent/CopyOnWriteArrayList$COWIterator
+instanceKlass jdk/internal/logger/BootstrapLogger$DetectBackend$1
+instanceKlass jdk/internal/logger/BootstrapLogger$DetectBackend
+instanceKlass jdk/internal/logger/BootstrapLogger
+instanceKlass sun/util/logging/PlatformLogger$ConfigurableBridge
+instanceKlass sun/util/logging/PlatformLogger$Bridge
+instanceKlass jdk/internal/logger/DefaultLoggerFinder$1
+instanceKlass java/lang/System$LoggerFinder
+instanceKlass jdk/internal/logger/LazyLoggers$LazyLoggerFactories
+instanceKlass jdk/internal/logger/LazyLoggers$1
+instanceKlass jdk/internal/logger/LazyLoggers
+instanceKlass jdk/internal/event/EventHelper$ThreadTrackHolder
+instanceKlass java/net/URLClassLoader$2
+instanceKlass org/eclipse/osgi/internal/framework/AliasMapper
+instanceKlass org/eclipse/osgi/framework/util/KeyedElement
+instanceKlass org/eclipse/osgi/internal/hookregistry/ClassLoaderHook
+instanceKlass org/eclipse/osgi/internal/hookregistry/HookRegistry
+instanceKlass org/eclipse/osgi/service/datalocation/Location
+instanceKlass org/eclipse/osgi/service/debug/DebugOptions
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxConfiguration
+instanceKlass org/eclipse/osgi/service/environment/EnvironmentInfo
+# instanceKlass org/eclipse/osgi/internal/framework/EquinoxContainer$$InjectedInvoker+0x00000139da08c400
+instanceKlass java/lang/invoke/MethodHandleImpl$BindCaller$InjectedInvokerHolder
+instanceKlass java/lang/invoke/MethodHandleImpl$BindCaller
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da08c000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da08ac00
+instanceKlass java/lang/annotation/Target
+instanceKlass java/lang/reflect/Proxy$ProxyBuilder$1
+instanceKlass jdk/internal/org/objectweb/asm/Edge
+instanceKlass  @bci java/lang/reflect/ProxyGenerator addProxyMethod (Ljava/lang/reflect/Method;Ljava/lang/Class;)V 23 <appendix> argL0 ; # java/lang/reflect/ProxyGenerator$$Lambda+0x00000139da032448
+instanceKlass  @bci java/lang/reflect/ProxyGenerator addProxyMethod (Ljava/lang/reflect/ProxyGenerator$ProxyMethod;)V 10 <appendix> argL0 ; # java/lang/reflect/ProxyGenerator$$Lambda+0x00000139da032208
+instanceKlass java/lang/reflect/ProxyGenerator$ProxyMethod
+instanceKlass  @bci java/lang/reflect/Proxy getLoader (Ljava/lang/Module;)Ljava/lang/ClassLoader; 6 <appendix> member <vmtarget> ; # java/lang/reflect/Proxy$$Lambda+0x00000139da031ab0
+instanceKlass  @bci java/lang/module/ModuleDescriptor$Builder packages (Ljava/util/Set;)Ljava/lang/module/ModuleDescriptor$Builder; 17 <appendix> argL0 ; # java/lang/module/ModuleDescriptor$Builder$$Lambda+0x800000002
+instanceKlass java/lang/module/ModuleDescriptor$Builder
+instanceKlass  @bci java/lang/reflect/Proxy$ProxyBuilder getDynamicModule (Ljava/lang/ClassLoader;)Ljava/lang/Module; 4 <appendix> argL0 ; # java/lang/reflect/Proxy$ProxyBuilder$$Lambda+0x00000139da031670
+instanceKlass java/lang/PublicMethods
+instanceKlass java/lang/reflect/Proxy$ProxyBuilder
+instanceKlass  @bci java/lang/reflect/Proxy getProxyConstructor (Ljava/lang/Class;Ljava/lang/ClassLoader;[Ljava/lang/Class;)Ljava/lang/reflect/Constructor; 35 <appendix> argL0 ; # java/lang/reflect/Proxy$$Lambda+0x00000139da030dd8
+instanceKlass java/lang/reflect/Proxy
+instanceKlass sun/reflect/annotation/AnnotationInvocationHandler
+instanceKlass java/lang/reflect/InvocationHandler
+instanceKlass sun/reflect/annotation/AnnotationParser$1
+instanceKlass sun/reflect/annotation/ExceptionProxy
+instanceKlass java/lang/annotation/Inherited
+instanceKlass java/lang/annotation/Retention
+instanceKlass sun/reflect/annotation/AnnotationType$1
+instanceKlass sun/reflect/annotation/AnnotationType
+instanceKlass java/lang/reflect/GenericArrayType
+instanceKlass sun/reflect/generics/visitor/Reifier
+instanceKlass sun/reflect/generics/visitor/TypeTreeVisitor
+instanceKlass sun/reflect/generics/factory/CoreReflectionFactory
+instanceKlass sun/reflect/generics/factory/GenericsFactory
+instanceKlass sun/reflect/generics/scope/AbstractScope
+instanceKlass sun/reflect/generics/scope/Scope
+instanceKlass sun/reflect/generics/tree/ClassTypeSignature
+instanceKlass sun/reflect/generics/tree/SimpleClassTypeSignature
+instanceKlass sun/reflect/generics/tree/FieldTypeSignature
+instanceKlass sun/reflect/generics/tree/BaseType
+instanceKlass sun/reflect/generics/tree/TypeSignature
+instanceKlass sun/reflect/generics/tree/ReturnType
+instanceKlass sun/reflect/generics/tree/TypeArgument
+instanceKlass sun/reflect/generics/tree/TypeTree
+instanceKlass sun/reflect/generics/tree/Tree
+instanceKlass sun/reflect/generics/parser/SignatureParser
+instanceKlass org/eclipse/osgi/framework/util/SecureAction$1
+instanceKlass org/eclipse/osgi/framework/util/SecureAction
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxContainer
+instanceKlass org/eclipse/osgi/launch/Equinox
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da08a800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da08a400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da08a000
+instanceKlass org/osgi/framework/BundleContext
+instanceKlass org/osgi/framework/BundleReference
+instanceKlass org/eclipse/core/runtime/adaptor/EclipseStarter$StartupEventListener
+instanceKlass org/osgi/framework/FrameworkListener
+instanceKlass org/osgi/framework/SynchronousBundleListener
+instanceKlass java/util/concurrent/Semaphore
+instanceKlass org/eclipse/core/runtime/adaptor/EclipseStarter$InitialBundle
+instanceKlass java/util/EventObject
+instanceKlass org/osgi/framework/launch/Framework
+instanceKlass org/osgi/framework/Bundle
+instanceKlass org/osgi/framework/BundleListener
+instanceKlass java/util/EventListener
+instanceKlass org/eclipse/equinox/plurl/PlurlStreamHandler
+instanceKlass org/eclipse/core/runtime/adaptor/EclipseStarter
+instanceKlass  @bci java/io/FilePermissionCollection add (Ljava/security/Permission;)V 68 <appendix> argL0 ; # java/io/FilePermissionCollection$$Lambda+0x00000139da02ade0
+instanceKlass sun/security/util/SecurityProperties
+instanceKlass sun/security/util/FilePermCompat
+instanceKlass java/io/FilePermission$1
+instanceKlass jdk/internal/access/JavaIOFilePermissionAccess
+instanceKlass java/net/URLClassLoader$1
+instanceKlass  @bci org/eclipse/equinox/launcher/Main basicRun ([Ljava/lang/String;)V 162 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da084b88
+instanceKlass java/nio/file/FileStore
+instanceKlass sun/nio/fs/WindowsSecurity
+instanceKlass sun/nio/fs/AbstractAclFileAttributeView
+instanceKlass java/nio/file/attribute/AclFileAttributeView
+instanceKlass java/nio/file/attribute/FileOwnerAttributeView
+instanceKlass sun/nio/fs/WindowsLinkSupport
+instanceKlass sun/nio/fs/WindowsFileSystemProvider$1
+instanceKlass org/eclipse/equinox/launcher/JNIBridge
+instanceKlass  @bci java/util/stream/MatchOps makeRef (Ljava/util/function/Predicate;Ljava/util/stream/MatchOps$MatchKind;)Ljava/util/stream/TerminalOp; 20 <appendix> member <vmtarget> ; # java/util/stream/MatchOps$$Lambda+0x00000139da028530
+instanceKlass java/util/stream/MatchOps$BooleanTerminalSink
+instanceKlass java/util/stream/MatchOps$MatchOp
+instanceKlass java/util/stream/MatchOps
+instanceKlass  @bci org/eclipse/equinox/launcher/Main extractFromJAR (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; 146 <appendix> member <vmtarget> ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da0846e0
+instanceKlass java/util/AbstractList$RandomAccessSpliterator
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryFromFragment (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; 96 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da084490
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryFromFragment (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; 86 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da084250
+instanceKlass  @bci java/util/zip/ZipFile stream ()Ljava/util/stream/Stream; 25 <appendix> member <vmtarget> ; # java/util/zip/ZipFile$$Lambda+0x00000139da0277c8
+instanceKlass java/util/Spliterators$AbstractSpliterator
+instanceKlass  @bci java/util/stream/StreamSpliterators$WrappingSpliterator initPartialTraversalState ()V 37 <appendix> member <vmtarget> ; # java/util/stream/StreamSpliterators$WrappingSpliterator$$Lambda+0x00000139da0275a0
+instanceKlass java/util/function/BooleanSupplier
+instanceKlass java/util/stream/Sink$ChainedInt
+instanceKlass java/util/stream/Sink$OfInt
+instanceKlass java/util/function/IntConsumer
+instanceKlass  @bci java/util/stream/StreamSpliterators$WrappingSpliterator initPartialTraversalState ()V 24 <appendix> member <vmtarget> ; # java/util/stream/StreamSpliterators$WrappingSpliterator$$Lambda+0x00000139da0265c0
+instanceKlass java/util/stream/StreamSpliterators
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryPath (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String; 190 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da084000
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryPath (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String; 180 <appendix> member <vmtarget> ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01bcc0
+instanceKlass java/util/stream/Stream$Builder
+instanceKlass java/util/stream/Streams$AbstractStreamBuilderImpl
+instanceKlass java/util/stream/Streams$2
+instanceKlass java/util/stream/Streams
+instanceKlass java/util/stream/StreamSpliterators$AbstractWrappingSpliterator
+instanceKlass  @bci java/util/stream/AbstractPipeline spliterator ()Ljava/util/Spliterator; 103 <appendix> member <vmtarget> ; # java/util/stream/AbstractPipeline$$Lambda+0x00000139da025a30
+instanceKlass java/util/stream/Streams$ConcatSpliterator
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryPath (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String; 143 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01ba80
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryPath (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String; 133 <appendix> member <vmtarget> ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01b858
+instanceKlass  @cpi org/eclipse/equinox/launcher/Main 2078 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da082c00
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getLibraryPath (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String; 117 <appendix> member <vmtarget> ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01b610
+instanceKlass java/util/function/IntUnaryOperator
+instanceKlass java/util/stream/Streams$RangeIntSpliterator
+instanceKlass java/util/stream/IntStream
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences absolutePath ()Ljava/lang/String; 66 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da082800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da082400
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences absolutePath ()Ljava/lang/String; 66 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da082000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da081c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da081800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da081400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da081000
+instanceKlass  @bci org/eclipse/core/internal/preferences/EclipsePreferences absolutePath ()Ljava/lang/String; 66 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da080c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da080800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da080400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da080000
+instanceKlass java/io/RandomAccessFile$1
+instanceKlass  @bci com/sun/org/apache/xerces/internal/dom/DOMMessageFormatter formatMessage (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String; 43 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da01fc00
+instanceKlass java/lang/invoke/LambdaFormEditor$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01f800
+instanceKlass  @bci com/sun/org/apache/xerces/internal/dom/DOMMessageFormatter formatMessage (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String; 43 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da01f400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01f000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01ec00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01e800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01e400
+instanceKlass  @bci com/sun/org/apache/xerces/internal/dom/DOMMessageFormatter formatMessage (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String; 43 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da01e000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01dc00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01d800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da01d400
+instanceKlass  @bci org/eclipse/equinox/launcher/Main searchFor (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String; 95 <appendix> member <vmtarget> ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01b3c8
+instanceKlass  @bci org/eclipse/equinox/launcher/Main findMax (Ljava/lang/String;Ljava/util/List;)Ljava/util/Optional; 34 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01b188
+instanceKlass java/util/stream/ReduceOps$2ReducingSink
+instanceKlass  @bci java/util/function/BinaryOperator maxBy (Ljava/util/Comparator;)Ljava/util/function/BinaryOperator; 6 <appendix> member <vmtarget> ; # java/util/function/BinaryOperator$$Lambda+0x00000139da022cd8
+instanceKlass  @bci java/util/Comparator comparing (Ljava/util/function/Function;Ljava/util/Comparator;)Ljava/util/Comparator; 12 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x00000139da022a38
+instanceKlass  @cpi java/util/Comparator 256 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da01d000
+instanceKlass  @bci java/util/Comparator comparing (Ljava/util/function/Function;)Ljava/util/Comparator; 6 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x00000139da022798
+instanceKlass  @bci org/eclipse/equinox/launcher/Main$Identifier <clinit> ()V 34 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$Identifier$$Lambda+0x00000139da01af48
+instanceKlass  @bci org/eclipse/equinox/launcher/Main$Identifier <clinit> ()V 18 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$Identifier$$Lambda+0x00000139da01ad28
+instanceKlass  @bci java/util/Comparator thenComparing (Ljava/util/Comparator;)Ljava/util/Comparator; 7 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x00000139da0224f8
+instanceKlass  @cpi java/util/Comparator 251 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da01cc00
+instanceKlass  @bci org/eclipse/equinox/launcher/Main$Identifier <clinit> ()V 8 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$Identifier$$Lambda+0x00000139da01ab08
+instanceKlass  @bci java/util/Comparator comparingInt (Ljava/util/function/ToIntFunction;)Ljava/util/Comparator; 6 <appendix> member <vmtarget> ; # java/util/Comparator$$Lambda+0x00000139da022258
+instanceKlass  @bci java/lang/invoke/BootstrapMethodInvoker invoke (Ljava/lang/Class;Ljava/lang/invoke/MethodHandle;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object; 462 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da01c800
+instanceKlass  @cpi java/util/Comparator 259 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da01c400
+instanceKlass  @bci org/eclipse/equinox/launcher/Main$Identifier <clinit> ()V 0 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$Identifier$$Lambda+0x00000139da01a8e8
+instanceKlass java/util/function/ToIntFunction
+instanceKlass  @bci org/eclipse/equinox/launcher/Main findMax (Ljava/lang/String;Ljava/util/List;)Ljava/util/Optional; 18 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01a6a8
+instanceKlass  @cpi java/util/ResourceBundle$ResourceBundleControlProviderHolder 125 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da01c000
+instanceKlass  @bci org/eclipse/equinox/launcher/Main findMax (Ljava/lang/String;Ljava/util/List;)Ljava/util/Optional; 8 <appendix> member <vmtarget> ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01a250
+instanceKlass java/util/ArrayList$ArrayListSpliterator
+instanceKlass  @bci org/eclipse/jdt/launching/JavaRuntime <clinit> ()V 3 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da019c00
+instanceKlass java/util/stream/AbstractSpinedBuffer
+instanceKlass java/util/stream/Node$Builder
+instanceKlass java/util/stream/Node$OfDouble
+instanceKlass java/util/stream/Node$OfLong
+instanceKlass java/util/stream/Node$OfInt
+instanceKlass java/util/stream/Node$OfPrimitive
+instanceKlass java/util/stream/Nodes$EmptyNode
+instanceKlass java/util/stream/Node
+instanceKlass java/util/stream/Nodes
+instanceKlass  @bci java/util/stream/ReferencePipeline toArray ()[Ljava/lang/Object; 1 <appendix> argL0 ; # java/util/stream/ReferencePipeline$$Lambda+0x00000139da0213d8
+instanceKlass java/util/ImmutableCollections$Access$1
+instanceKlass jdk/internal/access/JavaUtilCollectionAccess
+instanceKlass java/util/ImmutableCollections$Access
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getArrayFromList (Ljava/lang/String;)Ljava/util/List; 32 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da01a000
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getArrayFromList (Ljava/lang/String;)Ljava/util/List; 22 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da015d00
+instanceKlass java/util/regex/Pattern$1MatcherIterator
+instanceKlass sun/net/www/MimeEntry
+instanceKlass java/util/Hashtable$Enumerator
+instanceKlass java/util/Collections$SynchronizedCollection
+instanceKlass java/util/Properties$EntrySet
+instanceKlass sun/net/www/MimeTable$DefaultInstanceHolder$1
+instanceKlass sun/net/www/MimeTable$DefaultInstanceHolder
+instanceKlass sun/net/www/MimeTable$2
+instanceKlass sun/net/www/MimeTable$1
+instanceKlass sun/net/www/MimeTable
+instanceKlass java/net/URLConnection$1
+instanceKlass java/net/FileNameMap
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getInstallLocation ()Ljava/net/URL; 287 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da019800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da019400
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getInstallLocation ()Ljava/net/URL; 287 <appendix> argL3 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da019000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da018c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da018800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da018400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da018000
+instanceKlass  @bci org/eclipse/equinox/launcher/Main getInstallLocation ()Ljava/net/URL; 287 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da017c00
+instanceKlass  @bci com/sun/org/apache/xml/internal/serializer/ToXMLStream startDocumentInternal ()V 72 <appendix> argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da017800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da017400
+instanceKlass  @bci org/eclipse/core/internal/resources/LocalMetaArea getSafeTableLocationFor (Ljava/lang/String;)Lorg/eclipse/core/runtime/IPath; 44 <appendix> argL1 argL1 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da017000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da016c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da016800
+instanceKlass java/lang/Long$LongCache
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da016400
+instanceKlass java/util/Collections$3
+instanceKlass jdk/internal/loader/URLClassPath$1
+instanceKlass java/lang/CompoundEnumeration
+instanceKlass jdk/internal/loader/BuiltinClassLoader$1
+instanceKlass java/util/Collections$EmptyEnumeration
+instanceKlass java/util/ServiceLoader$3
+instanceKlass java/util/ServiceLoader$2
+instanceKlass java/util/ServiceLoader$LazyClassPathLookupIterator
+instanceKlass java/util/Spliterators$1Adapter
+instanceKlass java/util/Spliterators$ArraySpliterator
+instanceKlass java/util/ServiceLoader$ModuleServicesLookupIterator
+instanceKlass java/util/ServiceLoader
+instanceKlass java/net/spi/URLStreamHandlerProvider
+instanceKlass java/net/URL$1
+instanceKlass java/net/URL$2
+instanceKlass java/net/URL$ThreadTrackHolder
+instanceKlass  @bci org/eclipse/equinox/launcher/Main basicRun ([Ljava/lang/String;)V 29 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da015ae0
+instanceKlass java/util/function/IntFunction
+instanceKlass  @bci org/eclipse/equinox/launcher/Main processCommandLine (Ljava/util/List;)Ljava/util/List; 832 <appendix> argL0 ; # org/eclipse/equinox/launcher/Main$$Lambda+0x00000139da0158b0
+instanceKlass  @cpi org/eclipse/core/internal/events/NotificationManager$NotifyJob 101 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da016000
+instanceKlass  @bci java/util/ArrayDeque copyElements (Ljava/util/Collection;)V 2 <appendix> member <vmtarget> ; # java/util/ArrayDeque$$Lambda+0x00000139da07ebd0
+instanceKlass java/lang/Thread$ThreadNumbering
+instanceKlass java/nio/file/attribute/PosixFilePermissions
+instanceKlass java/security/Policy
+instanceKlass jdk/internal/misc/PreviewFeatures
+instanceKlass jdk/internal/misc/MainMethodFinder
+instanceKlass org/eclipse/equinox/launcher/Main
+instanceKlass sun/security/util/ManifestEntryVerifier$SunProviderHolder
+instanceKlass java/util/Base64$Encoder
+instanceKlass java/util/Base64$Decoder
+instanceKlass java/util/Base64
+instanceKlass javax/crypto/SecretKey
+instanceKlass sun/security/util/Length
+instanceKlass sun/security/util/KeyUtil
+instanceKlass java/security/interfaces/XECKey
+instanceKlass java/security/interfaces/ECKey
+instanceKlass sun/security/util/JarConstraintsParameters
+instanceKlass sun/security/util/ConstraintsParameters
+instanceKlass java/security/CodeSigner
+instanceKlass java/security/Timestamp
+instanceKlass sun/security/timestamp/TimestampToken
+instanceKlass java/security/cert/CertPath
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da014c00
+instanceKlass java/math/MutableBigInteger
+instanceKlass sun/security/rsa/RSAPadding
+instanceKlass sun/security/rsa/RSACore
+instanceKlass java/security/interfaces/RSAPrivateCrtKey
+instanceKlass sun/security/pkcs/PKCS8Key
+instanceKlass sun/security/util/InternalPrivateKey
+instanceKlass java/security/interfaces/RSAPrivateKey
+instanceKlass java/security/PrivateKey
+instanceKlass javax/security/auth/Destroyable
+instanceKlass jdk/internal/icu/util/CodePointTrie$Data
+instanceKlass jdk/internal/icu/util/CodePointMap
+instanceKlass jdk/internal/icu/util/VersionInfo
+instanceKlass  @bci jdk/internal/module/SystemModuleFinders$SystemModuleReader open (Ljava/lang/String;)Ljava/util/Optional; 6 <appendix> member <vmtarget> ; # jdk/internal/module/SystemModuleFinders$SystemModuleReader$$Lambda+0x00000139da076be0
+instanceKlass jdk/internal/jimage/decompressor/ZipDecompressor
+instanceKlass jdk/internal/jimage/decompressor/ResourceDecompressor
+instanceKlass jdk/internal/jimage/decompressor/ResourceDecompressorFactory
+instanceKlass jdk/internal/jimage/decompressor/ResourceDecompressorRepository
+instanceKlass jdk/internal/jimage/decompressor/CompressedResourceHeader
+instanceKlass  @bci jdk/internal/jimage/BasicImageReader getResourceBuffer (Ljdk/internal/jimage/ImageLocation;)Ljava/nio/ByteBuffer; 168 <appendix> member <vmtarget> ; # jdk/internal/jimage/BasicImageReader$$Lambda+0x00000139da075b20
+instanceKlass jdk/internal/jimage/decompressor/ResourceDecompressor$StringsProvider
+instanceKlass java/util/TimSort
+instanceKlass java/util/Arrays$LegacyMergeSort
+instanceKlass java/util/AbstractMap$SimpleEntry
+instanceKlass jdk/internal/jimage/ImageBufferCache$2
+instanceKlass jdk/internal/jimage/ImageBufferCache
+instanceKlass jdk/internal/module/Checks
+instanceKlass jdk/internal/icu/impl/ICUBinary$1
+instanceKlass jdk/internal/icu/impl/ICUBinary
+instanceKlass jdk/internal/icu/impl/NormalizerImpl$IsAcceptable
+instanceKlass jdk/internal/icu/impl/ICUBinary$Authenticate
+instanceKlass jdk/internal/icu/impl/NormalizerImpl
+instanceKlass jdk/internal/icu/impl/Norm2AllModes$Norm2AllModesSingleton
+instanceKlass jdk/internal/icu/impl/Norm2AllModes$NFKCSingleton
+instanceKlass jdk/internal/icu/impl/Norm2AllModes
+instanceKlass jdk/internal/icu/text/Normalizer2
+instanceKlass jdk/internal/icu/text/NormalizerBase$ModeImpl
+instanceKlass jdk/internal/icu/text/NormalizerBase$NFKDModeImpl
+instanceKlass jdk/internal/icu/text/NormalizerBase$1
+instanceKlass jdk/internal/icu/text/NormalizerBase$Mode
+instanceKlass jdk/internal/icu/text/NormalizerBase
+instanceKlass java/text/Normalizer
+instanceKlass sun/security/x509/AVAKeyword
+instanceKlass java/util/StringJoiner
+instanceKlass sun/security/jca/ServiceId
+instanceKlass java/security/Signature$1
+instanceKlass jdk/internal/access/JavaSecuritySignatureAccess
+instanceKlass java/security/SignatureSpi
+instanceKlass sun/security/util/SignatureUtil
+instanceKlass java/lang/invoke/VarHandle$AccessDescriptor
+instanceKlass sun/security/provider/ByteArrayAccess$BE
+instanceKlass sun/security/provider/ByteArrayAccess
+instanceKlass sun/security/util/MessageDigestSpi2
+instanceKlass java/security/MessageDigestSpi
+instanceKlass sun/security/pkcs/SigningCertificateInfo$ESSCertId
+instanceKlass sun/security/pkcs/SigningCertificateInfo
+instanceKlass sun/security/pkcs/PKCS9Attribute
+instanceKlass sun/security/pkcs/PKCS9Attributes
+instanceKlass java/time/Instant
+instanceKlass java/time/zone/ZoneOffsetTransition
+instanceKlass java/time/LocalTime
+instanceKlass java/time/temporal/ValueRange
+instanceKlass java/time/Duration
+instanceKlass java/time/temporal/TemporalAmount
+instanceKlass java/time/temporal/TemporalUnit
+instanceKlass java/time/temporal/TemporalField
+instanceKlass java/time/LocalDate
+instanceKlass java/time/chrono/ChronoLocalDate
+instanceKlass java/time/ZonedDateTime
+instanceKlass java/time/chrono/ChronoZonedDateTime
+instanceKlass java/time/LocalDateTime
+instanceKlass java/time/chrono/ChronoLocalDateTime
+instanceKlass java/time/temporal/Temporal
+instanceKlass java/time/zone/ZoneOffsetTransitionRule
+instanceKlass java/time/zone/ZoneRules
+instanceKlass  @bci java/time/ZoneOffset ofTotalSeconds (I)Ljava/time/ZoneOffset; 37 <appendix> argL0 ; # java/time/ZoneOffset$$Lambda+0x80000000c
+instanceKlass java/time/temporal/TemporalAdjuster
+instanceKlass java/time/temporal/TemporalAccessor
+instanceKlass java/time/ZoneId
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_DIGIT ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x800000025
+instanceKlass  @bci java/util/regex/CharPredicates ASCII_SPACE ()Ljava/util/regex/Pattern$BmpCharPredicate; 0 <appendix> argL0 ; # java/util/regex/CharPredicates$$Lambda+0x800000026
+instanceKlass java/util/regex/CharPredicates
+instanceKlass sun/security/util/DisabledAlgorithmConstraints$Constraints$Holder
+instanceKlass sun/security/util/DisabledAlgorithmConstraints$Constraint
+instanceKlass java/util/StringTokenizer
+instanceKlass java/security/spec/ECFieldF2m
+instanceKlass java/security/spec/ECParameterSpec
+instanceKlass java/security/spec/ECPoint
+instanceKlass java/security/spec/EllipticCurve
+instanceKlass java/security/spec/ECFieldFp
+instanceKlass java/security/spec/ECField
+instanceKlass sun/security/util/CurveDB
+instanceKlass sun/security/util/DisabledAlgorithmConstraints$Constraints
+instanceKlass java/util/TreeMap$PrivateEntryIterator
+instanceKlass java/util/NavigableSet
+instanceKlass java/util/SortedSet
+instanceKlass sun/security/util/AbstractAlgorithmConstraints$1
+instanceKlass sun/security/util/AlgorithmDecomposer
+instanceKlass sun/security/util/DisabledAlgorithmConstraints$JarHolder
+instanceKlass  @bci java/util/regex/Pattern DOT ()Ljava/util/regex/Pattern$CharPredicate; 0 <appendix> argL0 ; # java/util/regex/Pattern$$Lambda+0x00000139da0681f8
+instanceKlass java/util/regex/ASCII
+instanceKlass sun/security/util/AbstractAlgorithmConstraints
+instanceKlass java/security/AlgorithmConstraints
+instanceKlass sun/security/pkcs/SignerInfo
+instanceKlass java/security/cert/PolicyQualifierInfo
+instanceKlass sun/security/x509/CertificatePolicyId
+instanceKlass sun/security/x509/PolicyInformation
+instanceKlass sun/security/x509/DistributionPoint
+instanceKlass sun/security/x509/DNSName
+instanceKlass sun/security/x509/URIName
+instanceKlass sun/security/x509/GeneralName
+instanceKlass sun/security/x509/AccessDescription
+instanceKlass sun/security/x509/GeneralNames
+instanceKlass java/lang/invoke/VarForm
+instanceKlass java/lang/invoke/VarHandleGuards
+instanceKlass java/lang/invoke/VarHandles
+instanceKlass java/lang/System$Logger
+instanceKlass jdk/internal/event/EventHelper
+instanceKlass sun/security/jca/JCAUtil
+instanceKlass sun/security/util/MemoryCache$CacheEntry
+instanceKlass sun/security/x509/KeyIdentifier
+instanceKlass java/util/TreeMap$Entry
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da014800
+instanceKlass sun/security/x509/OIDMap$OIDInfo
+instanceKlass sun/security/x509/PKIXExtensions
+instanceKlass sun/security/x509/OIDMap
+instanceKlass sun/security/x509/Extension
+instanceKlass java/security/cert/Extension
+instanceKlass java/util/Collections$SynchronizedMap
+instanceKlass java/util/NavigableMap
+instanceKlass java/util/SortedMap
+instanceKlass sun/security/x509/CertificateExtensions
+instanceKlass sun/security/rsa/RSAUtil
+instanceKlass java/security/interfaces/RSAPublicKey
+instanceKlass java/security/interfaces/RSAKey
+instanceKlass java/security/spec/PSSParameterSpec
+instanceKlass java/security/spec/AlgorithmParameterSpec
+instanceKlass java/security/spec/RSAPrivateKeySpec
+instanceKlass java/security/spec/RSAPublicKeySpec
+instanceKlass java/security/KeyFactorySpi
+instanceKlass sun/security/rsa/SunRsaSignEntries
+instanceKlass sun/security/jca/ProviderList$ServiceList$1
+instanceKlass java/security/KeyFactory
+instanceKlass  @bci java/security/spec/EncodedKeySpec <clinit> ()V 0 <appendix> argL0 ; # java/security/spec/EncodedKeySpec$$Lambda+0x00000139da05e7f0
+instanceKlass  @cpi org/eclipse/jdt/internal/core/search/processing/JobManager 551 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da014400
+instanceKlass jdk/internal/access/JavaSecuritySpecAccess
+instanceKlass java/security/spec/EncodedKeySpec
+instanceKlass java/security/spec/KeySpec
+instanceKlass sun/security/util/BitArray
+instanceKlass sun/security/x509/X509Key
+instanceKlass java/security/PublicKey
+instanceKlass java/security/Key
+instanceKlass sun/security/x509/CertificateX509Key
+instanceKlass java/util/Date
+instanceKlass sun/util/calendar/CalendarUtils
+instanceKlass sun/util/calendar/CalendarDate
+instanceKlass sun/util/calendar/CalendarSystem$GregorianHolder
+instanceKlass sun/util/calendar/CalendarSystem
+instanceKlass sun/security/x509/CertificateValidity
+instanceKlass sun/security/x509/AVA
+instanceKlass sun/security/x509/RDN
+instanceKlass javax/security/auth/x500/X500Principal
+instanceKlass  @bci sun/security/x509/X500Name <clinit> ()V 153 <appendix> argL0 ; # sun/security/x509/X500Name$$Lambda+0x00000139da05c2e8
+instanceKlass sun/security/x509/X500Name
+instanceKlass sun/security/x509/GeneralNameInterface
+instanceKlass sun/security/x509/CertificateAlgorithmId
+instanceKlass sun/security/x509/SerialNumber
+instanceKlass sun/security/x509/CertificateSerialNumber
+instanceKlass sun/security/x509/CertificateVersion
+instanceKlass sun/security/x509/X509CertInfo
+instanceKlass sun/security/util/Cache$EqualByteArray
+instanceKlass java/security/cert/X509Extension
+instanceKlass java/lang/Byte$ByteCache
+instanceKlass  @bci sun/security/util/DerInputStream seeOptionalContextSpecific (I)Z 2 <appendix> member <vmtarget> ; # sun/security/util/DerInputStream$$Lambda+0x00000139da059c18
+instanceKlass  @cpi sun/security/util/DerInputStream 295 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da014000
+instanceKlass sun/security/jca/GetInstance$Instance
+instanceKlass sun/security/util/Cache
+instanceKlass jdk/internal/event/Event
+instanceKlass sun/security/jca/GetInstance
+instanceKlass java/security/cert/CertificateFactorySpi
+instanceKlass java/security/cert/CertificateFactory
+instanceKlass sun/security/x509/AlgorithmId
+instanceKlass sun/security/util/ByteArrayTagOrder
+instanceKlass sun/security/util/ByteArrayLexOrder
+instanceKlass sun/security/util/DerValue
+instanceKlass sun/security/util/ObjectIdentifier
+instanceKlass sun/security/pkcs/ContentInfo
+instanceKlass sun/security/util/DerEncoder
+instanceKlass sun/security/util/DerInputStream
+instanceKlass sun/security/pkcs/PKCS7
+instanceKlass java/util/Collections$EmptyIterator
+instanceKlass java/util/LinkedHashMap$LinkedHashIterator
+instanceKlass sun/security/util/SecurityProviderConstants
+instanceKlass java/security/Provider$UString
+instanceKlass java/security/Provider$Service
+instanceKlass sun/security/provider/NativePRNG$NonBlocking
+instanceKlass sun/security/provider/NativePRNG$Blocking
+instanceKlass sun/security/provider/NativePRNG
+instanceKlass sun/security/provider/SunEntries$1
+instanceKlass sun/security/provider/SunEntries
+instanceKlass sun/security/util/SecurityConstants
+instanceKlass java/security/Security$1
+instanceKlass jdk/internal/access/JavaSecurityPropertiesAccess
+instanceKlass java/util/concurrent/ConcurrentHashMap$MapEntry
+instanceKlass java/io/FileInputStream$1
+instanceKlass java/util/Properties$LineReader
+instanceKlass  @bci java/security/Security <clinit> ()V 9 <appendix> argL0 ; # java/security/Security$$Lambda+0x80000000b
+instanceKlass java/security/Security
+instanceKlass sun/security/jca/ProviderList$2
+instanceKlass jdk/internal/math/FloatingDecimal$ASCIIToBinaryBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$PreparedASCIIToBinaryBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$ASCIIToBinaryConverter
+instanceKlass jdk/internal/math/FloatingDecimal$BinaryToASCIIBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$ExceptionalBinaryToASCIIBuffer
+instanceKlass jdk/internal/math/FloatingDecimal$BinaryToASCIIConverter
+instanceKlass jdk/internal/math/FloatingDecimal
+instanceKlass javax/security/auth/login/Configuration$Parameters
+instanceKlass java/security/Policy$Parameters
+instanceKlass java/security/cert/CertStoreParameters
+instanceKlass java/security/SecureRandomParameters
+instanceKlass java/security/Provider$EngineDescription
+instanceKlass java/security/Provider$ServiceKey
+instanceKlass sun/security/jca/ProviderConfig
+instanceKlass sun/security/jca/ProviderList
+instanceKlass sun/security/jca/Providers
+instanceKlass  @bci sun/security/util/ManifestDigester <init> ([B)V 350 <appendix> argL0 ; # sun/security/util/ManifestDigester$$Lambda+0x00000139da04d630
+instanceKlass sun/security/util/ManifestDigester$Section
+instanceKlass sun/security/util/ManifestDigester$Entry
+instanceKlass sun/security/util/ManifestDigester$Position
+instanceKlass sun/security/util/ManifestDigester
+instanceKlass sun/security/util/ManifestEntryVerifier
+instanceKlass jdk/internal/misc/ThreadTracker
+instanceKlass java/util/jar/JarFile$ThreadTrackHolder
+instanceKlass java/util/jar/JarVerifier
+instanceKlass sun/nio/cs/ArrayDecoder
+instanceKlass java/nio/charset/CharsetDecoder
+instanceKlass sun/launcher/LauncherHelper
+instanceKlass lombok/patcher/scripts/ScriptBuilder$SetSymbolDuringMethodCallBuilder
+instanceKlass lombok/patcher/scripts/ScriptBuilder$ReplaceMethodCallBuilder
+instanceKlass lombok/eclipse/agent/EclipsePatcher$4
+instanceKlass lombok/eclipse/agent/EclipsePatcher$3
+instanceKlass lombok/patcher/scripts/ScriptBuilder$WrapMethodCallBuilder
+instanceKlass lombok/patcher/ScriptManager$WitnessAction
+instanceKlass lombok/patcher/scripts/ScriptBuilder$WrapReturnValueBuilder
+instanceKlass lombok/patcher/ClassRootFinder
+instanceKlass lombok/patcher/scripts/ScriptBuilder$AddFieldBuilder
+instanceKlass java/util/Collections$1
+instanceKlass lombok/patcher/PatchScript$MethodPatcherFactory
+instanceKlass org/lombokweb/asm/ClassVisitor
+instanceKlass lombok/patcher/Hook
+instanceKlass  @bci java/util/regex/Pattern negate (Ljava/util/regex/Pattern$CharPredicate;)Ljava/util/regex/Pattern$CharPredicate; 1 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000031
+instanceKlass java/util/regex/Pattern$BitClass
+instanceKlass lombok/patcher/MethodTarget
+instanceKlass lombok/patcher/scripts/ScriptBuilder$ExitEarlyBuilder
+instanceKlass lombok/patcher/scripts/ScriptBuilder
+instanceKlass lombok/eclipse/agent/EclipseLoaderPatcher
+instanceKlass lombok/eclipse/agent/EclipsePatcher$2
+instanceKlass lombok/eclipse/agent/EclipsePatcher$1
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da00d800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da00d400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da00d000
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da00cc00
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x00000139da00c800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da00c400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da00c000
+instanceKlass java/lang/instrument/ClassDefinition
+instanceKlass lombok/patcher/ScriptManager$OurClassFileTransformer
+instanceKlass lombok/patcher/Filter$1
+instanceKlass lombok/patcher/TransplantMapper$1
+instanceKlass java/lang/instrument/ClassFileTransformer
+instanceKlass lombok/patcher/ScriptManager
+instanceKlass lombok/patcher/TransplantMapper
+instanceKlass lombok/patcher/Filter
+instanceKlass lombok/patcher/PatchScript
+instanceKlass lombok/patcher/TargetMatcher
+instanceKlass lombok/eclipse/agent/EclipsePatcher
+instanceKlass lombok/core/AgentLauncher$AgentLaunchable
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da008c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da008800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da008400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da008000
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da007c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da007800
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da007400
+instanceKlass java/lang/ClassValue$Version
+instanceKlass java/lang/ClassValue$Identity
+instanceKlass java/lang/ClassValue
+instanceKlass java/lang/invoke/MethodHandleImpl$ArrayAccessor
+instanceKlass java/lang/invoke/MethodHandleImpl$LoopClauses
+instanceKlass java/lang/invoke/MethodHandleImpl$CasesHolder
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da007000
+instanceKlass  @cpi com/google/inject/spi/BindingSourceRestriction$PermitMapConstruction 106 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da006c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da006800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da006400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da006000
+# instanceKlass java/lang/invoke/LambdaForm$BMH+0x00000139da005c00
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da005800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da005400
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da005000
+instanceKlass java/lang/invoke/ClassSpecializer$Factory$1Var
+instanceKlass java/lang/invoke/MethodHandles$1
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da004c00
+instanceKlass sun/invoke/util/ValueConversions$1
+instanceKlass sun/invoke/util/ValueConversions$WrapperCache
+# instanceKlass java/lang/invoke/LambdaForm$DMH+0x00000139da004800
+instanceKlass jdk/internal/foreign/MemorySessionImpl
+instanceKlass java/lang/foreign/MemorySegment$Scope
+instanceKlass lombok/core/AgentLauncher$AgentInfo
+instanceKlass lombok/core/AgentLauncher
+instanceKlass java/util/IdentityHashMap$IdentityHashMapIterator
+instanceKlass lombok/launch/ClassFileMetaData
+instanceKlass sun/net/www/MessageHeader
+instanceKlass sun/net/www/protocol/jar/JarFileFactory
+instanceKlass sun/net/www/protocol/jar/URLJarFile$URLJarFileCloseController
+instanceKlass java/net/URLConnection
+instanceKlass java/util/zip/ZipFile$ZipEntryIterator
+instanceKlass java/util/WeakHashMap$HashIterator
+instanceKlass java/net/URLDecoder
+instanceKlass java/util/regex/IntHashSet
+instanceKlass java/util/regex/Matcher
+instanceKlass java/util/regex/MatchResult
+instanceKlass java/util/regex/Pattern$TreeInfo
+instanceKlass  @bci java/util/regex/Pattern Single (I)Ljava/util/regex/Pattern$BmpCharPredicate; 1 <appendix> member <vmtarget> ; # java/util/regex/Pattern$$Lambda+0x800000029
+instanceKlass java/util/regex/Pattern$BmpCharPredicate
+instanceKlass java/util/regex/Pattern$CharPredicate
+instanceKlass java/util/regex/Pattern$Node
+instanceKlass java/util/regex/Pattern
+instanceKlass jdk/internal/jimage/ImageLocation
+instanceKlass jdk/internal/jimage/decompressor/Decompressor
+instanceKlass jdk/internal/jimage/ImageStringsReader
+instanceKlass jdk/internal/jimage/ImageStrings
+instanceKlass jdk/internal/jimage/ImageHeader
+instanceKlass jdk/internal/jimage/NativeImageBuffer$1
+instanceKlass jdk/internal/jimage/NativeImageBuffer
+instanceKlass jdk/internal/jimage/BasicImageReader$1
+instanceKlass jdk/internal/jimage/BasicImageReader
+instanceKlass jdk/internal/jimage/ImageReader
+instanceKlass jdk/internal/jimage/ImageReaderFactory$1
+instanceKlass java/net/URI$Parser
+instanceKlass java/nio/file/FileSystems$DefaultFileSystemHolder$1
+instanceKlass java/nio/file/FileSystems$DefaultFileSystemHolder
+instanceKlass java/nio/file/FileSystems
+instanceKlass java/nio/file/Paths
+instanceKlass jdk/internal/jimage/ImageReaderFactory
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemImage
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemModuleReader
+instanceKlass java/lang/module/ModuleReader
+instanceKlass jdk/internal/loader/BuiltinClassLoader$5
+instanceKlass jdk/internal/loader/BuiltinClassLoader$2
+instanceKlass jdk/internal/module/Resources
+instanceKlass java/util/Arrays$ArrayItr
+instanceKlass lombok/launch/PackageShader
+instanceKlass java/io/Reader
+instanceKlass java/lang/Readable
+instanceKlass lombok/launch/Main
+instanceKlass  @bci jdk/internal/reflect/DirectMethodHandleAccessor invokeImpl (Ljava/lang/Object;[Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object; 136 <adapter> ; # java/lang/invoke/LambdaForm$MH+0x00000139da002c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da002800
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da002400
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da002000
+instanceKlass  @bci org/eclipse/jdt/ls/core/internal/handlers/BundleUtils startBundle (Ljava/lang/String;)V 5 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da001c00
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da001800
+instanceKlass sun/instrument/InstrumentationImpl$1
+instanceKlass lombok/launch/Agent
+instanceKlass java/security/SecureClassLoader$DebugHolder
+instanceKlass java/security/Permission
+instanceKlass java/security/Guard
+instanceKlass java/security/PermissionCollection
+instanceKlass java/security/SecureClassLoader$1
+instanceKlass java/util/zip/Checksum$1
+instanceKlass java/util/zip/CRC32
+instanceKlass java/util/zip/Checksum
+instanceKlass sun/nio/ByteBuffered
+instanceKlass java/lang/Package$VersionInfo
+instanceKlass java/lang/NamedPackage
+instanceKlass java/util/jar/Attributes$Name
+instanceKlass java/util/jar/Attributes
+instanceKlass jdk/internal/loader/Resource
+instanceKlass sun/security/action/GetIntegerAction
+instanceKlass sun/security/util/Debug
+instanceKlass sun/security/util/SignatureFileVerifier
+instanceKlass java/util/zip/ZipFile$InflaterCleanupAction
+instanceKlass java/util/zip/Inflater$InflaterZStreamRef
+instanceKlass java/util/zip/Inflater
+instanceKlass java/util/zip/ZipEntry
+instanceKlass java/util/zip/ZipFile$2
+instanceKlass java/nio/Bits$1
+instanceKlass jdk/internal/misc/VM$BufferPool
+instanceKlass java/nio/Bits
+instanceKlass sun/nio/ch/DirectBuffer
+instanceKlass jdk/internal/perf/PerfCounter$CoreCounters
+instanceKlass jdk/internal/perf/Perf
+instanceKlass jdk/internal/perf/Perf$GetPerfAction
+instanceKlass jdk/internal/perf/PerfCounter
+instanceKlass sun/util/locale/LocaleUtils
+instanceKlass sun/util/locale/BaseLocale
+instanceKlass java/util/Locale
+instanceKlass java/nio/file/attribute/FileTime
+instanceKlass java/lang/StringCoding
+instanceKlass java/util/zip/ZipUtils
+instanceKlass java/util/zip/ZipFile$Source$End
+instanceKlass java/io/RandomAccessFile$2
+instanceKlass jdk/internal/access/JavaIORandomAccessFileAccess
+instanceKlass java/io/RandomAccessFile
+instanceKlass java/io/DataInput
+instanceKlass java/io/DataOutput
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$CompletionStatus
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$AclInformation
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$Account
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$DiskFreeSpace
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$VolumeInformation
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$FirstStream
+instanceKlass sun/nio/fs/WindowsNativeDispatcher$FirstFile
+instanceKlass java/util/Enumeration
+instanceKlass java/util/concurrent/ConcurrentHashMap$Traverser
+instanceKlass sun/nio/fs/WindowsNativeDispatcher
+instanceKlass sun/nio/fs/NativeBuffer$Deallocator
+instanceKlass sun/nio/fs/NativeBuffer
+instanceKlass java/lang/ThreadLocal$ThreadLocalMap
+instanceKlass java/lang/ThreadLocal
+instanceKlass sun/nio/fs/NativeBuffers
+instanceKlass sun/nio/fs/WindowsFileAttributes
+instanceKlass java/nio/file/attribute/DosFileAttributes
+instanceKlass sun/nio/fs/AbstractBasicFileAttributeView
+instanceKlass sun/nio/fs/DynamicFileAttributeView
+instanceKlass sun/nio/fs/WindowsFileAttributeViews
+instanceKlass sun/nio/fs/Util
+instanceKlass java/nio/file/attribute/BasicFileAttributeView
+instanceKlass java/nio/file/attribute/FileAttributeView
+instanceKlass java/nio/file/attribute/AttributeView
+instanceKlass java/nio/file/Files
+instanceKlass java/nio/file/CopyOption
+instanceKlass java/nio/file/attribute/BasicFileAttributes
+instanceKlass sun/nio/fs/WindowsPath
+instanceKlass java/util/zip/ZipFile$Source$Key
+instanceKlass java/util/concurrent/ForkJoinPool$ManagedBlocker
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer$Node
+instanceKlass sun/nio/fs/WindowsPathParser$Result
+instanceKlass sun/nio/fs/WindowsPathParser
+instanceKlass java/nio/file/FileSystem
+instanceKlass java/nio/file/OpenOption
+instanceKlass java/nio/file/spi/FileSystemProvider
+instanceKlass sun/nio/fs/DefaultFileSystemProvider
+instanceKlass java/util/zip/ZipFile$Source
+instanceKlass java/lang/ref/Cleaner$Cleanable
+instanceKlass jdk/internal/ref/CleanerImpl
+instanceKlass java/lang/ref/Cleaner$1
+instanceKlass java/lang/ref/Cleaner
+instanceKlass jdk/internal/ref/CleanerFactory$1
+instanceKlass java/util/concurrent/ThreadFactory
+instanceKlass jdk/internal/ref/CleanerFactory
+instanceKlass java/util/zip/ZipCoder
+instanceKlass java/util/zip/ZipFile$CleanableResource
+instanceKlass java/lang/Runtime$Version
+instanceKlass java/util/jar/JavaUtilJarAccessImpl
+instanceKlass jdk/internal/access/JavaUtilJarAccess
+instanceKlass jdk/internal/loader/FileURLMapper
+instanceKlass jdk/internal/loader/URLClassPath$JarLoader$1
+instanceKlass java/util/zip/ZipFile$1
+instanceKlass jdk/internal/access/JavaUtilZipFileAccess
+instanceKlass java/util/zip/ZipFile
+instanceKlass java/util/zip/ZipConstants
+instanceKlass jdk/internal/loader/URLClassPath$Loader
+instanceKlass jdk/internal/loader/URLClassPath$3
+instanceKlass java/security/PrivilegedExceptionAction
+instanceKlass sun/net/util/URLUtil
+instanceKlass sun/instrument/TransformerManager$TransformerInfo
+instanceKlass sun/instrument/TransformerManager
+instanceKlass jdk/internal/loader/NativeLibraries$3
+instanceKlass jdk/internal/loader/NativeLibrary
+instanceKlass java/util/ArrayDeque$DeqIterator
+instanceKlass jdk/internal/loader/NativeLibraries$NativeLibraryContext$1
+instanceKlass jdk/internal/loader/NativeLibraries$NativeLibraryContext
+instanceKlass jdk/internal/loader/NativeLibraries$2
+instanceKlass jdk/internal/loader/NativeLibraries$1
+instanceKlass jdk/internal/loader/NativeLibraries$LibraryPaths
+instanceKlass  @bci sun/instrument/InstrumentationImpl <clinit> ()V 16 <appendix> argL0 ; # sun/instrument/InstrumentationImpl$$Lambda+0x00000139da042df0
+instanceKlass sun/instrument/InstrumentationImpl
+instanceKlass java/lang/instrument/Instrumentation
+instanceKlass java/lang/invoke/StringConcatFactory
+instanceKlass jdk/internal/module/ModuleBootstrap$SafeModuleFinder
+instanceKlass  @bci java/lang/WeakPairMap computeIfAbsent (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object; 18 <appendix> member <vmtarget> ; # java/lang/WeakPairMap$$Lambda+0x00000139da042678
+instanceKlass  @bci java/lang/Module implAddExportsOrOpens (Ljava/lang/String;Ljava/lang/Module;ZZ)V 145 <appendix> argL0 ; # java/lang/Module$$Lambda+0x00000139da041d20
+instanceKlass  @bci jdk/internal/module/ModuleBootstrap decode (Ljava/lang/String;Ljava/lang/String;Z)Ljava/util/Map; 193 <appendix> argL0 ; # jdk/internal/module/ModuleBootstrap$$Lambda+0x00000139da041ae0
+instanceKlass java/lang/ModuleLayer$Controller
+instanceKlass java/util/concurrent/CopyOnWriteArrayList
+instanceKlass jdk/internal/module/ServicesCatalog$ServiceProvider
+instanceKlass jdk/internal/loader/AbstractClassLoaderValue$Memoizer
+instanceKlass jdk/internal/module/ModuleLoaderMap$Modules
+instanceKlass jdk/internal/module/ModuleLoaderMap$Mapper
+instanceKlass jdk/internal/module/ModuleLoaderMap
+instanceKlass java/lang/module/ResolvedModule
+instanceKlass java/util/Collections$UnmodifiableCollection$1
+instanceKlass java/util/SequencedMap
+instanceKlass java/util/SequencedSet
+instanceKlass java/lang/ModuleLayer
+instanceKlass java/util/ImmutableCollections$ListItr
+instanceKlass java/util/ListIterator
+instanceKlass java/lang/module/ModuleFinder$1
+instanceKlass java/nio/file/Path
+instanceKlass java/nio/file/Watchable
+instanceKlass java/lang/module/Resolver
+instanceKlass java/lang/module/Configuration
+instanceKlass java/util/stream/ForEachOps$ForEachOp
+instanceKlass java/util/stream/ForEachOps
+instanceKlass  @bci jdk/internal/module/ModuleBootstrap boot2 ()Ljava/lang/ModuleLayer; 791 <appendix> member <vmtarget> ; # jdk/internal/module/ModuleBootstrap$$Lambda+0x00000139da0410b0
+instanceKlass  @cpi org/eclipse/core/internal/preferences/EclipsePreferences 1062 form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$DMH+0x00000139da000c00
+instanceKlass  @bci jdk/internal/module/ModuleBootstrap boot2 ()Ljava/lang/ModuleLayer; 779 <appendix> member <vmtarget> ; # jdk/internal/module/ModuleBootstrap$$Lambda+0x00000139da040e58
+instanceKlass  @bci jdk/internal/module/ModuleBootstrap boot2 ()Ljava/lang/ModuleLayer; 767 <appendix> argL0 ; # jdk/internal/module/ModuleBootstrap$$Lambda+0x00000139da040c18
+instanceKlass  @bci jdk/internal/module/ModuleBootstrap boot2 ()Ljava/lang/ModuleLayer; 757 <appendix> argL0 ; # jdk/internal/module/ModuleBootstrap$$Lambda+0x00000139da0409d8
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 43 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x800000048
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 38 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x80000004a
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 16 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x800000049
+instanceKlass  @bci java/util/stream/FindOps$FindSink$OfRef <clinit> ()V 11 <appendix> argL0 ; # java/util/stream/FindOps$FindSink$OfRef$$Lambda+0x80000004b
+instanceKlass java/util/stream/FindOps$FindOp
+instanceKlass java/util/stream/FindOps$FindSink
+instanceKlass java/util/stream/FindOps
+instanceKlass  @bci jdk/internal/module/DefaultRoots exportsAPI (Ljava/lang/module/ModuleDescriptor;)Z 9 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000051
+instanceKlass java/util/stream/Sink$ChainedReference
+instanceKlass java/util/stream/ReduceOps$AccumulatingSink
+instanceKlass java/util/stream/TerminalSink
+instanceKlass java/util/stream/Sink
+instanceKlass java/util/function/Consumer
+instanceKlass java/util/stream/ReduceOps$Box
+instanceKlass java/util/stream/ReduceOps$ReduceOp
+instanceKlass java/util/stream/TerminalOp
+instanceKlass java/util/stream/ReduceOps
+instanceKlass  @bci java/util/stream/Collectors castingIdentity ()Ljava/util/function/Function; 0 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000042
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 14 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000040
+instanceKlass java/util/function/BinaryOperator
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 9 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000039
+instanceKlass java/util/function/BiConsumer
+instanceKlass  @bci java/util/stream/Collectors toSet ()Ljava/util/stream/Collector; 4 <appendix> argL0 ; # java/util/stream/Collectors$$Lambda+0x800000045
+instanceKlass java/util/stream/Collector
+instanceKlass java/util/Collections$UnmodifiableCollection
+instanceKlass java/util/stream/Collectors
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 42 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x80000004e
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 32 <appendix> member <vmtarget> ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000052
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 21 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x80000004f
+instanceKlass  @bci com/google/common/io/Closer <clinit> ()V 0 <appendix> form vmentry <vmtarget> ; # java/lang/invoke/LambdaForm$MH+0x00000139da000800
+instanceKlass  @bci jdk/internal/module/DefaultRoots compute (Ljava/lang/module/ModuleFinder;Ljava/lang/module/ModuleFinder;)Ljava/util/Set; 11 <appendix> argL0 ; # jdk/internal/module/DefaultRoots$$Lambda+0x800000050
+instanceKlass java/lang/invoke/LambdaProxyClassArchive
+instanceKlass java/lang/invoke/InfoFromMemberName
+instanceKlass java/lang/invoke/MethodHandleInfo
+instanceKlass jdk/internal/org/objectweb/asm/ConstantDynamic
+instanceKlass jdk/internal/org/objectweb/asm/Handle
+instanceKlass sun/security/action/GetBooleanAction
+instanceKlass java/lang/invoke/AbstractValidatingLambdaMetafactory
+instanceKlass java/lang/invoke/BootstrapMethodInvoker
+instanceKlass java/util/function/Predicate
+instanceKlass java/lang/WeakPairMap$Pair$Lookup
+instanceKlass java/lang/WeakPairMap$Pair
+instanceKlass java/lang/WeakPairMap
+instanceKlass java/lang/Module$ReflectionData
+instanceKlass java/lang/invoke/LambdaMetafactory
+# instanceKlass java/lang/invoke/LambdaForm$MH+0x00000139da000400
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassDefiner
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassFile
+instanceKlass jdk/internal/org/objectweb/asm/Handler
+instanceKlass jdk/internal/org/objectweb/asm/Attribute
+instanceKlass jdk/internal/org/objectweb/asm/FieldVisitor
+instanceKlass java/util/ArrayList$Itr
+instanceKlass sun/invoke/empty/Empty
+instanceKlass sun/invoke/util/VerifyType
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$ClassData
+instanceKlass jdk/internal/org/objectweb/asm/AnnotationVisitor
+instanceKlass jdk/internal/org/objectweb/asm/Frame
+instanceKlass jdk/internal/org/objectweb/asm/Label
+instanceKlass jdk/internal/org/objectweb/asm/Type
+instanceKlass jdk/internal/org/objectweb/asm/MethodVisitor
+instanceKlass sun/invoke/util/BytecodeDescriptor
+instanceKlass jdk/internal/org/objectweb/asm/ByteVector
+instanceKlass jdk/internal/org/objectweb/asm/Symbol
+instanceKlass jdk/internal/org/objectweb/asm/SymbolTable
+instanceKlass jdk/internal/org/objectweb/asm/ClassVisitor
+instanceKlass java/lang/invoke/LambdaFormBuffer
+instanceKlass java/lang/invoke/LambdaFormEditor$TransformKey
+instanceKlass java/lang/invoke/LambdaFormEditor
+instanceKlass java/lang/invoke/Invokers$Holder
+instanceKlass java/lang/invoke/DelegatingMethodHandle$Holder
+instanceKlass java/lang/invoke/DirectMethodHandle$2
+instanceKlass java/lang/invoke/ClassSpecializer$Factory
+instanceKlass java/lang/invoke/ClassSpecializer$SpeciesData
+instanceKlass java/lang/invoke/ClassSpecializer$1
+instanceKlass java/lang/invoke/ClassSpecializer
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator$1
+instanceKlass java/lang/invoke/InvokerBytecodeGenerator
+instanceKlass java/lang/invoke/LambdaForm$Holder
+instanceKlass java/lang/invoke/LambdaForm$Name
+instanceKlass java/lang/reflect/Array
+instanceKlass java/lang/invoke/Invokers
+instanceKlass sun/invoke/util/ValueConversions
+instanceKlass java/lang/invoke/DirectMethodHandle$Holder
+instanceKlass java/lang/Void
+instanceKlass sun/invoke/util/Wrapper$Format
+instanceKlass java/lang/invoke/MethodHandleImpl$1
+instanceKlass jdk/internal/access/JavaLangInvokeAccess
+instanceKlass java/lang/invoke/LambdaForm$NamedFunction
+instanceKlass java/lang/invoke/MethodHandleImpl
+instanceKlass jdk/internal/reflect/MethodHandleAccessorFactory$LazyStaticHolder
+instanceKlass java/lang/invoke/MethodTypeForm
+instanceKlass jdk/internal/util/StrongReferenceKey
+instanceKlass jdk/internal/util/ReferenceKey
+instanceKlass jdk/internal/util/ReferencedKeyMap
+instanceKlass java/lang/invoke/MethodType$1
+instanceKlass sun/reflect/annotation/AnnotationParser
+instanceKlass java/lang/Class$3
+instanceKlass java/lang/PublicMethods$Key
+instanceKlass java/lang/PublicMethods$MethodList
+instanceKlass java/util/EnumMap$1
+instanceKlass java/util/stream/StreamOpFlag$MaskBuilder
+instanceKlass java/util/stream/Stream
+instanceKlass java/util/stream/BaseStream
+instanceKlass java/util/stream/PipelineHelper
+instanceKlass java/util/stream/StreamSupport
+instanceKlass java/util/Spliterators$IteratorSpliterator
+instanceKlass java/util/Spliterator$OfDouble
+instanceKlass java/util/Spliterator$OfLong
+instanceKlass java/util/Spliterator$OfInt
+instanceKlass java/util/Spliterator$OfPrimitive
+instanceKlass java/util/Spliterator
+instanceKlass java/util/Spliterators$EmptySpliterator
+instanceKlass java/util/Spliterators
+instanceKlass jdk/internal/module/DefaultRoots
+instanceKlass jdk/internal/loader/BuiltinClassLoader$LoadedModule
+instanceKlass jdk/internal/loader/AbstractClassLoaderValue
+instanceKlass jdk/internal/module/ServicesCatalog
+instanceKlass java/util/Deque
+instanceKlass java/util/Queue
+instanceKlass sun/net/util/IPAddressUtil$MASKS
+instanceKlass sun/net/util/IPAddressUtil
+instanceKlass java/net/URLStreamHandler
+instanceKlass sun/net/www/ParseUtil
+instanceKlass java/net/URL$3
+instanceKlass jdk/internal/access/JavaNetURLAccess
+instanceKlass java/net/URL$DefaultFactory
+instanceKlass java/net/URLStreamHandlerFactory
+instanceKlass jdk/internal/loader/URLClassPath
+instanceKlass java/security/Principal
+instanceKlass java/security/ProtectionDomain$Key
+instanceKlass java/security/ProtectionDomain$JavaSecurityAccessImpl
+instanceKlass jdk/internal/access/JavaSecurityAccess
+instanceKlass java/lang/ClassLoader$ParallelLoaders
+instanceKlass java/security/cert/Certificate
+instanceKlass jdk/internal/loader/ArchivedClassLoaders
+instanceKlass java/util/concurrent/ConcurrentHashMap$CollectionView
+instanceKlass jdk/internal/loader/ClassLoaderHelper
+instanceKlass jdk/internal/loader/NativeLibraries
+instanceKlass java/lang/Module$EnableNativeAccess
+instanceKlass jdk/internal/loader/BootLoader
+instanceKlass java/util/Optional
+instanceKlass jdk/internal/module/SystemModuleFinders$SystemModuleFinder
+instanceKlass java/lang/module/ModuleFinder
+instanceKlass jdk/internal/module/SystemModuleFinders$3
+instanceKlass jdk/internal/module/ModuleHashes$HashSupplier
+instanceKlass jdk/internal/module/SystemModuleFinders$2
+instanceKlass java/util/function/Supplier
+instanceKlass java/lang/module/ModuleReference
+instanceKlass jdk/internal/module/ModuleResolution
+instanceKlass java/util/Collections$UnmodifiableMap
+instanceKlass jdk/internal/module/ModuleHashes$Builder
+instanceKlass jdk/internal/module/ModuleHashes
+instanceKlass jdk/internal/module/ModuleTarget
+instanceKlass java/util/ImmutableCollections$Set12$1
+instanceKlass java/lang/reflect/AccessFlag$18
+instanceKlass java/lang/reflect/AccessFlag$17
+instanceKlass java/lang/reflect/AccessFlag$16
+instanceKlass java/lang/reflect/AccessFlag$15
+instanceKlass java/lang/reflect/AccessFlag$14
+instanceKlass java/lang/reflect/AccessFlag$13
+instanceKlass java/lang/reflect/AccessFlag$12
+instanceKlass java/lang/reflect/AccessFlag$11
+instanceKlass java/lang/reflect/AccessFlag$10
+instanceKlass java/lang/reflect/AccessFlag$9
+instanceKlass java/lang/reflect/AccessFlag$8
+instanceKlass java/lang/reflect/AccessFlag$7
+instanceKlass java/lang/reflect/AccessFlag$6
+instanceKlass java/lang/reflect/AccessFlag$5
+instanceKlass java/lang/reflect/AccessFlag$4
+instanceKlass java/lang/reflect/AccessFlag$3
+instanceKlass java/lang/reflect/AccessFlag$2
+instanceKlass java/lang/reflect/AccessFlag$1
+instanceKlass java/lang/module/ModuleDescriptor$Version
+instanceKlass java/lang/module/ModuleDescriptor$Provides
+instanceKlass java/lang/module/ModuleDescriptor$Opens
+instanceKlass java/util/ImmutableCollections$SetN$SetNIterator
+instanceKlass java/lang/module/ModuleDescriptor$Exports
+instanceKlass java/lang/module/ModuleDescriptor$Requires
+instanceKlass jdk/internal/module/Builder
+instanceKlass jdk/internal/module/SystemModules$all
+instanceKlass jdk/internal/module/SystemModules
+instanceKlass jdk/internal/module/SystemModulesMap
+instanceKlass java/net/URI$1
+instanceKlass jdk/internal/access/JavaNetUriAccess
+instanceKlass java/net/URI
+instanceKlass jdk/internal/module/SystemModuleFinders
+instanceKlass jdk/internal/module/ArchivedModuleGraph
+instanceKlass jdk/internal/module/ArchivedBootLayer
+instanceKlass jdk/internal/module/ModuleBootstrap$Counters
+instanceKlass jdk/internal/module/ModulePatcher
+instanceKlass java/io/FileSystem
+instanceKlass java/io/DefaultFileSystem
+instanceKlass java/io/File
+instanceKlass java/lang/module/ModuleDescriptor$1
+instanceKlass jdk/internal/access/JavaLangModuleAccess
+instanceKlass sun/invoke/util/VerifyAccess
+instanceKlass java/util/KeyValueHolder
+instanceKlass java/util/ImmutableCollections$MapN$MapNIterator
+instanceKlass java/lang/StrictMath
+instanceKlass java/lang/invoke/MethodHandles$Lookup
+instanceKlass java/lang/invoke/MemberName$Factory
+instanceKlass java/lang/invoke/MethodHandles
+instanceKlass java/lang/module/ModuleDescriptor
+instanceKlass jdk/internal/module/ModuleBootstrap
+instanceKlass java/lang/Character$CharacterCache
+instanceKlass java/util/HexFormat
+instanceKlass jdk/internal/util/ClassFileDumper
+instanceKlass sun/security/action/GetPropertyAction
+instanceKlass java/lang/invoke/MethodHandleStatics
+instanceKlass jdk/internal/misc/Blocker
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer$ConditionObject
+instanceKlass java/util/concurrent/locks/Condition
+instanceKlass java/util/Collections
+instanceKlass java/lang/Thread$ThreadIdentifiers
+instanceKlass sun/io/Win32ErrorMode
+instanceKlass jdk/internal/misc/OSEnvironment
+instanceKlass java/lang/Integer$IntegerCache
+instanceKlass jdk/internal/misc/Signal$NativeHandler
+instanceKlass java/util/Hashtable$Entry
+instanceKlass jdk/internal/misc/Signal
+instanceKlass java/lang/Terminator$1
+instanceKlass jdk/internal/misc/Signal$Handler
+instanceKlass java/lang/Terminator
+instanceKlass java/nio/ByteOrder
+instanceKlass java/nio/Buffer$2
+instanceKlass jdk/internal/access/JavaNioAccess
+instanceKlass java/nio/Buffer$1
+instanceKlass jdk/internal/misc/ScopedMemoryAccess
+instanceKlass java/nio/charset/CodingErrorAction
+instanceKlass sun/nio/cs/SingleByte
+instanceKlass java/lang/StringUTF16
+instanceKlass sun/nio/cs/MS1252$Holder
+instanceKlass sun/nio/cs/ArrayEncoder
+instanceKlass java/nio/charset/CharsetEncoder
+instanceKlass java/io/Writer
+instanceKlass java/io/PrintStream$1
+instanceKlass jdk/internal/access/JavaIOPrintStreamAccess
+instanceKlass jdk/internal/misc/InternalLock
+instanceKlass java/io/OutputStream
+instanceKlass java/io/Flushable
+instanceKlass java/io/FileDescriptor$1
+instanceKlass jdk/internal/access/JavaIOFileDescriptorAccess
+instanceKlass java/io/FileDescriptor
+instanceKlass jdk/internal/util/StaticProperty
+instanceKlass jdk/internal/reflect/MethodHandleAccessorFactory
+instanceKlass java/lang/reflect/Modifier
+instanceKlass java/lang/Class$1
+instanceKlass java/lang/Class$Atomic
+instanceKlass java/lang/Class$ReflectionData
+instanceKlass java/nio/charset/StandardCharsets
+instanceKlass sun/nio/cs/HistoricallyNamedCharset
+instanceKlass java/nio/charset/spi/CharsetProvider
+instanceKlass java/nio/charset/Charset
+instanceKlass java/util/HashMap$HashIterator
+instanceKlass java/util/concurrent/locks/LockSupport
+instanceKlass java/util/concurrent/ConcurrentHashMap$Node
+instanceKlass java/util/concurrent/ConcurrentHashMap$CounterCell
+instanceKlass java/util/concurrent/locks/ReentrantLock
+instanceKlass java/util/concurrent/locks/Lock
+instanceKlass java/lang/CharacterData
+instanceKlass java/util/Arrays
+instanceKlass jdk/internal/util/Preconditions$3
+instanceKlass jdk/internal/util/Preconditions$2
+instanceKlass jdk/internal/util/Preconditions$4
+instanceKlass java/util/function/BiFunction
+instanceKlass jdk/internal/util/Preconditions$1
+instanceKlass java/util/function/Function
+instanceKlass jdk/internal/util/Preconditions
+instanceKlass java/lang/Runtime
+instanceKlass java/lang/VersionProps
+instanceKlass java/lang/StringConcatHelper
+instanceKlass java/util/HashMap$Node
+instanceKlass java/util/Map$Entry
+instanceKlass jdk/internal/util/ArraysSupport
+instanceKlass jdk/internal/util/SystemProps$Raw
+instanceKlass jdk/internal/util/SystemProps
+instanceKlass java/lang/System$2
+instanceKlass jdk/internal/access/JavaLangAccess
+instanceKlass java/lang/ref/NativeReferenceQueue$Lock
+instanceKlass java/lang/ref/ReferenceQueue
+instanceKlass java/lang/ref/Reference$1
+instanceKlass jdk/internal/access/JavaLangRefAccess
+instanceKlass jdk/internal/reflect/ReflectionFactory
+instanceKlass java/lang/Math
+instanceKlass java/lang/StringLatin1
+instanceKlass jdk/internal/reflect/Reflection
+instanceKlass jdk/internal/reflect/ReflectionFactory$GetReflectionFactoryAction
+instanceKlass java/security/PrivilegedAction
+instanceKlass jdk/internal/access/SharedSecrets
+instanceKlass java/lang/reflect/ReflectAccess
+instanceKlass jdk/internal/access/JavaLangReflectAccess
+instanceKlass java/util/ImmutableCollections
+instanceKlass java/util/Objects
+instanceKlass java/util/Set
+instanceKlass jdk/internal/misc/CDS
+instanceKlass java/lang/Module$ArchivedData
+instanceKlass jdk/internal/misc/VM
+instanceKlass java/lang/String$CaseInsensitiveComparator
+instanceKlass java/util/Comparator
+instanceKlass java/io/ObjectStreamField
+instanceKlass jdk/internal/vm/FillerObject
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorPayload
+instanceKlass jdk/internal/vm/vector/VectorSupport
+instanceKlass java/lang/reflect/RecordComponent
+instanceKlass java/util/Iterator
+instanceKlass java/lang/Number
+instanceKlass java/lang/Character
+instanceKlass java/lang/Boolean
+instanceKlass java/util/concurrent/locks/AbstractOwnableSynchronizer
+instanceKlass java/lang/LiveStackFrame
+instanceKlass java/lang/StackFrameInfo
+instanceKlass java/lang/StackWalker$StackFrame
+instanceKlass java/lang/StackStreamFactory$AbstractStackWalker
+instanceKlass java/lang/StackWalker
+instanceKlass java/nio/Buffer
+instanceKlass java/lang/StackTraceElement
+instanceKlass java/util/RandomAccess
+instanceKlass java/util/List
+instanceKlass java/util/SequencedCollection
+instanceKlass java/util/AbstractCollection
+instanceKlass java/util/Collection
+instanceKlass java/lang/Iterable
+instanceKlass java/util/concurrent/ConcurrentMap
+instanceKlass java/util/AbstractMap
+instanceKlass java/security/CodeSource
+instanceKlass jdk/internal/loader/ClassLoaders
+instanceKlass java/util/jar/Manifest
+instanceKlass java/lang/Enum
+instanceKlass java/net/URL
+instanceKlass java/io/InputStream
+instanceKlass java/io/Closeable
+instanceKlass java/lang/AutoCloseable
+instanceKlass jdk/internal/module/Modules
+instanceKlass jdk/internal/misc/Unsafe
+instanceKlass jdk/internal/misc/UnsafeConstants
+instanceKlass java/lang/AbstractStringBuilder
+instanceKlass java/lang/Appendable
+instanceKlass java/lang/AssertionStatusDirectives
+instanceKlass jdk/internal/foreign/abi/ABIDescriptor
+instanceKlass jdk/internal/foreign/abi/NativeEntryPoint
+instanceKlass java/lang/invoke/CallSite
+instanceKlass java/lang/invoke/MethodType
+instanceKlass java/lang/invoke/TypeDescriptor$OfMethod
+instanceKlass java/lang/invoke/LambdaForm
+instanceKlass java/lang/invoke/MethodHandleNatives
+instanceKlass java/lang/invoke/ResolvedMethodName
+instanceKlass java/lang/invoke/MemberName
+instanceKlass java/lang/invoke/VarHandle
+instanceKlass java/lang/invoke/MethodHandle
+instanceKlass jdk/internal/reflect/CallerSensitive
+instanceKlass java/lang/annotation/Annotation
+instanceKlass jdk/internal/reflect/FieldAccessor
+instanceKlass jdk/internal/reflect/ConstantPool
+instanceKlass jdk/internal/reflect/ConstructorAccessor
+instanceKlass jdk/internal/reflect/MethodAccessor
+instanceKlass jdk/internal/reflect/MagicAccessorImpl
+instanceKlass jdk/internal/vm/StackChunk
+instanceKlass jdk/internal/vm/Continuation
+instanceKlass jdk/internal/vm/ContinuationScope
+instanceKlass java/lang/reflect/Parameter
+instanceKlass java/lang/reflect/Member
+instanceKlass java/lang/reflect/AccessibleObject
+instanceKlass java/lang/Module
+instanceKlass java/util/Map
+instanceKlass java/util/Dictionary
+instanceKlass java/lang/ThreadGroup
+instanceKlass java/lang/Thread$UncaughtExceptionHandler
+instanceKlass java/lang/Thread$Constants
+instanceKlass java/lang/Thread$FieldHolder
+instanceKlass java/lang/Thread
+instanceKlass java/lang/Runnable
+instanceKlass java/lang/ref/Reference
+instanceKlass java/lang/Record
+instanceKlass java/security/AccessController
+instanceKlass java/security/AccessControlContext
+instanceKlass java/security/ProtectionDomain
+instanceKlass java/lang/SecurityManager
+instanceKlass java/lang/Throwable
+instanceKlass java/lang/System
+instanceKlass java/lang/ClassLoader
+instanceKlass java/lang/Cloneable
+instanceKlass java/lang/Class
+instanceKlass java/lang/invoke/TypeDescriptor$OfField
+instanceKlass java/lang/invoke/TypeDescriptor
+instanceKlass java/lang/reflect/Type
+instanceKlass java/lang/reflect/GenericDeclaration
+instanceKlass java/lang/reflect/AnnotatedElement
+instanceKlass java/lang/String
+instanceKlass java/lang/constant/ConstantDesc
+instanceKlass java/lang/constant/Constable
+instanceKlass java/lang/CharSequence
+instanceKlass java/lang/Comparable
+instanceKlass java/io/Serializable
+ciInstanceKlass java/lang/Object 1 1 124 7 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 3 8 1 7 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 3 1 1
+ciInstanceKlass java/io/Serializable 1 0 7 100 1 100 1 1 1
+ciInstanceKlass java/lang/System 1 1 834 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 10 7 12 1 1 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 10 7 12 1 1 1 18 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 1 9 12 1 1 8 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 9 12 1 1 8 1 10 12 1 1 10 100 12 1 1 1 8 1 10 12 1 7 1 10 12 1 8 1 10 12 1 10 12 1 1 100 1 10 12 10 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 100 1 100 1 8 1 10 12 1 10 12 1 1 7 1 10 12 1 100 1 8 1 10 10 12 1 100 1 8 1 10 8 1 10 7 12 1 1 8 1 10 12 100 1 8 1 10 10 12 1 1 10 7 12 1 1 1 100 1 18 12 1 100 1 9 100 12 1 1 1 10 12 1 100 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 7 1 10 12 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 7 12 1 1 1 7 1 8 1 10 9 12 1 9 12 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 8 1 11 12 1 10 12 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 1 7 1 11 12 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 11 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 8 1 9 12 1 8 1 10 7 12 1 1 8 1 7 1 9 7 12 1 1 1 10 12 1 7 1 9 12 10 9 12 7 1 10 12 9 12 1 1 8 1 10 12 1 1 8 1 10 7 12 1 1 10 12 1 10 12 1 1 11 7 12 1 1 10 12 10 7 12 1 1 1 9 12 1 1 7 1 8 1 10 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 8 1 8 1 10 8 1 8 1 8 1 8 1 10 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 7 1 8 1 10 10 10 12 1 1 10 12 1 1 8 1 10 12 1 8 1 8 1 10 12 1 10 7 12 1 1 1 10 12 1 1 7 1 10 10 12 1 10 12 1 9 12 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 1 1 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/System in Ljava/io/InputStream; java/io/ByteArrayInputStream
+staticfield java/lang/System out Ljava/io/PrintStream; java/io/PrintStream
+staticfield java/lang/System err Ljava/io/PrintStream; java/io/PrintStream
+instanceKlass com/sun/jna/Native$6
+instanceKlass org/eclipse/osgi/internal/permadmin/EquinoxSecurityManager
+instanceKlass org/eclipse/osgi/internal/loader/BundleLoader$ClassContext
+instanceKlass org/eclipse/osgi/internal/framework/ContextFinder$Finder
+ciInstanceKlass java/lang/SecurityManager 1 1 576 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 1 10 100 1 10 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 100 1 8 1 10 9 12 1 1 9 12 1 8 1 9 12 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 100 1 10 10 12 1 1 100 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 7 12 1 1 1 10 12 1 1 8 1 100 1 8 1 10 8 1 8 1 8 1 8 1 8 1 10 100 12 1 1 8 1 100 1 8 1 8 1 10 8 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 11 7 12 1 1 1 18 12 1 1 11 7 12 1 1 1 18 12 1 1 11 12 1 1 18 18 11 12 1 18 12 1 11 12 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 7 1 10 7 12 1 1 10 12 1 10 12 1 18 12 1 18 10 7 12 1 1 1 18 12 1 10 12 1 18 18 8 1 10 12 1 9 12 1 1 11 7 12 1 1 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 8 1 100 1 10 9 12 1 8 1 10 12 1 8 1 100 1 10 10 7 12 1 1 10 7 1 9 7 12 1 1 1 11 12 1 1 10 12 1 11 12 1 10 12 1 7 1 10 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 7 12 1 1 1 16 1 16 15 10 12 16 1 15 10 12 16 15 11 7 1 16 1 16 1 15 10 12 16 15 10 12 16 15 10 12 1 16 1 15 11 12 1 15 10 12 16 15 10 16 1 15 10 7 12 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/SecurityManager packageAccessLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/SecurityManager packageDefinitionLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/SecurityManager nonExportedPkgs Ljava/util/Map; java/util/concurrent/ConcurrentHashMap
+ciInstanceKlass java/security/AccessController 1 1 295 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 7 1 7 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 9 100 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 10 100 1 10 11 7 12 1 1 1 10 7 12 1 1 11 7 1 100 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 8 1 10 100 12 1 1 1 8 1 7 1 10 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 3 1 1 1
+staticfield java/security/AccessController $assertionsDisabled Z 1
+instanceKlass org/eclipse/osgi/internal/loader/ModuleClassLoader$GenerationProtectionDomain
+ciInstanceKlass java/security/ProtectionDomain 1 1 348 10 7 12 1 1 1 9 7 12 1 1 1 7 1 10 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 7 1 9 12 1 9 12 1 1 7 1 9 12 1 1 9 12 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 9 12 1 9 100 12 1 1 10 12 1 1 10 100 1 10 12 1 1 8 1 7 1 8 1 10 12 1 10 11 10 7 12 1 1 1 10 12 1 1 8 1 11 8 1 10 12 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 8 1 8 1 10 7 12 1 1 1 9 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 100 1 18 12 1 1 10 7 12 1 1 1 10 7 1 10 12 1 10 12 1 1 11 100 12 1 1 11 12 1 100 1 11 7 12 1 1 1 10 12 1 10 11 12 1 1 11 12 1 1 10 12 1 10 7 12 1 1 10 100 12 1 1 11 12 1 10 12 10 12 1 8 1 8 1 10 7 12 1 1 1 7 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 7 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 100 1 1 16 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/security/ProtectionDomain filePermCompatInPD Z 0
+ciInstanceKlass java/security/CodeSource 1 1 398 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 10 7 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 7 1 10 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 8 1 8 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 10 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 100 1 10 12 1 10 12 10 12 1 1 10 100 12 1 1 10 12 1 7 1 10 12 10 100 12 1 1 1 10 8 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 100 1 7 1 8 1 8 1 10 10 12 1 1 10 100 12 1 1 1 7 1 10 12 10 12 1 1 11 7 12 1 1 10 10 12 1 11 10 12 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 11 12 1 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Boolean 1 1 152 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 8 1 10 7 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 9 100 12 1 1 9 12 10 100 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Boolean TRUE Ljava/lang/Boolean; java/lang/Boolean
+staticfield java/lang/Boolean FALSE Ljava/lang/Boolean; java/lang/Boolean
+staticfield java/lang/Boolean TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/Comparable 1 0 12 100 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/constant/Constable 1 0 11 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/util/Map 1 1 263 11 7 12 1 1 1 11 12 1 1 10 7 12 1 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 7 1 11 12 1 11 12 1 100 1 100 1 10 12 1 1 11 7 12 1 1 1 11 100 12 1 1 1 11 12 1 11 12 1 10 12 1 1 11 12 1 11 7 12 1 9 7 12 1 1 1 7 1 10 12 7 1 7 1 10 12 1 7 1 10 7 1 11 12 1 11 12 1 1 11 12 1 1 7 1 11 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Class 1 1 1687 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 8 1 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 7 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 18 12 1 1 11 7 12 1 1 1 8 1 8 1 8 1 10 7 12 1 1 1 11 12 1 1 8 1 10 12 1 10 11 100 12 1 1 1 11 7 12 1 1 1 11 8 1 18 8 1 10 12 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 18 12 1 1 10 7 12 1 1 1 10 7 12 1 10 12 1 1 10 7 1 7 1 10 12 1 1 9 12 1 1 7 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 12 1 7 1 7 1 10 10 12 1 1 10 12 1 1 100 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 10 7 1 10 12 1 10 12 1 10 12 1 1 10 9 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 1 10 7 12 1 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 9 100 12 1 1 1 9 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 7 1 10 10 10 12 1 1 10 12 1 1 10 12 10 10 12 1 1 7 1 8 1 10 10 12 1 1 10 12 1 100 1 11 12 1 10 100 12 1 1 10 12 1 10 12 1 10 100 12 1 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 7 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 10 12 11 7 12 1 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 10 12 1 1 7 1 10 10 12 1 1 10 7 12 1 1 1 100 1 7 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 11 7 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 1 10 12 1 9 100 12 1 1 1 9 12 1 10 100 12 1 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 10 12 1 1 100 1 10 8 1 10 12 1 11 11 12 1 1 11 7 12 1 1 11 12 1 8 1 10 12 1 10 12 1 1 9 12 1 9 12 1 1 10 7 12 1 1 9 12 1 10 12 1 1 10 10 12 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 9 12 1 1 10 12 1 9 12 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 100 1 10 10 12 1 1 7 1 10 12 1 1 100 11 7 1 9 12 1 1 9 12 1 7 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 9 12 1 7 1 10 10 12 1 1 10 10 12 1 10 12 10 10 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 8 10 7 8 1 18 8 1 8 1 10 12 1 9 12 1 9 12 1 1 10 12 1 7 1 7 1 10 12 1 9 12 1 1 7 1 10 10 12 1 10 7 1 9 12 1 8 1 10 12 1 7 1 10 12 1 10 12 1 1 100 1 7 1 9 12 1 100 1 8 1 10 10 7 12 1 1 1 10 12 11 7 12 1 1 1 10 12 1 10 12 1 1 10 8 1 8 1 10 12 1 1 9 7 12 1 1 11 12 7 1 11 7 12 1 1 9 12 1 10 100 12 1 1 1 10 7 12 1 1 10 12 1 1 9 12 1 9 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 12 1 7 1 11 12 1 10 7 12 1 1 1 10 12 1 11 12 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 11 12 1 11 12 1 1 10 12 1 10 12 1 1 9 12 1 1 9 7 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 100 1 10 12 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 18 12 1 1 11 12 1 1 18 11 12 1 18 12 1 11 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 8 1 10 12 1 7 1 9 12 1 1 7 1 7 1 7 1 7 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 11 12 16 1 16 15 16 15 10 12 16 16 15 10 12 16 15 16 1 15 10 12 16 15 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 100 1 100 1 1 100 1 100 1 1 100 1 100 1 1
+staticfield java/lang/Class EMPTY_CLASS_ARRAY [Ljava/lang/Class; 0 [Ljava/lang/Class;
+staticfield java/lang/Class serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+ciInstanceKlass java/lang/reflect/AnnotatedElement 1 1 164 11 7 12 1 1 1 11 12 1 1 7 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 11 12 1 1 11 7 12 1 1 10 7 12 1 1 1 10 12 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 18 12 1 18 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 7 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 16 15 16 1 16 1 15 11 12 16 16 1 15 10 100 12 1 1 1 16 1 15 10 100 12 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor 1 0 17 100 1 100 1 1 1 1 1 1 100 1 100 1 1 1 1
+ciInstanceKlass java/lang/reflect/GenericDeclaration 1 0 30 7 1 7 1 7 1 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1
+ciInstanceKlass java/lang/reflect/Type 1 1 17 11 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor$OfField 1 0 21 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StringBuilder 1 1 422 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 100 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 100 1 100 1 8 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 7 1 7 1 7 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/StringBuilder
+instanceKlass java/lang/StringBuffer
+ciInstanceKlass java/lang/AbstractStringBuilder 1 1 599 7 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 3 3 10 12 1 10 12 1 1 11 7 1 100 1 7 1 10 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 8 1 10 10 12 1 1 100 1 10 12 10 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 100 1 10 10 7 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 10 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 100 1 100 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 18 12 1 1 100 1 10 100 12 1 1 1 18 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 10 12 1 10 12 10 10 10 12 1 10 5 0 10 10 12 1 1 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 100 1 10 12 100 1 10 100 1 10 7 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 7 1 1 16 1 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/AbstractStringBuilder EMPTYVALUE [B 0
+ciMethod java/lang/StringBuilder toString ()Ljava/lang/String; 14 0 23714 0 -1
+ciInstanceKlass java/lang/Appendable 1 0 14 100 1 100 1 1 1 1 100 1 1 1 1 1
+ciInstanceKlass java/lang/CharSequence 1 1 131 11 7 12 1 1 1 18 12 1 1 100 1 10 100 12 1 1 1 18 10 100 12 1 1 1 11 12 1 1 11 7 1 11 12 1 1 10 100 12 1 1 1 11 12 1 1 100 1 10 12 1 1 10 100 12 1 1 1 100 1 10 10 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 11 12 16 15 11 12 15 10 100 12 1 1 1 1 1 100 1 100 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/AutoCloseable 1 0 12 100 1 100 1 1 1 1 100 1 1 1
+ciInstanceKlass java/io/Closeable 1 0 14 100 1 100 1 100 1 1 1 1 100 1 1 1
+instanceKlass org/eclipse/equinox/security/storage/StorageException
+instanceKlass javax/xml/transform/TransformerException
+instanceKlass org/eclipse/jface/text/templates/TemplateException
+instanceKlass com/google/common/collect/RegularImmutableMap$BucketOverflowException
+instanceKlass com/google/inject/internal/ErrorsException
+instanceKlass com/google/inject/internal/InternalProvisionException
+instanceKlass org/codehaus/plexus/context/ContextException
+instanceKlass lombok/eclipse/agent/PatchDelegate$CantMakeDelegates
+instanceKlass org/codehaus/plexus/PlexusContainerException
+instanceKlass org/codehaus/plexus/util/xml/pull/XmlPullParserException
+instanceKlass org/apache/commons/cli/ParseException
+instanceKlass org/eclipse/jface/text/BadLocationException
+instanceKlass org/eclipse/jdt/core/compiler/InvalidInputException
+instanceKlass org/eclipse/jdt/internal/compiler/classfmt/ClassFormatException
+instanceKlass java/text/ParseException
+instanceKlass org/codehaus/plexus/component/configurator/expression/ExpressionEvaluationException
+instanceKlass org/codehaus/plexus/classworlds/ClassWorldException
+instanceKlass org/apache/maven/cli/internal/ExtensionResolutionException
+instanceKlass org/apache/maven/plugin/AbstractMojoExecutionException
+instanceKlass org/apache/maven/plugin/PluginConfigurationException
+instanceKlass org/apache/maven/plugin/PluginManagerException
+instanceKlass org/apache/maven/settings/building/SettingsBuildingException
+instanceKlass org/apache/maven/artifact/InvalidRepositoryException
+instanceKlass org/apache/maven/plugin/version/PluginVersionResolutionException
+instanceKlass org/codehaus/plexus/component/configurator/ComponentConfigurationException
+instanceKlass org/apache/maven/plugin/InvalidPluginDescriptorException
+instanceKlass org/apache/maven/plugin/MojoNotFoundException
+instanceKlass org/apache/maven/plugin/PluginDescriptorParsingException
+instanceKlass org/apache/maven/plugin/PluginResolutionException
+instanceKlass org/apache/maven/artifact/resolver/AbstractArtifactResolutionException
+instanceKlass org/apache/maven/execution/MavenExecutionRequestPopulationException
+instanceKlass org/apache/maven/project/ProjectBuildingException
+instanceKlass org/eclipse/aether/RepositoryException
+instanceKlass org/codehaus/plexus/component/repository/exception/ComponentLookupException
+instanceKlass org/apache/maven/project/DuplicateProjectException
+instanceKlass org/codehaus/plexus/util/dag/CycleDetectedException
+instanceKlass ch/qos/logback/core/util/DynamicClassLoadingException
+instanceKlass ch/qos/logback/core/util/IncompatibleClassException
+instanceKlass ch/qos/logback/core/joran/spi/JoranException
+instanceKlass java/util/concurrent/TimeoutException
+instanceKlass org/osgi/service/application/ApplicationException
+instanceKlass org/eclipse/core/runtime/CoreException
+instanceKlass org/osgi/service/prefs/BackingStoreException
+instanceKlass org/apache/felix/scr/impl/inject/methods/SuitableMethodNotAccessibleException
+instanceKlass org/xml/sax/SAXException
+instanceKlass java/util/concurrent/ExecutionException
+instanceKlass java/lang/CloneNotSupportedException
+instanceKlass javax/xml/parsers/ParserConfigurationException
+instanceKlass org/osgi/service/resolver/ResolutionException
+instanceKlass java/security/GeneralSecurityException
+instanceKlass org/eclipse/osgi/container/ModuleContainer$ResolutionLockException
+instanceKlass java/security/PrivilegedActionException
+instanceKlass org/osgi/framework/InvalidSyntaxException
+instanceKlass java/lang/InterruptedException
+instanceKlass org/osgi/framework/BundleException
+instanceKlass java/net/URISyntaxException
+instanceKlass java/lang/instrument/UnmodifiableClassException
+instanceKlass java/io/IOException
+instanceKlass java/lang/ReflectiveOperationException
+instanceKlass java/lang/RuntimeException
+ciInstanceKlass java/lang/Exception 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass lombok/eclipse/agent/PatchDelegate$DelegateRecursion
+instanceKlass java/lang/Exception
+instanceKlass java/lang/Error
+ciInstanceKlass java/lang/Throwable 1 1 404 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 8 1 10 100 12 1 1 10 10 12 1 100 1 8 1 10 10 12 1 1 10 7 12 1 1 10 12 1 8 1 9 7 12 1 1 1 10 12 1 1 100 1 10 12 10 12 1 10 100 12 1 1 1 100 1 10 12 10 12 1 10 12 1 100 1 10 10 7 12 1 1 1 11 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 8 1 8 1 9 12 1 1 10 12 1 1 100 1 10 11 12 1 8 1 8 1 10 7 12 1 1 8 1 10 12 1 8 1 100 1 10 12 1 9 12 1 1 10 12 1 10 7 12 1 9 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 100 12 1 1 10 12 1 1 7 1 10 100 12 1 1 1 10 12 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 8 1 10 12 1 1 8 1 10 10 9 100 12 1 1 1 8 1 10 12 1 1 11 10 100 1 8 1 10 11 12 1 1 8 1 9 12 1 10 100 12 1 1 11 9 12 1 1 11 12 1 1 100 10 12 1 10 12 1 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Throwable UNASSIGNED_STACK [Ljava/lang/StackTraceElement; 0 [Ljava/lang/StackTraceElement;
+staticfield java/lang/Throwable SUPPRESSED_SENTINEL Ljava/util/List; java/util/Collections$EmptyList
+staticfield java/lang/Throwable EMPTY_THROWABLE_ARRAY [Ljava/lang/Throwable; 0 [Ljava/lang/Throwable;
+staticfield java/lang/Throwable $assertionsDisabled Z 1
+instanceKlass org/eclipse/core/internal/resources/SaveManager$MasterTable
+instanceKlass org/eclipse/osgi/util/NLS$MessagesProperties
+instanceKlass org/eclipse/core/internal/preferences/SortedProperties
+instanceKlass java/security/Provider
+ciInstanceKlass java/util/Properties 1 1 690 10 7 12 1 1 1 100 1 10 7 12 1 1 7 1 10 12 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 8 1 10 12 1 7 1 10 12 10 12 1 1 9 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 7 1 3 10 10 100 12 1 1 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 1 8 1 10 100 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 10 12 1 10 12 1 1 100 1 9 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 9 12 1 1 7 1 7 1 10 12 1 7 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 11 12 1 10 12 1 1 8 1 10 12 1 10 100 12 1 1 10 12 1 100 1 10 10 12 1 10 12 1 100 1 10 10 12 1 1 10 7 12 1 1 9 100 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 100 1 100 1 10 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 1 10 12 1 1 7 1 10 10 12 1 11 7 12 1 1 10 7 12 1 1 1 8 1 10 100 12 1 1 11 11 7 1 8 1 10 100 1 11 10 12 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 10 11 12 1 4 11 10 12 1 1 10 100 12 1 1 11 12 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 10 12 1 10 10 100 12 1 1 1 100 1 6 0 10 12 1 1 11 100 12 1 1 1 10 12 1 10 12 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+staticfield java/util/Properties UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+instanceKlass org/apache/felix/scr/impl/helper/ReadOnlyDictionary
+instanceKlass org/osgi/framework/FrameworkUtil$MapAsDictionary
+instanceKlass org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap$UnmodifiableDictionary
+instanceKlass org/eclipse/osgi/framework/util/CaseInsensitiveDictionaryMap
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxBundle$SystemBundle$SystemBundleHeaders
+instanceKlass org/eclipse/osgi/storage/BundleInfo$CachedManifest
+instanceKlass java/util/Hashtable
+ciInstanceKlass java/util/Dictionary 1 1 36 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/Properties
+ciInstanceKlass java/util/Hashtable 1 1 516 7 1 10 7 12 1 1 1 9 7 12 1 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 8 1 10 12 1 9 12 1 1 7 1 9 12 1 1 4 10 7 12 1 1 1 9 12 1 4 10 12 1 11 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 1 100 1 10 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 10 12 1 3 9 12 1 9 12 1 3 10 12 1 10 12 1 10 12 1 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 7 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 9 12 9 12 1 1 10 100 1 7 1 10 12 1 10 8 1 10 10 12 1 8 1 10 8 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 100 1 10 12 1 10 12 1 1 7 1 10 100 1 10 10 12 1 1 11 12 1 1 11 12 1 7 1 10 10 10 100 12 1 1 11 100 12 1 1 1 100 1 10 11 100 12 1 1 11 100 12 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 8 10 100 12 1 1 100 1 8 1 10 4 4 10 12 1 1 10 12 1 8 1 4 10 12 10 100 12 1 1 1 100 1 11 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 7 1 7 1 1 1 1 1 1 5 0 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 7 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/String 1 1 1443 10 7 12 1 1 1 8 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 10 7 12 1 1 1 10 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 10 12 9 7 12 1 1 10 12 1 1 3 10 12 1 1 7 1 11 12 1 1 11 12 1 11 12 1 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 11 12 1 1 10 12 1 1 10 12 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 100 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 100 1 100 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 100 1 11 10 7 12 1 1 11 12 1 11 12 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 3 3 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 10 12 1 8 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 7 1 10 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 10 12 1 100 1 10 10 12 1 1 10 12 1 1 10 7 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 11 7 1 11 12 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 9 12 1 1 11 7 12 1 1 1 10 12 10 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 10 10 12 1 10 12 10 10 12 10 10 12 1 10 12 1 10 10 12 10 7 12 1 1 1 10 12 10 10 12 10 12 1 10 12 10 12 10 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 10 7 12 1 1 1 10 12 1 1 10 10 7 12 1 1 1 11 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 7 1 8 1 10 10 10 12 1 10 12 1 1 8 1 10 12 1 3 3 10 12 1 10 12 1 1 10 12 7 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 7 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 11 7 12 1 1 1 11 7 12 1 1 11 12 1 10 12 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 10 12 10 12 1 1 10 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 10 12 1 1 10 10 12 1 8 1 10 12 1 1 18 12 1 1 11 100 12 1 1 1 7 1 3 18 12 1 18 12 1 8 1 10 100 12 1 1 1 11 12 1 1 10 12 10 10 12 1 10 11 12 1 1 10 12 1 1 11 12 1 18 3 11 10 12 1 11 11 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 11 100 12 1 100 1 100 1 10 12 100 1 10 10 100 12 1 1 1 100 1 10 7 1 10 10 12 1 10 10 12 1 8 1 10 10 12 1 8 1 8 1 10 12 1 10 12 1 10 10 12 10 7 12 1 1 10 7 12 1 1 10 7 12 1 1 8 1 10 12 1 10 12 1 10 9 12 1 10 12 9 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 100 12 1 1 1 10 12 10 12 1 1 10 12 10 10 12 10 12 7 1 9 12 1 1 7 1 10 7 1 7 1 7 1 7 1 1 1 1 1 1 5 0 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 12 15 10 12 15 10 12 15 10 100 12 1 1 1 1 1 1 1 100 1 100 1 1 1
+staticfield java/lang/String COMPACT_STRINGS Z 1
+staticfield java/lang/String serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+staticfield java/lang/String CASE_INSENSITIVE_ORDER Ljava/util/Comparator; java/lang/String$CaseInsensitiveComparator
+ciMethod java/lang/String equals (Ljava/lang/Object;)Z 774 0 8119 0 416
+ciMethod java/lang/String hashCode ()I 850 0 7206 0 176
+ciMethod java/lang/String length ()I 600 0 307719 0 112
+ciMethod java/lang/String charAt (I)C 916 0 599438 0 192
+ciInstanceKlass java/lang/constant/ConstantDesc 1 0 37 100 1 100 1 1 1 1 100 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/InternalError 1 1 34 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass javax/xml/parsers/FactoryConfigurationError
+instanceKlass com/google/common/util/concurrent/ExecutionError
+instanceKlass java/util/ServiceConfigurationError
+instanceKlass java/lang/ThreadDeath
+instanceKlass java/lang/AssertionError
+instanceKlass java/lang/VirtualMachineError
+instanceKlass java/lang/LinkageError
+ciInstanceKlass java/lang/Error 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/StackOverflowError
+instanceKlass java/lang/OutOfMemoryError
+instanceKlass java/lang/InternalError
+ciInstanceKlass java/lang/VirtualMachineError 1 1 34 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/Iterator 1 1 53 100 1 8 1 10 12 1 1 10 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory$NamedPipeInputStream
+instanceKlass sun/nio/ch/ChannelInputStream
+instanceKlass java/io/ObjectInputStream$PeekInputStream
+instanceKlass java/io/ObjectInputStream$BlockDataInputStream
+instanceKlass org/eclipse/core/internal/resources/ContentDescriptionManager$LazyFileInputStream
+instanceKlass java/io/ObjectInputStream
+instanceKlass org/eclipse/core/internal/localstore/SafeChunkyInputStream
+instanceKlass org/eclipse/core/internal/registry/BufferedRandomInputStream
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLEntityManager$RewindableInputStream
+instanceKlass org/eclipse/osgi/storage/url/reference/ReferenceInputStream
+instanceKlass java/util/jar/JarVerifier$VerifierStream
+instanceKlass java/util/zip/ZipFile$ZipFileInputStream
+instanceKlass java/io/FilterInputStream
+instanceKlass java/io/FileInputStream
+instanceKlass java/io/ByteArrayInputStream
+ciInstanceKlass java/io/InputStream 1 1 195 7 1 10 7 12 1 1 1 100 1 10 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 100 1 3 10 12 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 3 7 1 8 1 10 10 7 12 1 1 1 7 1 10 11 7 12 1 1 1 10 12 1 1 11 12 1 1 11 7 12 1 1 1 11 12 1 1 7 1 10 7 12 1 1 1 5 0 10 12 1 10 12 1 1 100 1 10 8 1 10 8 1 8 1 10 12 1 1 10 100 12 1 1 1 7 1 5 0 10 12 1 100 1 7 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/misc/Unsafe 1 1 1287 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 10 10 12 1 1 10 12 1 1 5 0 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 5 0 5 0 5 0 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 7 1 8 1 10 100 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 9 12 1 100 1 10 10 12 1 1 8 1 10 8 1 8 1 10 12 1 1 9 7 12 1 1 1 9 7 1 9 7 1 9 7 1 9 9 7 1 9 7 1 9 7 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 5 0 5 0 9 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 3 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 100 1 10 9 12 1 5 0 10 12 1 1 5 0 10 12 1 5 0 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 5 0 5 0 5 0 10 12 1 1 10 12 1 10 12 1 10 12 10 100 12 1 1 8 1 100 1 11 12 1 1 8 1 11 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 1 10 12 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 7 1 9 12 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/misc/Unsafe theUnsafe Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield jdk/internal/misc/Unsafe ARRAY_BOOLEAN_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_BYTE_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_SHORT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_CHAR_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_INT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_LONG_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_FLOAT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_DOUBLE_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_OBJECT_BASE_OFFSET I 16
+staticfield jdk/internal/misc/Unsafe ARRAY_BOOLEAN_INDEX_SCALE I 1
+staticfield jdk/internal/misc/Unsafe ARRAY_BYTE_INDEX_SCALE I 1
+staticfield jdk/internal/misc/Unsafe ARRAY_SHORT_INDEX_SCALE I 2
+staticfield jdk/internal/misc/Unsafe ARRAY_CHAR_INDEX_SCALE I 2
+staticfield jdk/internal/misc/Unsafe ARRAY_INT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ARRAY_LONG_INDEX_SCALE I 8
+staticfield jdk/internal/misc/Unsafe ARRAY_FLOAT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ARRAY_DOUBLE_INDEX_SCALE I 8
+staticfield jdk/internal/misc/Unsafe ARRAY_OBJECT_INDEX_SCALE I 4
+staticfield jdk/internal/misc/Unsafe ADDRESS_SIZE I 8
+instanceKlass org/eclipse/sisu/space/CloningClassSpace$CloningClassLoader
+instanceKlass org/apache/aries/spifly/Util$WrapperCL
+instanceKlass org/apache/aries/spifly/MultiDelegationClassloader
+instanceKlass lombok/launch/ShadowClassLoader
+instanceKlass org/eclipse/osgi/internal/loader/ModuleClassLoader
+instanceKlass org/eclipse/osgi/internal/framework/ContextFinder
+instanceKlass org/eclipse/osgi/internal/framework/EquinoxContainer$1
+instanceKlass lombok/launch/ShadowClassLoader
+instanceKlass jdk/internal/reflect/DelegatingClassLoader
+instanceKlass java/security/SecureClassLoader
+ciInstanceKlass java/lang/ClassLoader 1 1 1108 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 10 7 12 1 10 7 1 10 7 1 7 1 7 1 10 12 1 10 12 1 9 12 1 1 10 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 7 1 10 12 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 10 12 1 1 9 12 10 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 7 1 7 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 100 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 10 10 12 1 1 10 12 1 1 7 1 8 1 10 8 1 10 12 1 10 12 1 100 1 8 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 7 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 12 1 10 12 1 1 8 1 8 1 10 7 12 1 1 100 1 10 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 10 7 1 7 1 10 12 1 1 10 12 1 10 7 1 10 12 1 100 1 18 12 1 10 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 10 12 1 100 1 10 12 1 8 1 10 10 12 1 1 10 12 1 10 12 1 1 7 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 8 1 100 1 10 10 12 1 9 12 1 10 7 12 1 1 10 12 1 7 1 8 1 10 12 1 10 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 7 1 100 1 10 12 1 1 7 1 7 1 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 7 1 18 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 18 12 1 11 100 12 1 1 1 100 1 10 12 1 1 10 12 1 10 11 12 1 1 10 18 10 12 1 1 11 7 12 1 18 12 1 11 12 1 1 10 12 10 12 1 1 10 12 1 1 100 1 8 1 10 10 12 1 8 1 8 1 10 100 12 1 1 10 12 1 100 1 10 10 12 1 8 1 8 1 8 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 11 7 12 1 1 100 1 10 11 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 9 12 1 1 9 12 9 12 1 9 12 1 9 12 1 8 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 11 12 1 1 10 100 12 1 1 1 100 1 10 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 10 12 16 1 16 15 10 12 16 1 16 1 15 10 12 16 15 10 12 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/ClassLoader nocerts [Ljava/security/cert/Certificate; 0 [Ljava/security/cert/Certificate;
+staticfield java/lang/ClassLoader $assertionsDisabled Z 1
+ciInstanceKlass java/lang/reflect/Constructor 1 1 439 10 100 12 1 1 1 10 100 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 100 1 8 1 10 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 8 1 10 10 12 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 7 12 1 1 10 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+instanceKlass java/lang/reflect/Executable
+instanceKlass java/lang/reflect/Field
+ciInstanceKlass java/lang/reflect/AccessibleObject 1 1 400 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 7 1 10 7 12 1 1 1 11 12 1 7 1 10 12 1 7 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 7 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 7 1 10 12 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 10 7 1 100 1 8 1 10 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 100 1 8 1 10 11 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 100 1 10 12 1 7 1 10 12 1 10 12 1 1 10 100 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 10 7 12 1 1 8 1 10 7 12 1 1 1 8 1 10 7 12 1 1 1 9 12 1 7 1 10 7 1 10 10 7 12 1 1 1 7 1 10 10 7 12 1 1 1 7 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/reflect/AccessibleObject reflectionFactory Ljdk/internal/reflect/ReflectionFactory; jdk/internal/reflect/ReflectionFactory
+instanceKlass java/lang/reflect/Constructor
+instanceKlass java/lang/reflect/Method
+ciInstanceKlass java/lang/reflect/Executable 1 1 581 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 8 1 10 10 12 1 1 10 12 1 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 8 1 8 1 8 1 10 100 12 1 1 1 11 12 1 1 7 1 8 1 8 1 10 12 1 7 1 8 1 10 12 1 8 1 11 100 12 1 1 1 7 1 11 7 12 1 1 1 11 12 1 8 1 18 8 1 10 12 1 10 12 1 1 18 8 1 10 12 1 100 1 10 12 1 10 12 1 11 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 1 10 10 12 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 7 1 10 100 12 1 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 100 10 12 1 8 1 10 12 1 10 12 1 3 100 1 8 1 10 12 1 10 12 1 10 10 12 1 10 12 1 1 8 1 8 1 8 1 9 12 1 1 9 12 1 10 12 1 100 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 7 1 10 12 1 10 12 1 1 100 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 10 10 10 10 100 12 1 1 1 10 12 1 9 12 1 10 12 1 1 9 12 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 16 15 16 1 16 1 15 10 12 16 15 10 100 12 1 1 1 1 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/reflect/Member 1 1 37 100 1 10 12 1 1 100 1 100 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass com/sun/jna/internal/Cleaner$CleanerThread
+instanceKlass org/eclipse/core/internal/jobs/InternalWorker
+instanceKlass org/eclipse/core/internal/jobs/Worker
+instanceKlass java/util/logging/LogManager$Cleaner
+instanceKlass org/eclipse/osgi/framework/eventmgr/EventManager$EventThread
+instanceKlass org/eclipse/equinox/launcher/Main$SplashHandler
+instanceKlass jdk/internal/misc/InnocuousThread
+instanceKlass java/util/concurrent/ForkJoinWorkerThread
+instanceKlass java/lang/ref/Finalizer$FinalizerThread
+instanceKlass java/lang/ref/Reference$ReferenceHandler
+instanceKlass java/lang/BaseVirtualThread
+ciInstanceKlass java/lang/Thread 1 1 870 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 10 12 1 10 100 12 1 1 100 1 8 1 10 12 1 1 9 12 1 9 12 1 1 9 12 1 1 7 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 9 12 1 1 10 12 1 7 1 10 12 1 100 1 8 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 3 8 1 7 1 5 0 10 7 12 1 1 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 7 1 8 1 10 7 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 10 12 1 1 9 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 7 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 10 7 12 1 1 9 12 1 8 1 9 7 12 1 1 9 12 1 1 5 0 100 1 10 100 1 10 100 1 10 7 1 10 8 1 10 12 1 1 10 7 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 7 1 9 12 1 1 100 1 10 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 1 10 10 12 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 9 12 1 9 12 1 1 9 12 1 1 10 100 12 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 10 12 1 10 12 1 100 1 10 10 12 9 12 1 1 10 12 1 11 100 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 10 10 12 1 10 12 1 1 9 12 1 9 12 10 12 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 8 1 10 9 12 1 10 12 1 7 1 8 1 10 10 12 1 8 1 10 12 1 1 9 12 10 12 8 1 10 10 12 1 10 12 1 8 1 10 12 1 10 8 1 10 100 12 1 1 10 12 1 1 100 1 8 1 10 9 12 1 9 12 1 1 10 12 1 1 10 10 12 1 10 12 1 100 10 7 12 1 1 1 9 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 7 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 7 1 10 12 1 100 1 10 12 1 10 12 1 1 10 12 1 1 8 1 9 12 1 10 12 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Thread NEW_THREAD_BINDINGS Ljava/lang/Object; java/lang/Class
+staticfield java/lang/Thread EMPTY_STACK_TRACE [Ljava/lang/StackTraceElement; 0 [Ljava/lang/StackTraceElement;
+ciInstanceKlass java/lang/Runnable 1 0 11 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/net/URL 1 1 771 10 7 12 1 1 1 10 12 1 10 7 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 7 1 10 10 12 1 1 8 1 10 12 1 1 9 12 1 7 1 8 1 10 12 1 10 12 1 8 1 9 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 9 12 1 8 1 9 12 1 10 12 1 1 8 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 8 1 9 12 1 8 1 10 12 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 8 1 10 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 8 1 10 10 100 1 10 10 12 1 8 1 10 7 12 1 1 1 10 12 1 9 100 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 10 100 12 1 1 1 100 1 100 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 10 12 1 10 12 1 10 12 1 1 8 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 100 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 9 12 1 1 7 1 8 1 10 10 12 1 9 12 1 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 12 1 1 10 12 1 8 1 8 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 10 12 1 7 1 10 9 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 8 1 7 1 10 10 7 12 1 1 1 10 12 1 8 9 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 11 7 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 8 10 100 12 1 1 100 1 10 8 8 10 12 1 8 8 8 100 1 10 12 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 100 1 8 1 10 10 10 12 1 1 10 12 1 10 12 1 1 8 1 7 1 10 10 7 1 10 12 1 9 7 12 1 1 1 9 12 1 1 7 1 10 10 7 12 1 1 1 7 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/net/URL defaultFactory Ljava/net/URLStreamHandlerFactory; java/net/URL$DefaultFactory
+staticfield java/net/URL streamHandlerLock Ljava/lang/Object; java/lang/Object
+staticfield java/net/URL serialPersistentFields [Ljava/io/ObjectStreamField; 7 [Ljava/io/ObjectStreamField;
+ciMethod java/lang/System arraycopy (Ljava/lang/Object;ILjava/lang/Object;II)V 256 0 128 0 -1
+ciInstanceKlass java/lang/Module 1 1 1070 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 12 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 9 12 1 1 10 100 12 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 10 12 1 10 7 12 1 1 8 1 8 1 10 8 1 8 1 9 12 1 1 8 1 10 100 12 1 1 1 10 12 1 9 12 1 1 11 12 1 9 7 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 1 11 7 12 1 1 10 12 1 1 9 12 1 9 12 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 18 12 1 1 10 12 1 1 11 12 1 9 12 1 11 12 10 100 12 1 1 100 1 8 1 10 11 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 11 12 1 1 11 7 12 1 1 11 12 1 1 9 12 1 11 12 1 10 12 1 1 10 12 1 1 9 12 1 10 12 10 7 12 1 1 10 7 1 18 12 1 1 11 100 12 1 1 1 18 12 1 11 12 1 1 10 100 12 1 1 1 11 12 1 1 10 7 12 1 1 7 1 11 12 1 7 1 7 1 10 12 1 10 7 12 1 1 1 10 11 7 12 1 8 1 10 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 7 1 10 12 1 10 11 12 1 1 10 12 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 11 7 1 10 12 1 1 11 12 1 10 10 12 1 11 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 10 12 1 1 10 10 12 1 1 10 12 1 18 12 1 11 12 1 18 12 1 10 12 1 10 12 1 10 12 7 1 10 12 1 10 12 1 10 12 1 9 12 1 7 1 10 10 10 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 18 12 1 1 10 7 12 1 1 1 100 1 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 7 1 10 12 1 1 7 1 8 1 10 12 1 1 100 1 11 12 1 1 10 100 12 1 1 1 18 12 1 1 11 100 12 1 1 1 100 1 10 12 1 10 12 1 1 7 1 7 1 10 12 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 7 1 10 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 10 7 12 1 1 8 1 18 12 1 1 100 1 100 1 9 12 1 1 9 12 1 9 12 1 11 100 12 1 1 1 100 1 11 12 1 1 100 1 10 12 1 8 1 10 12 1 10 12 10 12 1 8 1 10 10 100 12 1 1 7 1 10 10 12 1 10 7 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 11 12 1 10 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 16 15 10 16 1 15 10 12 16 1 15 10 12 16 1 16 15 10 12 16 16 1 15 10 12 16 15 10 7 12 1 1 1 15 10 100 12 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 100 1 1
+staticfield java/lang/Module ALL_UNNAMED_MODULE Ljava/lang/Module; java/lang/Module
+staticfield java/lang/Module ALL_UNNAMED_MODULE_SET Ljava/util/Set; java/util/ImmutableCollections$Set12
+staticfield java/lang/Module EVERYONE_MODULE Ljava/lang/Module; java/lang/Module
+staticfield java/lang/Module EVERYONE_SET Ljava/util/Set; java/util/ImmutableCollections$Set12
+staticfield java/lang/Module $assertionsDisabled Z 1
+ciInstanceKlass java/lang/StringLatin1 1 1 392 7 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 10 12 1 10 12 1 10 9 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 100 1 7 1 8 1 10 12 1 8 1 10 12 1 1 100 1 10 10 12 10 7 12 1 1 1 8 1 8 1 8 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 10 12 1 10 12 10 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+staticfield java/lang/StringLatin1 $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Math 1 1 460 7 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 6 0 6 0 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 100 1 3 3 3 10 7 12 1 1 1 100 1 5 0 5 0 5 0 5 0 5 0 9 100 12 1 1 1 10 100 12 1 1 1 100 1 8 1 10 12 1 8 1 10 12 1 1 10 12 1 1 7 1 5 0 5 0 7 1 3 5 0 3 5 0 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 8 1 10 12 1 1 10 12 1 1 9 12 1 1 9 12 1 100 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 10 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 6 0 10 12 1 9 12 1 1 100 1 10 10 12 1 100 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 12 1 1 10 12 6 0 10 12 1 1 10 12 10 12 1 4 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 5 0 6 0 4 6 0 4 6 0 4 10 12 1 9 12 1 1 10 12 9 12 1 10 7 12 1 1 1 4 6 0 1 1 6 0 1 6 0 1 6 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Math negativeZeroFloatBits J -2147483648
+staticfield java/lang/Math negativeZeroDoubleBits J -9223372036854775808
+staticfield java/lang/Math $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/util/ArraysSupport 1 1 378 7 1 7 1 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 10 12 9 12 1 10 12 1 1 10 12 7 1 10 12 1 1 10 12 1 100 1 10 12 1 1 10 12 100 1 10 12 1 100 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 9 12 1 1 11 100 12 1 1 1 9 12 1 9 12 1 10 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 9 12 1 9 12 1 10 12 1 1 10 12 1 9 12 1 10 12 1 10 7 12 1 1 1 9 12 1 9 12 1 10 12 1 10 12 1 10 7 12 1 1 1 3 10 12 1 7 1 8 1 8 1 8 1 10 10 100 12 1 1 1 11 7 12 1 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 7 1 10 7 12 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+staticfield jdk/internal/util/ArraysSupport U Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield jdk/internal/util/ArraysSupport BIG_ENDIAN Z 0
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_BOOLEAN_INDEX_SCALE I 0
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_BYTE_INDEX_SCALE I 0
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_CHAR_INDEX_SCALE I 1
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_SHORT_INDEX_SCALE I 1
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_INT_INDEX_SCALE I 2
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_LONG_INDEX_SCALE I 3
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_FLOAT_INDEX_SCALE I 2
+staticfield jdk/internal/util/ArraysSupport LOG2_ARRAY_DOUBLE_INDEX_SCALE I 3
+staticfield jdk/internal/util/ArraysSupport LOG2_BYTE_BIT_SIZE I 3
+staticfield jdk/internal/util/ArraysSupport JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$2
+ciInstanceKlass java/lang/Character 1 1 604 7 1 7 1 100 1 9 12 1 1 8 1 9 12 1 1 7 1 9 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 3 3 3 3 3 10 12 1 1 10 12 1 3 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 3 10 12 1 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 10 10 12 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 10 12 10 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 10 12 1 10 10 12 1 1 10 10 12 1 10 5 0 10 12 1 10 12 1 10 10 12 1 10 10 12 1 1 10 10 12 1 10 10 12 1 9 12 1 1 100 1 10 10 12 1 10 12 1 1 3 10 100 12 1 1 1 10 12 1 10 100 12 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 9 100 12 1 1 1 10 12 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 10 12 1 1 7 1 8 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 3 1 3 1 3 1 3 1 1 1 1 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 3 1 1 3 1 1 1 1 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1
+staticfield java/lang/Character TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Character $assertionsDisabled Z 1
+ciInstanceKlass java/lang/OutOfMemoryError 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciMethod java/lang/StringLatin1 equals ([B[B)Z 738 718 7171 0 -1
+ciMethod java/lang/StringLatin1 hashCode ([B)I 508 0 5450 0 624
+ciMethod java/lang/StringLatin1 indexOf ([BIII)I 524 0 6744 0 496
+ciMethod java/lang/StringLatin1 indexOfChar ([BIII)I 328 4102 6710 0 -1
+ciMethod java/lang/StringLatin1 charAt ([BI)C 934 0 600268 0 152
+ciMethod java/lang/StringLatin1 canEncode (I)Z 782 0 42331 0 0
+ciInstanceKlass java/lang/StringUTF16 1 1 604 7 1 7 1 10 7 12 1 1 1 100 1 10 7 1 3 7 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 100 1 8 1 10 12 1 9 12 1 1 9 12 1 10 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 100 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 1 10 12 1 3 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 10 12 10 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 100 1 8 1 8 1 10 12 1 1 100 1 10 10 7 12 1 1 1 10 100 12 1 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 10 12 1 10 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 5 0 5 0 10 12 1 10 12 10 12 10 7 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1
+staticfield java/lang/StringUTF16 HI_BYTE_SHIFT I 0
+staticfield java/lang/StringUTF16 LO_BYTE_SHIFT I 8
+staticfield java/lang/StringUTF16 $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Integer 1 1 453 7 1 7 1 7 1 7 1 10 12 1 1 9 12 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 9 12 1 1 9 12 1 100 1 8 1 10 12 1 7 1 10 12 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 8 1 10 12 1 1 3 10 12 1 1 3 10 12 1 1 10 12 1 1 10 7 12 1 1 1 11 7 1 10 12 1 1 11 10 12 1 1 8 1 10 12 1 1 8 1 7 1 10 12 1 1 10 12 1 1 5 0 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 7 1 9 12 1 1 9 12 1 1 10 12 1 10 7 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 10 12 1 1 8 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 5 0 3 3 3 3 10 12 1 10 12 1 3 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 3 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Integer TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Integer digits [C 36
+staticfield java/lang/Integer DigitTens [B 100
+staticfield java/lang/Integer DigitOnes [B 100
+instanceKlass java/math/BigDecimal
+instanceKlass com/google/gson/internal/LazilyParsedNumber
+instanceKlass com/sun/jna/IntegerType
+instanceKlass java/util/concurrent/atomic/Striped64
+instanceKlass java/math/BigInteger
+instanceKlass java/util/concurrent/atomic/AtomicLong
+instanceKlass java/util/concurrent/atomic/AtomicInteger
+instanceKlass java/lang/Long
+instanceKlass java/lang/Integer
+instanceKlass java/lang/Short
+instanceKlass java/lang/Byte
+instanceKlass java/lang/Double
+instanceKlass java/lang/Float
+ciInstanceKlass java/lang/Number 1 1 37 10 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod java/lang/StringUTF16 length ([B)I 2 0 88 0 -1
+ciMethod java/lang/StringUTF16 checkIndex (I[B)V 0 0 62 0 -1
+ciMethod java/lang/StringUTF16 hashCode ([B)I 0 0 1 0 -1
+ciMethod java/lang/StringUTF16 compress ([CII)[B 1024 0 13990 0 552
+ciMethod java/lang/StringUTF16 compress ([CI[BII)I 254 6572 2568 0 -1
+ciMethod java/lang/StringUTF16 toBytes ([CII)[B 0 0 1 0 -1
+ciMethod java/lang/StringUTF16 indexOf ([BIII)I 0 0 1 0 0
+ciMethod java/lang/StringUTF16 indexOfChar ([BIII)I 2 0 1 0 -1
+ciMethod java/lang/StringUTF16 getChar ([BI)C 1024 0 11527 0 -1
+ciMethod java/lang/StringUTF16 charAt ([BI)C 0 0 11 0 0
+ciMethod java/lang/StringUTF16 checkBoundsBeginEnd (II[B)V 10 0 1 0 -1
+ciMethod java/lang/StringUTF16 indexOfSupplementary ([BIII)I 0 0 1 0 -1
+ciMethod java/lang/StringUTF16 indexOfCharUnsafe ([BIII)I 2 34 1 0 -1
+ciInstanceKlass java/lang/Thread$FieldHolder 1 1 48 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 100 1 1 1
+ciInstanceKlass java/lang/Thread$Constants 0 0 59 7 1 10 7 12 1 1 1 100 1 10 10 7 12 1 1 1 7 1 8 1 10 12 1 9 7 12 1 1 1 7 1 7 1 10 12 1 10 12 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ThreadGroup 1 1 411 10 7 12 1 1 1 9 7 12 1 1 1 8 1 9 12 1 1 7 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 18 12 1 1 11 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 11 12 1 1 11 7 12 1 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 11 12 1 11 12 1 1 100 1 10 10 12 1 100 1 10 18 12 1 1 11 7 12 1 1 1 11 12 1 1 9 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 11 12 10 12 1 1 10 12 1 1 11 7 1 9 12 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 7 1 8 1 10 8 1 10 12 1 10 12 1 8 1 9 12 1 1 9 12 1 10 100 12 1 1 1 100 9 12 1 1 7 1 9 12 1 10 12 10 12 1 1 100 10 12 9 12 1 10 12 1 100 1 10 11 12 1 1 7 1 10 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/ThreadGroup $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Thread$UncaughtExceptionHandler 1 0 16 100 1 100 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/security/AccessControlContext 1 1 374 9 7 12 1 1 1 9 12 1 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 7 1 10 12 1 11 7 12 1 1 1 11 12 1 11 12 1 11 12 1 1 7 1 11 12 1 1 10 12 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 11 100 12 1 1 1 10 7 1 100 1 8 1 10 12 1 10 12 1 1 7 1 10 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 10 7 12 1 1 1 9 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 10 7 12 1 1 1 10 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 8 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 100 1 10 12 1 10 12 1 1 100 1 10 12 1 8 1 10 12 1 10 12 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 11 10 12 1 10 12 1 1 10 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1
+instanceKlass java/lang/ThreadBuilders$BoundVirtualThread
+instanceKlass java/lang/VirtualThread
+ciInstanceKlass java/lang/BaseVirtualThread 0 0 36 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 1
+ciInstanceKlass java/lang/VirtualThread 0 0 907 9 7 12 1 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 100 1 10 12 1 9 12 1 1 18 12 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 10 12 1 10 12 1 10 12 1 10 12 1 11 100 12 1 1 1 100 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 100 1 10 10 12 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 10 12 1 9 12 1 1 9 12 1 100 1 10 10 12 1 10 100 12 1 1 10 9 10 10 12 1 1 10 12 1 1 10 100 12 1 1 10 100 1 10 9 10 10 12 1 7 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 10 12 1 10 12 1 9 12 1 1 10 12 1 10 12 1 9 12 1 1 10 12 1 10 12 1 10 12 1 11 100 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 10 100 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 9 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 7 1 9 12 1 1 10 7 12 1 1 10 9 12 1 1 18 9 100 12 1 1 1 11 100 12 1 1 1 11 100 1 11 12 10 12 1 10 12 1 1 10 12 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 11 100 12 1 1 10 12 9 100 12 1 1 1 9 12 1 10 12 1 1 9 12 1 9 12 1 9 12 1 7 1 10 10 12 1 1 10 12 1 10 12 7 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 8 1 10 10 12 1 10 12 1 10 7 12 1 1 8 1 8 1 10 9 100 12 1 1 1 10 12 1 1 10 12 1 10 10 10 12 9 12 1 10 12 1 1 9 12 1 10 12 1 1 9 12 1 10 12 1 1 18 12 1 1 18 12 1 10 7 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 1 18 12 1 10 100 12 1 1 1 100 1 10 12 1 8 1 10 12 1 8 1 10 12 1 1 8 1 8 1 10 100 12 1 1 8 1 10 12 1 8 1 8 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 18 12 1 1 18 12 1 1 5 0 9 12 1 10 12 1 18 12 1 100 1 10 12 10 7 12 1 1 10 12 1 1 7 1 8 1 10 10 12 1 10 12 1 1 10 12 1 9 12 1 8 10 12 1 1 8 8 9 12 1 8 10 12 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 15 16 15 10 12 16 15 10 12 16 16 15 10 12 16 15 10 12 16 15 10 12 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 7 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/ThreadBuilders$BoundVirtualThread 0 0 132 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 9 100 12 1 1 1 10 12 1 1 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/ContinuationScope 0 0 50 10 100 12 1 1 1 10 100 12 1 1 1 100 1 9 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/StackChunk 0 0 32 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Float 1 1 279 7 1 7 1 10 100 12 1 1 1 10 100 12 1 1 1 4 7 1 10 12 1 1 10 12 1 1 8 1 8 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 100 1 4 10 7 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 3 3 100 1 4 4 4 3 10 12 1 1 9 12 1 1 100 1 10 3 3 4 4 10 12 1 3 3 3 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 8 1 10 12 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 4 1 4 1 1 1 4 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Float TYPE Ljava/lang/Class; java/lang/Class
+staticfield java/lang/Float $assertionsDisabled Z 1
+ciMethod java/lang/Float intBitsToFloat (I)F 12 0 6 0 -1
+ciInstanceKlass java/lang/Double 1 1 290 7 1 7 1 10 100 12 1 1 1 10 12 1 1 10 7 1 10 12 1 1 10 7 12 1 1 1 6 0 8 1 10 12 1 1 8 1 10 12 1 1 8 1 6 0 10 12 1 1 100 1 5 0 5 0 8 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 1 6 0 10 7 12 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 5 0 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 6 0 1 6 0 1 6 0 1 1 1 6 0 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Double TYPE Ljava/lang/Class; java/lang/Class
+ciMethod java/lang/Double longBitsToDouble (J)D 1798 0 899 0 -1
+ciInstanceKlass java/lang/Byte 1 1 213 7 1 100 1 10 7 12 1 1 1 9 12 1 1 8 1 9 12 1 1 7 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 7 12 1 1 1 10 12 1 1 100 1 7 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 8 1 8 1 10 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 5 0 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 1 1 3 1 3 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Byte TYPE Ljava/lang/Class; java/lang/Class
+ciMethod java/lang/Byte valueOf (B)Ljava/lang/Byte; 148 0 74 0 -1
+ciInstanceKlass java/lang/Short 1 1 222 7 1 7 1 100 1 10 7 12 1 1 1 10 12 1 1 100 1 7 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 8 1 9 12 1 1 7 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 9 7 12 1 1 1 10 12 1 10 12 1 1 10 8 1 8 1 10 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 3 3 5 0 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 1 1 3 1 3 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Short TYPE Ljava/lang/Class; java/lang/Class
+ciMethod java/lang/Short valueOf (S)Ljava/lang/Short; 104 0 52 0 -1
+ciInstanceKlass java/lang/Integer$IntegerCache 1 1 100 10 7 12 1 1 1 7 1 10 7 12 1 1 1 9 7 12 1 1 1 8 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 3 10 12 1 100 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 100 1 10 10 12 1 9 12 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 100 1 1 1 1 1
+staticfield java/lang/Integer$IntegerCache high I 127
+staticfield java/lang/Integer$IntegerCache cache [Ljava/lang/Integer; 256 [Ljava/lang/Integer;
+staticfield java/lang/Integer$IntegerCache $assertionsDisabled Z 1
+ciInstanceKlass java/lang/Long 1 1 524 7 1 7 1 7 1 7 1 10 12 1 1 9 12 1 1 9 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 10 12 10 12 1 10 12 1 10 12 1 5 0 5 0 7 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 5 0 5 0 9 12 1 1 9 12 1 5 0 100 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 10 12 1 1 5 0 10 12 1 1 5 0 10 12 1 1 10 12 1 1 10 100 12 1 1 1 11 7 1 10 12 1 1 11 10 12 1 1 8 1 10 12 1 1 8 1 7 1 10 12 1 1 10 12 1 8 1 8 1 11 12 1 1 10 12 1 10 12 1 10 12 1 5 0 5 0 9 7 12 1 1 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 7 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 100 1 100 1 10 12 1 1 10 12 1 1 5 0 10 12 1 10 12 1 5 0 5 0 5 0 10 12 1 1 10 12 1 5 0 5 0 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 9 12 1 1 7 1 7 1 7 1 1 1 1 5 0 1 1 1 1 3 1 3 1 5 0 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/Long TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport 0 0 573 100 1 10 100 12 1 1 1 9 12 1 1 10 12 1 1 100 1 10 12 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 11 100 12 1 1 1 11 100 12 1 1 100 1 10 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 11 100 12 1 1 9 12 1 1 10 100 12 1 1 11 100 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorShuffle
+instanceKlass jdk/internal/vm/vector/VectorSupport$VectorMask
+instanceKlass jdk/internal/vm/vector/VectorSupport$Vector
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorPayload 0 0 32 10 100 12 1 1 1 9 100 12 1 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$Vector 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorMask 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/vector/VectorSupport$VectorShuffle 0 0 28 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciInstanceKlass jdk/internal/vm/FillerObject 0 0 16 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1
+instanceKlass java/lang/ref/PhantomReference
+instanceKlass java/lang/ref/FinalReference
+instanceKlass java/lang/ref/WeakReference
+instanceKlass java/lang/ref/SoftReference
+ciInstanceKlass java/lang/ref/Reference 1 1 190 9 7 12 1 1 1 9 7 12 1 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 7 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 8 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 7 1 100 1 10 12 9 12 1 9 12 1 100 1 10 10 12 1 10 10 7 12 1 1 7 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 7 1 1 1
+staticfield java/lang/ref/Reference processPendingLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/ref/Reference $assertionsDisabled Z 1
+instanceKlass java/io/ClassCache$CacheRef
+instanceKlass org/eclipse/sisu/inject/MildKeys$Soft
+instanceKlass org/eclipse/core/internal/registry/ReferenceMap$SoftRef
+instanceKlass sun/util/locale/provider/LocaleResources$ResourceReference
+instanceKlass sun/util/resources/Bundles$BundleReference
+instanceKlass java/util/ResourceBundle$BundleReference
+instanceKlass sun/util/locale/LocaleObjectCache$CacheEntry
+instanceKlass sun/security/util/MemoryCache$SoftCacheEntry
+instanceKlass java/lang/invoke/LambdaFormEditor$Transform
+ciInstanceKlass java/lang/ref/SoftReference 1 1 47 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1
+instanceKlass com/google/common/cache/LocalCache$WeakEntry
+instanceKlass org/eclipse/sisu/inject/MildKeys$Weak
+instanceKlass com/sun/jna/CallbackReference
+instanceKlass java/util/ResourceBundle$KeyElementReference
+instanceKlass java/util/logging/LogManager$LoggerWeakRef
+instanceKlass java/util/logging/Level$KnownLevel
+instanceKlass org/eclipse/osgi/internal/container/KeyBasedLockStore$LockWeakRef
+instanceKlass sun/nio/ch/FileLockTable$FileLockReference
+instanceKlass java/lang/ClassValue$Entry
+instanceKlass java/lang/ThreadLocal$ThreadLocalMap$Entry
+instanceKlass java/lang/WeakPairMap$WeakRefPeer
+instanceKlass jdk/internal/util/WeakReferenceKey
+instanceKlass java/util/WeakHashMap$Entry
+ciInstanceKlass java/lang/ref/WeakReference 1 1 31 10 7 12 1 1 1 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/ref/Finalizer
+ciInstanceKlass java/lang/ref/FinalReference 1 1 50 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 7 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1
+instanceKlass com/sun/jna/internal/Cleaner$CleanerRef
+instanceKlass jdk/internal/ref/PhantomCleanable
+instanceKlass jdk/internal/ref/Cleaner
+ciInstanceKlass java/lang/ref/PhantomReference 1 1 39 10 100 12 1 1 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ref/Finalizer 1 1 155 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 10 12 1 7 1 8 1 10 12 1 10 12 1 1 9 12 1 100 1 10 12 1 7 1 11 100 12 1 1 10 12 1 7 1 10 12 1 100 1 10 12 1 10 7 12 1 1 1 10 100 12 1 1 1 100 1 10 10 12 1 7 1 10 12 1 7 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 10 7 1 10 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/ref/Finalizer lock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/ref/Finalizer ENABLED Z 1
+staticfield java/lang/ref/Finalizer $assertionsDisabled Z 1
+instanceKlass com/google/gson/ReflectionAccessFilter$FilterResult
+instanceKlass com/google/gson/stream/JsonToken
+instanceKlass com/google/gson/Strictness
+instanceKlass com/google/gson/ToNumberPolicy
+instanceKlass com/google/gson/FieldNamingPolicy
+instanceKlass com/google/gson/LongSerializationPolicy
+instanceKlass org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions$LookupStrategy
+instanceKlass org/eclipse/buildship/core/internal/CoreTraceScopes
+instanceKlass org/eclipse/jdt/ls/core/internal/DiagnosticsState$ErrorLevel
+instanceKlass javax/xml/catalog/CatalogFeatures$State
+instanceKlass com/sun/org/apache/xalan/internal/utils/XMLSecurityPropertyManager$Property
+instanceKlass com/sun/org/apache/xalan/internal/utils/FeaturePropertyBase$State
+instanceKlass jdk/xml/internal/JdkProperty$ImplPropMap
+instanceKlass jdk/xml/internal/JdkXmlFeatures$XmlFeature
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate
+instanceKlass com/google/inject/spi/InjectionPoint$Position
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/Preferences$SearchScope
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/ProjectEncodingMode
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/InlayHintsParameterMode
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/CompletionGuessMethodArgumentsMode
+instanceKlass org/eclipse/jdt/ls/core/internal/handlers/CompletionMatchCaseMode
+instanceKlass org/eclipse/jdt/ls/core/internal/preferences/Preferences$FeatureStatus
+instanceKlass com/google/common/util/concurrent/AbstractFutureState$VarHandleAtomicHelperMaker
+instanceKlass java/lang/annotation/ElementType
+instanceKlass com/google/inject/internal/InternalFlags$ColorizeOption
+instanceKlass com/google/inject/internal/InternalFlags$BytecodeGenOption
+instanceKlass com/google/inject/internal/InternalFlags$NullableProvidesOption
+instanceKlass com/google/inject/internal/InternalFlags$CustomClassLoadingOption
+instanceKlass com/google/inject/internal/InternalFlags$IncludeStackTraceOption
+instanceKlass com/google/inject/Key$NullAnnotationStrategy
+instanceKlass sun/reflect/annotation/TypeAnnotation$TypeAnnotationTarget
+instanceKlass lombok/eclipse/agent/PatchDelegate$DelegateReceiver
+instanceKlass com/google/inject/Stage
+instanceKlass org/eclipse/sisu/space/BeanScanning
+instanceKlass ch/qos/logback/core/spi/FilterReply
+instanceKlass org/apache/maven/model/building/ModelProblem$Severity
+instanceKlass com/google/common/cache/LocalCache$EntryFactory
+instanceKlass com/google/common/cache/CacheBuilder$NullListener
+instanceKlass com/google/common/cache/CacheBuilder$OneWeigher
+instanceKlass com/google/common/cache/LocalCache$Strength
+instanceKlass org/eclipse/m2e/core/internal/preferences/ProblemSeverity
+instanceKlass org/eclipse/m2e/core/lifecyclemapping/model/PluginExecutionAction
+instanceKlass org/slf4j/helpers/Reporter$Level
+instanceKlass org/slf4j/helpers/Reporter$TargetChoice
+instanceKlass ch/qos/logback/classic/spi/Configurator$ExecutionStatus
+instanceKlass org/apache/felix/scr/impl/inject/field/FieldHandler$METHOD_TYPE
+instanceKlass java/security/DrbgParameters$Capability
+instanceKlass jdk/xml/internal/XMLSecurityManager$NameMap
+instanceKlass jdk/xml/internal/XMLSecurityManager$Processor
+instanceKlass jdk/xml/internal/XMLSecurityManager$Limit
+instanceKlass java/nio/file/StandardCopyOption
+instanceKlass java/math/RoundingMode
+instanceKlass java/time/format/TextStyle
+instanceKlass java/time/format/DateTimeFormatterBuilder$SettingsParser
+instanceKlass java/time/format/ResolverStyle
+instanceKlass java/time/format/SignStyle
+instanceKlass java/time/temporal/JulianFields$Field
+instanceKlass java/time/temporal/IsoFields$Unit
+instanceKlass java/time/temporal/IsoFields$Field
+instanceKlass org/apache/felix/scr/impl/inject/ValueUtils$ValueType
+instanceKlass org/apache/felix/scr/impl/manager/RegistrationManager$RegState
+instanceKlass org/apache/felix/scr/impl/manager/AbstractComponentManager$State
+instanceKlass org/osgi/util/promise/PromiseFactory$Option
+instanceKlass org/apache/felix/scr/impl/metadata/ReferenceMetadata$ReferenceScope
+instanceKlass org/apache/felix/scr/impl/metadata/ServiceMetadata$Scope
+instanceKlass org/apache/felix/scr/impl/metadata/DSVersion
+instanceKlass com/sun/org/apache/xerces/internal/impl/XMLScanner$NameType
+instanceKlass com/sun/org/apache/xerces/internal/util/Status
+instanceKlass javax/xml/catalog/CatalogFeatures$Feature
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager$Property
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLSecurityPropertyManager$State
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLSecurityManager$NameMap
+instanceKlass jdk/xml/internal/JdkProperty$State
+instanceKlass com/sun/org/apache/xerces/internal/utils/XMLSecurityManager$Limit
+instanceKlass org/apache/felix/scr/impl/logger/InternalLogger$Level
+instanceKlass sun/util/locale/provider/LocaleProviderAdapter$Type
+instanceKlass java/util/Locale$Category
+instanceKlass java/lang/StackStreamFactory$WalkerState
+instanceKlass java/lang/StackWalker$ExtendedOption
+instanceKlass java/time/zone/ZoneOffsetTransitionRule$TimeDefinition
+instanceKlass java/time/DayOfWeek
+instanceKlass java/time/Month
+instanceKlass aQute/bnd/header/Attrs$Type
+instanceKlass org/apache/aries/spifly/ProviderBundleTrackerCustomizer$DiscoveryMode
+instanceKlass org/eclipse/osgi/container/Module$StartOptions
+instanceKlass org/eclipse/osgi/container/ModuleContainerAdaptor$ContainerEvent
+instanceKlass org/eclipse/osgi/report/resolution/ResolutionReport$Entry$Type
+instanceKlass java/util/Comparators$NaturalOrderComparator
+instanceKlass org/apache/felix/resolver/PermutationType
+instanceKlass java/lang/StackWalker$Option
+instanceKlass org/eclipse/equinox/plurl/impl/PlurlImpl$SetFactories
+instanceKlass org/eclipse/osgi/container/ModuleDatabase$Sort
+instanceKlass org/eclipse/osgi/container/Module$Settings
+instanceKlass org/eclipse/osgi/container/ModuleContainerAdaptor$ModuleEvent
+instanceKlass org/eclipse/osgi/storage/ContentProvider$Type
+instanceKlass org/eclipse/osgi/container/Module$State
+instanceKlass org/osgi/service/log/LogLevel
+instanceKlass sun/util/logging/PlatformLogger$Level
+instanceKlass jdk/internal/logger/BootstrapLogger$LoggingBackend
+instanceKlass java/lang/reflect/ProxyGenerator$PrimitiveTypeInfo
+instanceKlass java/lang/annotation/RetentionPolicy
+instanceKlass java/nio/file/AccessMode
+instanceKlass java/util/stream/MatchOps$MatchKind
+instanceKlass java/nio/file/attribute/PosixFilePermission
+instanceKlass jdk/internal/icu/util/CodePointTrie$ValueWidth
+instanceKlass jdk/internal/icu/util/CodePointTrie$Type
+instanceKlass java/text/Normalizer$Form
+instanceKlass java/time/temporal/ChronoUnit
+instanceKlass java/time/temporal/ChronoField
+instanceKlass sun/security/util/DisabledAlgorithmConstraints$Constraint$Operator
+instanceKlass java/lang/System$Logger$Level
+instanceKlass sun/security/rsa/RSAUtil$KeyType
+instanceKlass sun/security/util/KnownOIDs
+instanceKlass lombok/patcher/StackRequest
+instanceKlass java/util/regex/Pattern$Qtype
+instanceKlass java/lang/invoke/MethodHandleImpl$ArrayAccess
+instanceKlass java/util/zip/ZipCoder$Comparison
+instanceKlass java/nio/file/LinkOption
+instanceKlass sun/nio/fs/WindowsPathType
+instanceKlass java/util/concurrent/TimeUnit
+instanceKlass java/nio/file/StandardOpenOption
+instanceKlass java/util/stream/Collector$Characteristics
+instanceKlass java/util/stream/StreamShape
+instanceKlass java/lang/invoke/MethodHandles$Lookup$ClassOption
+instanceKlass java/lang/invoke/VarHandle$AccessType
+instanceKlass java/lang/invoke/VarHandle$AccessMode
+instanceKlass java/lang/invoke/MethodHandleImpl$Intrinsic
+instanceKlass java/lang/invoke/LambdaForm$BasicType
+instanceKlass java/lang/invoke/LambdaForm$Kind
+instanceKlass sun/invoke/util/Wrapper
+instanceKlass java/util/stream/StreamOpFlag$Type
+instanceKlass java/util/stream/StreamOpFlag
+instanceKlass java/io/File$PathStatus
+instanceKlass java/lang/module/ModuleDescriptor$Requires$Modifier
+instanceKlass java/lang/reflect/AccessFlag$Location
+instanceKlass java/lang/reflect/AccessFlag
+instanceKlass java/lang/module/ModuleDescriptor$Modifier
+instanceKlass java/lang/reflect/ClassFileFormatVersion
+instanceKlass java/lang/Thread$State
+ciInstanceKlass java/lang/Enum 1 1 204 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 10 7 12 1 1 1 100 1 10 10 12 1 1 10 12 1 7 1 10 10 7 12 1 1 10 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 1 100 1 8 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 100 1 8 1 10 10 12 1 1 10 100 12 1 1 1 7 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 1 1 100 1 7 1 1 100 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/reflect/Method 1 1 472 9 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 8 1 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 7 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 8 1 10 12 1 10 12 1 7 1 8 1 8 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 11 7 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 11 12 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 7 12 1 1 1 7 1 100 1 100 1 10 12 1 10 12 1 1 10 12 1 100 1 8 1 10 12 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/reflect/Field 1 1 457 9 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 100 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 7 1 10 7 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 10 12 1 8 1 8 1 10 11 7 1 9 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 1 10 12 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 7 12 1 1 10 12 1 1 11 7 1 10 12 1 7 1 10 100 12 1 1 1 10 7 12 1 1 1 9 12 1 10 7 12 1 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 1 9 7 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/reflect/Parameter 0 0 243 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 11 7 12 1 1 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 8 1 8 1 10 7 12 1 1 1 10 12 1 10 12 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 8 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 10 12 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 7 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 9 12 1 100 1 10 11 12 1 1 11 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1
+ciInstanceKlass java/lang/reflect/RecordComponent 1 1 196 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 100 12 1 1 10 100 12 1 1 9 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 10 9 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 10 100 12 1 1 1 10 12 1 1 11 7 12 1 1 10 7 12 1 1 7 1 9 12 1 9 12 1 1 9 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 7 1 10 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 9 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/StringBuffer 1 1 483 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 100 12 1 1 1 10 10 12 1 1 9 12 1 1 10 100 12 1 1 10 100 1 8 10 100 12 1 1 1 8 10 12 1 8 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 7 1 10 12 100 1 8 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 10 12 10 12 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 7 1 10 12 1 9 7 12 1 1 1 9 7 1 9 12 1 1 7 1 7 1 7 1 7 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/StringBuffer serialPersistentFields [Ljava/io/ObjectStreamField; 3 [Ljava/io/ObjectStreamField;
+instanceKlass jdk/internal/loader/BuiltinClassLoader
+instanceKlass java/net/URLClassLoader
+ciInstanceKlass java/security/SecureClassLoader 1 1 102 10 7 12 1 1 1 7 1 10 12 1 9 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 7 1 10 7 1 10 12 1 7 1 10 12 1 11 7 12 1 1 1 7 1 11 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+instanceKlass org/codehaus/plexus/classworlds/realm/ClassRealm
+instanceKlass org/eclipse/equinox/launcher/Main$StartupClassLoader
+ciInstanceKlass java/net/URLClassLoader 1 1 600 10 7 12 1 1 1 7 1 10 12 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 7 1 10 12 1 9 12 1 1 10 12 1 10 10 12 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 100 1 10 7 12 1 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 11 12 1 1 7 1 11 12 1 11 7 12 1 1 10 12 1 11 12 1 11 12 1 1 11 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 1 7 1 100 1 10 12 1 1 7 1 10 10 12 1 1 10 7 12 1 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 8 1 10 12 1 1 10 10 12 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 100 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 1 11 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 7 12 1 1 1 8 1 10 12 1 1 7 1 10 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 7 1 10 7 12 1 1 9 7 12 1 1 1 10 12 1 8 1 100 1 8 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 9 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 100 1 8 1 10 100 1 10 12 1 10 7 12 1 100 1 10 12 1 10 12 1 100 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 100 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/util/jar/Manifest 1 1 339 10 7 12 1 1 1 7 1 10 9 7 12 1 1 1 7 1 10 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 1 11 12 1 1 10 12 1 1 10 100 12 1 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 11 100 1 10 12 1 10 12 1 1 11 12 1 1 10 12 1 11 12 1 1 11 100 12 1 1 1 11 7 12 1 1 11 12 1 1 100 1 10 12 1 8 1 11 12 1 7 1 10 12 1 1 11 12 1 10 12 1 10 12 1 10 7 12 1 1 1 8 1 10 12 1 1 10 9 7 12 1 1 1 10 12 1 1 10 100 12 1 10 12 1 10 12 1 9 100 12 1 1 1 8 1 10 12 1 8 1 8 1 7 1 10 12 1 10 12 1 10 12 1 1 100 1 8 1 10 12 1 1 8 1 10 10 12 1 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 11 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 11 10 12 1 11 10 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/io/ByteArrayInputStream 1 1 117 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 10 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 3 10 100 1 10 100 12 1 1 1 9 12 1 1 100 1 10 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/io/ByteArrayInputStream $assertionsDisabled Z 1
+instanceKlass java/nio/DoubleBuffer
+instanceKlass java/nio/FloatBuffer
+instanceKlass java/nio/ShortBuffer
+instanceKlass java/nio/CharBuffer
+instanceKlass java/nio/IntBuffer
+instanceKlass java/nio/LongBuffer
+instanceKlass java/nio/ByteBuffer
+ciInstanceKlass java/nio/Buffer 1 1 256 100 1 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 100 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 8 1 10 12 1 1 10 12 1 8 1 9 12 1 1 100 1 8 1 10 12 1 8 1 8 1 9 12 10 12 1 8 1 8 1 8 1 10 12 1 8 1 8 1 8 1 100 1 10 100 1 10 100 1 10 9 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 10 12 1 10 100 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 7 1 10 10 12 1 1 7 1 10 10 7 12 1 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1
+staticfield java/nio/Buffer UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield java/nio/Buffer SCOPED_MEMORY_ACCESS Ljdk/internal/misc/ScopedMemoryAccess; jdk/internal/misc/ScopedMemoryAccess
+staticfield java/nio/Buffer IOOBE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+staticfield java/nio/Buffer $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/util/Preconditions 1 1 194 10 7 12 1 1 1 11 7 12 1 1 1 11 100 12 1 1 1 7 1 100 1 10 7 12 1 1 1 10 12 1 8 1 7 1 10 7 12 1 1 1 10 12 1 1 8 1 8 1 10 7 12 1 1 7 1 10 12 1 8 1 10 7 12 1 1 1 8 1 10 12 1 1 10 12 1 1 11 12 1 8 1 8 1 11 12 1 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 7 1 10 10 12 1 1 9 12 1 1 7 1 10 9 12 1 7 1 10 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/util/Preconditions SIOOBE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+staticfield jdk/internal/util/Preconditions AIOOBE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+staticfield jdk/internal/util/Preconditions IOOBE_FORMATTER Ljava/util/function/BiFunction; jdk/internal/util/Preconditions$4
+instanceKlass java/util/Collections$CopiesList
+instanceKlass org/eclipse/osgi/internal/container/InternalUtils$CopyOnFirstWriteList
+instanceKlass org/eclipse/osgi/internal/weaving/DynamicImportList
+instanceKlass java/util/AbstractSequentialList
+instanceKlass java/util/Collections$SingletonList
+instanceKlass java/util/Vector
+instanceKlass sun/security/jca/ProviderList$ServiceList
+instanceKlass sun/security/jca/ProviderList$3
+instanceKlass java/util/Arrays$ArrayList
+instanceKlass java/util/ArrayList$SubList
+instanceKlass java/util/Collections$EmptyList
+instanceKlass java/util/ArrayList
+ciInstanceKlass java/util/AbstractList 1 1 218 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 10 12 1 1 11 100 12 1 1 1 11 12 1 1 11 12 1 10 7 12 1 1 1 10 12 1 11 12 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 11 7 1 11 7 1 10 12 1 100 1 10 12 1 10 12 1 1 7 1 100 1 10 12 1 100 1 10 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 8 1 100 1 8 1 8 1 8 1 10 7 1 11 10 10 12 1 11 12 1 10 12 1 1 8 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass java/util/List 1 1 251 10 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 1 11 12 1 1 11 100 12 1 1 11 12 1 1 11 12 1 1 10 100 12 1 1 1 7 1 7 1 10 12 1 1 100 1 10 100 12 1 1 1 11 12 1 1 11 12 1 11 12 1 100 1 10 12 1 11 12 1 1 11 12 1 1 11 12 1 10 100 12 1 1 1 9 7 12 1 1 1 7 1 10 12 10 12 1 7 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 1 1
+ciInstanceKlass java/util/SequencedCollection 1 1 109 100 1 10 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1 1 8 1
+ciInstanceKlass java/util/Collection 1 1 115 11 7 12 1 1 1 7 1 11 7 12 1 1 1 10 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 11 12 1 1 11 100 12 1 1 1 11 12 1 1 10 100 12 1 1 1 11 12 1 10 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/Iterable 1 1 62 10 7 12 1 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod java/util/List add (Ljava/lang/Object;)Z 0 0 1 0 -1
+ciMethod java/util/List iterator ()Ljava/util/Iterator; 0 0 1 0 -1
+instanceKlass com/google/common/collect/ImmutableCollection
+instanceKlass org/apache/felix/resolver/util/ArrayMap$1
+instanceKlass com/sun/jna/Structure$StructureSet
+instanceKlass java/util/AbstractMap$2
+instanceKlass java/util/TreeMap$Values
+instanceKlass java/util/IdentityHashMap$Values
+instanceKlass org/apache/felix/resolver/util/OpenHashMap$AbstractObjectCollection
+instanceKlass org/eclipse/osgi/internal/container/NamespaceList$Builder
+instanceKlass java/util/AbstractQueue
+instanceKlass java/util/LinkedHashMap$LinkedValues
+instanceKlass java/util/HashMap$Values
+instanceKlass java/util/ArrayDeque
+instanceKlass java/util/AbstractSet
+instanceKlass java/util/ImmutableCollections$AbstractImmutableCollection
+instanceKlass java/util/AbstractList
+ciInstanceKlass java/util/AbstractCollection 1 1 160 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 100 12 1 1 1 100 1 10 11 12 1 11 7 1 10 12 1 10 12 1 10 100 12 1 1 1 11 8 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod java/util/AbstractCollection <init> ()V 602 0 41675 0 80
+ciMethod java/util/AbstractList <init> ()V 284 0 25612 0 88
+ciInstanceKlass java/lang/AssertionStatusDirectives 0 0 24 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass org/eclipse/lsp4j/jsonrpc/ResponseErrorException
+instanceKlass com/google/gson/JsonParseException
+instanceKlass java/io/UncheckedIOException
+instanceKlass org/gradle/api/UncheckedIOException
+instanceKlass org/eclipse/buildship/core/internal/GradlePluginsRuntimeException
+instanceKlass com/google/inject/OutOfScopeException
+instanceKlass com/sun/jna/LastErrorException
+instanceKlass java/lang/annotation/IncompleteAnnotationException
+instanceKlass org/eclipse/text/edits/MalformedTreeException
+instanceKlass com/google/inject/CreationException
+instanceKlass com/google/inject/ConfigurationException
+instanceKlass com/google/inject/ProvisionException
+instanceKlass org/w3c/dom/DOMException
+instanceKlass org/eclipse/jdt/internal/codeassist/select/SelectionNodeFound
+instanceKlass org/eclipse/jdt/internal/core/DeltaProcessor$1FoundRelevantDeltaException
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding$DysfunctionalInterfaceException
+instanceKlass org/eclipse/jdt/internal/codeassist/complete/InvalidCursorLocation
+instanceKlass org/eclipse/jdt/internal/codeassist/complete/CompletionNodeFound
+instanceKlass org/eclipse/jdt/internal/compiler/problem/AbortCompilation
+instanceKlass org/eclipse/jdt/internal/compiler/lookup/SourceTypeCollisionException
+instanceKlass org/eclipse/jdt/internal/core/builder/MissingSourceFileException
+instanceKlass org/eclipse/jdt/internal/core/builder/ImageBuilderInternalException
+instanceKlass java/lang/NegativeArraySizeException
+instanceKlass org/eclipse/jdt/internal/core/ClasspathEntry$AssertionFailedException
+instanceKlass com/google/common/cache/CacheLoader$InvalidCacheLoadException
+instanceKlass com/google/common/util/concurrent/UncheckedExecutionException
+instanceKlass java/time/DateTimeException
+instanceKlass ch/qos/logback/core/LogbackException
+instanceKlass org/objectweb/asm/tree/UnsupportedClassVersionException
+instanceKlass java/lang/reflect/UndeclaredThrowableException
+instanceKlass org/eclipse/core/internal/events/BuildManager$JobManagerSuspendedException
+instanceKlass org/eclipse/core/internal/localstore/IsSynchronizedVisitor$ResourceChangedException
+instanceKlass java/lang/IllegalCallerException
+instanceKlass org/eclipse/core/internal/dtree/ObjectNotFoundException
+instanceKlass org/eclipse/core/internal/utils/WrappedRuntimeException
+instanceKlass org/eclipse/core/runtime/OperationCanceledException
+instanceKlass org/eclipse/equinox/internal/provisional/frameworkadmin/FrameworkAdminRuntimeException
+instanceKlass org/osgi/util/promise/FailedPromisesException
+instanceKlass org/eclipse/core/runtime/InvalidRegistryObjectException
+instanceKlass org/eclipse/core/runtime/AssertionFailedException
+instanceKlass org/osgi/service/component/ComponentException
+instanceKlass java/util/MissingResourceException
+instanceKlass org/osgi/framework/hooks/weaving/WeavingException
+instanceKlass java/util/concurrent/RejectedExecutionException
+instanceKlass java/lang/reflect/InaccessibleObjectException
+instanceKlass java/util/ConcurrentModificationException
+instanceKlass org/osgi/framework/ServiceException
+instanceKlass java/lang/TypeNotPresentException
+instanceKlass java/lang/IndexOutOfBoundsException
+instanceKlass org/eclipse/osgi/framework/util/ThreadInfoReport
+instanceKlass org/eclipse/osgi/storage/Storage$StorageException
+instanceKlass java/util/NoSuchElementException
+instanceKlass java/lang/SecurityException
+instanceKlass java/lang/invoke/WrongMethodTypeException
+instanceKlass java/lang/UnsupportedOperationException
+instanceKlass java/lang/IllegalStateException
+instanceKlass java/lang/IllegalArgumentException
+instanceKlass java/lang/ArithmeticException
+instanceKlass java/lang/NullPointerException
+instanceKlass java/lang/IllegalMonitorStateException
+instanceKlass java/lang/ArrayStoreException
+instanceKlass java/lang/ClassCastException
+ciInstanceKlass java/lang/RuntimeException 1 1 40 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/nio/DirectByteBuffer$Deallocator
+instanceKlass org/eclipse/jdt/internal/core/JavaModelManager$SecondaryTypesCache
+instanceKlass org/eclipse/m2e/core/embedder/ArtifactRepositoryRef
+instanceKlass org/eclipse/m2e/core/project/configurator/ProjectConfigurationRequest
+instanceKlass org/eclipse/m2e/core/embedder/ArtifactKey
+instanceKlass org/eclipse/m2e/core/embedder/MavenConfigurationChangeEvent
+instanceKlass org/eclipse/m2e/core/embedder/MavenSettingsLocations
+instanceKlass java/lang/reflect/Proxy$ProxyBuilder$ProxyClassContext
+instanceKlass org/eclipse/equinox/launcher/Main$Identifier
+instanceKlass sun/security/pkcs/SignerInfo$AlgorithmInfo
+instanceKlass jdk/internal/misc/ThreadTracker$ThreadRef
+instanceKlass java/security/SecureClassLoader$CodeSourceKey
+instanceKlass jdk/internal/module/ModuleReferenceImpl$CachedHash
+instanceKlass java/util/stream/Collectors$CollectorImpl
+instanceKlass jdk/internal/reflect/ReflectionFactory$Config
+instanceKlass jdk/internal/foreign/abi/UpcallLinker$CallRegs
+instanceKlass jdk/internal/foreign/abi/VMStorage
+ciInstanceKlass java/lang/Record 1 1 22 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/MethodType 1 1 780 7 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 9 7 12 1 1 8 1 10 100 12 1 1 1 9 7 1 9 7 1 10 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 7 1 8 1 10 12 1 100 1 10 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 9 12 1 11 12 1 1 7 10 12 1 1 10 12 1 1 7 1 7 1 10 7 12 1 1 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 8 1 8 1 10 12 1 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 10 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 12 1 11 12 1 1 11 12 1 10 100 12 1 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 9 12 1 1 7 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 8 1 10 7 12 1 1 1 11 12 1 1 9 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 100 1 10 12 1 1 11 100 12 1 1 18 12 1 1 11 12 1 1 18 12 1 11 12 1 100 1 11 100 12 1 1 10 12 1 100 1 10 12 1 10 100 12 1 1 10 12 1 1 9 12 1 1 9 100 12 1 1 1 10 7 12 1 1 1 9 12 1 10 100 12 1 1 10 12 1 100 10 12 1 1 10 12 1 7 1 10 10 12 1 1 7 1 7 1 9 12 1 1 7 1 7 1 7 1 1 1 5 0 1 1 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 16 16 15 10 12 16 15 10 100 12 1 1 1 1 1 7 1 1 7 1 1 100 1 100 1 1
+staticfield java/lang/invoke/MethodType internTable Ljdk/internal/util/ReferencedKeySet; jdk/internal/util/ReferencedKeySet
+staticfield java/lang/invoke/MethodType NO_PTYPES [Ljava/lang/Class; 0 [Ljava/lang/Class;
+staticfield java/lang/invoke/MethodType objectOnlyTypes [Ljava/lang/invoke/MethodType; 20 [Ljava/lang/invoke/MethodType;
+staticfield java/lang/invoke/MethodType METHOD_HANDLE_ARRAY [Ljava/lang/Class; 1 [Ljava/lang/Class;
+staticfield java/lang/invoke/MethodType serialPersistentFields [Ljava/io/ObjectStreamField; 0 [Ljava/io/ObjectStreamField;
+staticfield java/lang/invoke/MethodType $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/TypeDescriptor$OfMethod 1 0 43 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+instanceKlass java/lang/InstantiationException
+instanceKlass java/lang/IllegalAccessException
+instanceKlass java/lang/reflect/InvocationTargetException
+instanceKlass java/lang/NoSuchFieldException
+instanceKlass java/lang/NoSuchMethodException
+instanceKlass java/lang/ClassNotFoundException
+ciInstanceKlass java/lang/ReflectiveOperationException 1 1 34 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/invoke/DelegatingMethodHandle
+instanceKlass java/lang/invoke/BoundMethodHandle
+instanceKlass java/lang/invoke/DirectMethodHandle
+ciInstanceKlass java/lang/invoke/MethodHandle 1 1 733 100 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 7 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 8 1 10 7 12 1 1 1 9 12 1 1 100 1 10 9 7 12 1 1 1 9 7 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 11 12 1 10 12 1 10 12 1 1 10 100 12 1 1 100 1 11 12 1 10 100 1 11 12 1 7 1 10 12 1 11 12 1 9 100 12 1 1 1 11 12 1 1 11 100 12 1 1 1 10 12 1 1 9 12 1 11 12 1 9 12 1 9 12 1 9 12 1 11 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 8 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 10 10 7 12 1 1 10 12 1 1 100 1 7 1 8 1 8 1 10 10 12 1 1 10 12 1 10 12 1 7 1 10 100 12 1 1 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 8 1 8 1 10 7 12 1 1 9 12 1 9 12 1 1 9 12 1 1 10 12 1 7 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 11 7 12 1 1 9 12 1 10 12 1 1 9 12 1 10 12 1 8 10 12 1 1 8 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 100 1 7 1 100 1 1 100 1 1 100 1 1 1 1
+staticfield java/lang/invoke/MethodHandle FORM_OFFSET J 20
+staticfield java/lang/invoke/MethodHandle UPDATE_OFFSET J 13
+staticfield java/lang/invoke/MethodHandle $assertionsDisabled Z 1
+ciInstanceKlass java/util/concurrent/ConcurrentHashMap 1 1 1210 7 1 7 1 3 10 12 1 1 3 7 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 100 1 11 12 1 1 11 12 1 11 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 7 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 4 10 12 1 9 12 1 10 12 1 1 100 1 10 5 0 10 12 1 10 12 1 1 5 0 10 12 1 1 10 12 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 1 10 12 1 1 9 12 1 10 12 1 1 9 12 1 1 10 12 1 1 100 1 10 100 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 100 1 10 12 1 1 7 1 100 1 8 1 10 12 1 10 12 1 1 10 12 1 1 11 7 12 1 1 10 12 1 1 11 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 7 1 11 12 1 11 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 9 10 12 1 1 9 12 1 10 12 1 1 5 0 9 12 1 1 7 1 10 12 1 9 12 1 1 7 1 10 12 1 9 12 1 7 1 10 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 11 100 1 10 12 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 8 1 10 12 1 8 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 9 10 12 1 9 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 100 1 10 12 11 100 12 1 1 10 11 7 12 1 10 12 1 100 1 10 12 1 100 1 10 10 9 7 12 1 1 1 10 12 3 10 7 12 1 1 9 12 1 10 12 1 1 9 12 1 1 9 12 1 10 12 1 1 10 100 12 1 1 9 12 1 9 7 12 1 1 10 12 1 1 10 12 1 3 9 12 1 9 12 1 10 12 1 1 7 1 9 3 9 12 1 7 1 10 12 1 9 12 1 10 12 1 9 12 1 10 12 1 9 12 1 10 100 12 1 1 1 100 10 12 1 7 1 5 0 10 100 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 100 1 10 12 1 10 100 1 100 1 10 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 7 1 10 12 1 1 100 1 10 12 1 10 10 12 1 100 1 10 12 1 10 10 12 1 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 10 100 1 10 10 100 1 10 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 10 100 1 10 10 100 1 10 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 100 1 10 12 1 10 10 12 1 10 7 12 1 1 1 10 12 1 7 1 7 1 10 12 1 9 12 1 1 9 12 1 1 10 12 1 1 8 10 12 1 1 8 8 8 8 7 10 12 1 1 10 12 1 100 1 8 1 10 7 1 7 1 7 1 1 1 5 0 1 1 3 1 3 1 1 1 1 3 1 3 1 3 1 1 1 1 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/util/concurrent/ConcurrentHashMap NCPU I 12
+staticfield java/util/concurrent/ConcurrentHashMap serialPersistentFields [Ljava/io/ObjectStreamField; 3 [Ljava/io/ObjectStreamField;
+staticfield java/util/concurrent/ConcurrentHashMap U Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+staticfield java/util/concurrent/ConcurrentHashMap SIZECTL J 20
+staticfield java/util/concurrent/ConcurrentHashMap TRANSFERINDEX J 32
+staticfield java/util/concurrent/ConcurrentHashMap BASECOUNT J 24
+staticfield java/util/concurrent/ConcurrentHashMap CELLSBUSY J 36
+staticfield java/util/concurrent/ConcurrentHashMap CELLVALUE J 144
+staticfield java/util/concurrent/ConcurrentHashMap ABASE I 16
+staticfield java/util/concurrent/ConcurrentHashMap ASHIFT I 2
+instanceKlass com/google/gson/internal/LinkedTreeMap
+instanceKlass com/google/common/cache/LocalCache
+instanceKlass org/apache/felix/resolver/util/ArrayMap
+instanceKlass java/util/concurrent/ConcurrentSkipListMap
+instanceKlass org/eclipse/osgi/internal/framework/FilterImpl$DictionaryMap
+instanceKlass org/eclipse/osgi/internal/framework/FilterImpl$ServiceReferenceMap
+instanceKlass org/eclipse/osgi/internal/serviceregistry/ShrinkableValueCollectionMap
+instanceKlass java/util/Collections$SingletonMap
+instanceKlass java/util/TreeMap
+instanceKlass java/util/IdentityHashMap
+instanceKlass java/util/EnumMap
+instanceKlass java/util/WeakHashMap
+instanceKlass java/util/Collections$EmptyMap
+instanceKlass sun/util/PreHashedMap
+instanceKlass java/util/HashMap
+instanceKlass java/util/ImmutableCollections$AbstractImmutableMap
+instanceKlass java/util/concurrent/ConcurrentHashMap
+ciInstanceKlass java/util/AbstractMap 1 1 196 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 10 11 12 1 1 11 7 12 1 1 1 11 12 1 1 7 1 11 12 1 10 12 1 1 11 12 1 100 1 10 11 12 1 11 7 1 10 12 1 1 11 12 1 9 12 1 1 7 1 10 12 1 9 12 1 1 7 1 10 11 11 12 1 1 11 12 1 7 1 100 1 11 12 1 8 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1
+ciInstanceKlass java/util/concurrent/ConcurrentMap 1 1 208 11 7 12 1 1 1 10 100 12 1 1 11 12 1 1 11 100 12 1 1 1 11 7 12 1 1 1 11 12 1 1 100 1 11 12 1 11 12 1 100 1 11 100 12 1 1 1 18 12 1 11 12 1 1 11 100 12 1 1 11 12 1 1 11 100 12 1 11 12 1 1 11 12 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 11 12 15 10 100 12 1 1 1 1 1 100 1 100 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders 1 1 183 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 100 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 7 1 11 100 12 1 1 1 100 1 11 12 1 1 11 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 100 1 100 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 7 1 8 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 10 12 1 10 12 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/loader/ClassLoaders JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$2
+staticfield jdk/internal/loader/ClassLoaders BOOT_LOADER Ljdk/internal/loader/ClassLoaders$BootClassLoader; jdk/internal/loader/ClassLoaders$BootClassLoader
+staticfield jdk/internal/loader/ClassLoaders PLATFORM_LOADER Ljdk/internal/loader/ClassLoaders$PlatformClassLoader; jdk/internal/loader/ClassLoaders$PlatformClassLoader
+staticfield jdk/internal/loader/ClassLoaders APP_LOADER Ljdk/internal/loader/ClassLoaders$AppClassLoader; jdk/internal/loader/ClassLoaders$AppClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$BootClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$PlatformClassLoader
+instanceKlass jdk/internal/loader/ClassLoaders$AppClassLoader
+ciInstanceKlass jdk/internal/loader/BuiltinClassLoader 1 1 737 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 7 1 10 12 1 9 12 1 10 12 1 9 12 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 7 12 1 1 1 7 1 7 1 10 10 12 1 1 8 1 10 12 1 10 12 7 1 10 12 1 10 12 1 1 11 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 7 1 8 1 8 1 10 9 12 1 1 10 7 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 11 7 12 1 1 1 10 7 12 1 1 7 1 10 7 12 1 1 1 10 12 1 100 1 8 1 10 12 1 1 10 8 1 10 12 1 1 10 12 1 1 10 12 1 1 11 7 12 1 1 11 12 1 7 1 10 11 12 1 1 11 10 12 1 1 7 1 10 12 1 10 7 12 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 100 1 10 12 1 1 11 12 1 7 1 100 1 10 12 1 10 12 1 1 100 1 100 1 10 12 1 10 12 1 18 12 1 1 10 12 1 10 12 1 1 18 100 1 10 7 12 1 1 1 7 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 18 12 1 7 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 100 1 10 12 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 11 12 1 7 1 10 12 1 7 1 100 1 10 12 1 10 12 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 10 12 1 1 10 7 12 1 1 10 12 1 100 1 8 1 8 1 10 10 12 1 8 1 8 1 10 7 12 1 1 1 11 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 10 7 12 1 1 1 8 1 10 12 1 7 1 10 12 1 1 10 12 1 7 1 10 11 12 1 1 10 12 10 12 1 10 12 1 100 1 10 12 1 10 12 1 10 10 12 1 10 7 12 1 1 8 1 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 15 10 12 16 15 10 12 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 100 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/loader/BuiltinClassLoader packageToModule Ljava/util/Map; java/util/concurrent/ConcurrentHashMap
+staticfield jdk/internal/loader/BuiltinClassLoader $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders$AppClassLoader 1 1 119 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 7 1 8 1 10 12 10 7 12 1 1 1 10 7 12 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 7 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1
+ciInstanceKlass jdk/internal/loader/ClassLoaders$PlatformClassLoader 1 1 42 8 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 100 1 1
+ciInstanceKlass java/lang/ArithmeticException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ArrayStoreException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ClassCastException 1 1 26 10 7 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/ClassNotFoundException 1 1 96 7 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 7 1 10 12 1 9 12 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/ClassNotFoundException serialPersistentFields [Ljava/io/ObjectStreamField; 1 [Ljava/io/ObjectStreamField;
+instanceKlass java/nio/charset/UnsupportedCharsetException
+instanceKlass java/nio/charset/IllegalCharsetNameException
+instanceKlass java/lang/NumberFormatException
+ciInstanceKlass java/lang/IllegalArgumentException 1 1 35 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod java/lang/IllegalArgumentException <init> (Ljava/lang/String;)V 0 0 14 0 -1
+ciInstanceKlass java/lang/IllegalMonitorStateException 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/BootstrapMethodError 0 0 45 10 100 12 1 1 1 10 12 1 10 12 1 10 100 12 1 1 1 10 100 12 1 1 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass java/lang/ClassFormatError
+instanceKlass java/lang/UnsatisfiedLinkError
+instanceKlass java/lang/IncompatibleClassChangeError
+instanceKlass java/lang/BootstrapMethodError
+instanceKlass java/lang/NoClassDefFoundError
+ciInstanceKlass java/lang/LinkageError 1 1 31 10 7 12 1 1 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/NullPointerException 1 1 52 10 7 12 1 1 1 10 12 1 9 7 12 1 1 1 10 12 1 1 9 12 1 1 10 12 1 1 10 12 1 1 1 1 5 0 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass java/lang/NoClassDefFoundError 1 1 26 10 7 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackOverflowError 1 1 26 10 100 12 1 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/StackTraceElement 1 1 235 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 9 12 1 9 12 1 8 1 10 100 12 1 1 1 7 1 9 12 1 8 1 9 12 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 8 1 10 100 12 1 1 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 1 10 7 12 1 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 10 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 7 1 1 1 1 1 1 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/concurrent/locks/AbstractQueuedSynchronizer
+ciInstanceKlass java/util/concurrent/locks/AbstractOwnableSynchronizer 1 1 32 10 7 12 1 1 1 9 7 12 1 1 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/vm/Continuation 0 0 549 9 100 12 1 1 1 9 12 1 9 12 1 100 1 7 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 1 11 100 12 1 1 1 10 7 1 9 12 1 1 9 12 1 1 10 8 1 10 12 1 9 12 1 1 10 11 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 11 12 1 1 9 12 1 1 10 12 1 1 18 12 1 1 10 7 12 1 1 1 100 1 10 12 1 11 100 12 1 1 1 10 12 1 9 12 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 1 9 12 1 1 11 12 1 1 9 12 1 1 8 1 10 11 12 1 1 11 12 1 1 10 12 1 1 10 12 1 1 9 12 1 10 12 1 10 10 12 1 8 1 10 12 1 8 1 8 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 9 12 1 11 12 1 7 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 12 1 1 9 12 1 1 10 12 1 10 12 1 11 7 12 1 1 10 7 1 10 12 1 8 1 9 12 1 10 12 1 1 9 12 1 1 10 7 12 1 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 8 1 10 7 12 1 1 1 10 12 1 8 1 100 1 8 1 10 9 12 1 1 8 1 10 7 12 1 1 10 100 12 1 1 8 1 8 1 10 12 10 100 12 1 1 1 10 7 1 10 7 12 1 1 1 18 11 100 12 1 1 1 18 12 1 11 12 1 1 7 1 10 7 12 1 1 10 12 1 1 8 10 12 1 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 8 1 10 12 1 7 1 7 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 16 1 15 10 12 16 15 11 7 12 1 1 1 16 1 16 1 15 10 12 16 15 10 100 12 1 1 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/misc/UnsafeConstants 1 1 34 10 100 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1
+staticfield jdk/internal/misc/UnsafeConstants ADDRESS_SIZE0 I 8
+staticfield jdk/internal/misc/UnsafeConstants PAGE_SIZE I 4096
+staticfield jdk/internal/misc/UnsafeConstants BIG_ENDIAN Z 0
+staticfield jdk/internal/misc/UnsafeConstants UNALIGNED_ACCESS Z 1
+staticfield jdk/internal/misc/UnsafeConstants DATA_CACHE_LINE_FLUSH_SIZE I 0
+ciInstanceKlass java/lang/Void 1 1 31 10 7 12 1 1 1 8 1 10 7 12 1 1 1 9 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/Void TYPE Ljava/lang/Class; java/lang/Class
+ciInstanceKlass java/lang/invoke/LambdaForm 1 1 1059 7 1 100 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 9 12 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 12 1 1 9 7 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 9 12 1 1 9 12 1 9 12 1 1 10 12 1 9 12 1 10 100 12 1 1 1 10 12 1 1 7 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 10 12 1 8 1 8 1 9 12 1 9 12 1 1 10 12 1 1 10 12 1 9 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 10 100 12 1 1 1 9 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 9 12 1 7 1 10 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 10 12 1 10 12 1 1 10 12 1 1 10 10 12 1 1 10 12 1 1 7 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 8 1 10 100 12 1 1 1 10 7 12 1 1 10 12 10 12 1 1 10 12 1 1 9 12 1 8 10 12 1 1 100 1 10 12 1 1 10 12 1 9 7 12 1 1 9 7 12 1 1 1 8 1 10 100 12 1 1 10 12 1 1 7 1 7 1 10 10 12 1 1 10 12 1 1 8 1 8 1 7 1 8 1 10 12 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 10 12 1 1 8 1 8 1 8 1 7 1 8 1 7 1 8 1 7 1 8 1 10 12 1 8 1 9 10 7 12 1 1 1 10 12 1 9 12 1 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 100 10 12 1 10 12 1 9 12 1 1 10 7 12 1 1 8 1 8 1 7 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 8 1 8 1 8 1 10 12 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 9 12 1 1 8 1 10 12 1 1 9 12 1 1 10 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 7 1 10 7 12 1 1 1 9 12 1 10 12 1 10 12 1 8 1 10 12 1 9 12 1 1 7 1 10 7 12 1 1 1 8 1 100 1 10 12 1 9 12 1 9 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 9 7 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 9 12 10 12 1 10 10 12 1 9 12 1 9 9 12 1 7 9 12 1 1 10 12 1 1 9 12 1 10 12 1 10 7 1 9 1 1 1 1 3 1 3 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 100 1 1 7 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/LambdaForm DEFAULT_CUSTOMIZED Ljava/lang/invoke/MethodHandle; 
+staticfield java/lang/invoke/LambdaForm DEFAULT_KIND Ljava/lang/invoke/LambdaForm$Kind; java/lang/invoke/LambdaForm$Kind
+staticfield java/lang/invoke/LambdaForm COMPILE_THRESHOLD I 0
+staticfield java/lang/invoke/LambdaForm INTERNED_ARGUMENTS [[Ljava/lang/invoke/LambdaForm$Name; 5 [[Ljava/lang/invoke/LambdaForm$Name;
+staticfield java/lang/invoke/LambdaForm IMPL_NAMES Ljava/lang/invoke/MemberName$Factory; java/lang/invoke/MemberName$Factory
+staticfield java/lang/invoke/LambdaForm LF_identity [Ljava/lang/invoke/LambdaForm; 6 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/LambdaForm LF_zero [Ljava/lang/invoke/LambdaForm; 6 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/LambdaForm NF_identity [Ljava/lang/invoke/LambdaForm$NamedFunction; 6 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/LambdaForm NF_zero [Ljava/lang/invoke/LambdaForm$NamedFunction; 6 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/LambdaForm createFormsLock Ljava/lang/Object; java/lang/Object
+staticfield java/lang/invoke/LambdaForm DEBUG_NAME_COUNTERS Ljava/util/HashMap; 
+staticfield java/lang/invoke/LambdaForm DEBUG_NAMES Ljava/util/HashMap; 
+staticfield java/lang/invoke/LambdaForm TRACE_INTERPRETER Z 0
+staticfield java/lang/invoke/LambdaForm $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MemberName 1 1 724 7 1 7 1 100 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 9 7 12 1 1 10 12 1 7 1 7 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 8 1 10 100 12 1 1 1 7 1 10 10 12 1 1 100 1 100 1 10 12 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 8 1 9 12 1 1 3 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 7 1 8 10 12 1 1 10 12 1 1 8 1 9 7 1 8 9 7 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 8 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 8 1 8 1 7 1 10 12 1 10 100 12 1 1 1 100 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 3 10 12 1 3 10 12 1 3 3 3 3 3 3 10 12 1 3 9 12 1 10 12 1 1 3 10 12 1 10 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 10 10 12 1 10 12 1 1 10 12 1 10 10 12 1 1 10 12 1 10 12 1 10 12 1 7 1 10 10 10 12 100 1 10 10 10 12 1 1 10 12 1 1 10 10 12 1 8 10 7 1 10 12 1 10 7 1 10 12 1 10 12 1 10 12 1 10 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 1 100 1 8 1 10 7 1 10 12 1 10 12 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 7 12 1 1 1 8 1 8 1 10 12 1 8 1 10 10 10 12 1 10 12 1 8 1 8 1 10 10 12 1 8 1 10 100 12 1 1 1 8 1 100 1 10 12 1 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 100 1 10 8 1 8 1 8 1 8 1 10 12 1 7 1 100 1 7 1 10 100 1 10 7 1 10 7 12 1 1 1 9 7 12 1 1 1 7 1 7 1 1 1 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/MemberName $assertionsDisabled Z 1
+instanceKlass java/lang/invoke/VarHandleReferences$Array
+instanceKlass java/lang/invoke/VarHandleLongs$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleBooleans$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleReferences$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleByteArrayAsDoubles$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsFloats$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsChars$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsShorts$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleInts$FieldInstanceReadOnly
+instanceKlass java/lang/invoke/VarHandleByteArrayAsLongs$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleByteArrayAsInts$ByteArrayViewVarHandle
+instanceKlass java/lang/invoke/VarHandleReferences$FieldStaticReadOnly
+ciInstanceKlass java/lang/invoke/VarHandle 1 1 473 10 7 12 1 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 100 1 10 8 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 10 12 1 9 12 1 1 10 7 12 1 1 10 12 1 9 7 12 1 1 1 9 12 1 1 10 12 1 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 9 12 1 1 9 12 1 10 12 1 10 12 1 1 10 12 1 10 10 100 12 1 1 1 10 12 1 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 12 1 1 9 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 9 12 1 10 12 1 10 12 1 10 7 12 1 1 100 1 10 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 10 12 1 1 7 1 10 12 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 100 1 1 1 100 1 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1
+staticfield java/lang/invoke/VarHandle VFORM_OFFSET J 16
+staticfield java/lang/invoke/VarHandle $assertionsDisabled Z 1
+ciInstanceKlass java/util/Collections 1 1 933 10 7 12 1 1 1 11 7 12 1 1 1 7 1 11 12 1 1 7 1 10 12 1 1 10 12 1 11 12 1 1 7 1 11 12 1 1 11 12 1 1 10 12 1 11 100 12 1 1 11 12 1 1 11 12 1 10 12 1 10 12 1 10 12 11 100 12 1 1 1 10 12 1 1 11 12 1 11 12 1 1 9 12 1 1 100 1 10 10 12 1 1 10 12 1 11 100 12 1 1 1 11 12 1 1 10 12 1 11 12 1 100 1 8 1 10 12 1 11 7 12 1 1 1 11 7 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 12 1 1 7 1 10 12 1 11 7 1 100 1 10 12 1 11 7 1 7 1 10 12 1 11 100 1 100 1 10 12 1 11 7 1 7 1 10 12 1 11 100 1 100 1 10 12 1 11 7 1 11 7 1 10 12 10 11 7 1 7 1 10 12 1 11 100 1 100 1 10 11 100 1 100 1 10 12 1 11 100 1 100 1 10 12 1 7 1 10 10 12 1 7 1 10 10 12 1 100 1 10 100 1 10 100 1 10 100 1 10 10 12 1 10 7 1 10 7 1 10 100 1 10 100 1 10 12 1 10 100 12 1 1 1 100 1 100 1 10 12 1 100 1 10 12 1 100 1 10 12 1 100 1 10 12 1 100 1 10 12 1 100 1 10 100 1 10 12 1 100 1 10 12 1 100 1 10 12 1 9 7 12 1 1 1 9 100 12 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 7 1 10 12 7 1 10 7 1 10 7 1 10 7 1 10 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 7 1 10 12 1 9 7 12 1 1 1 9 7 12 1 1 1 7 1 9 12 1 1 10 12 7 1 10 7 1 10 11 7 12 1 1 11 12 1 10 12 1 11 11 12 1 11 11 12 1 8 1 7 1 10 11 100 1 10 12 1 100 1 10 100 12 1 1 1 100 1 10 12 1 7 1 10 7 1 10 7 1 10 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/util/Collections EMPTY_SET Ljava/util/Set; java/util/Collections$EmptySet
+staticfield java/util/Collections EMPTY_LIST Ljava/util/List; java/util/Collections$EmptyList
+staticfield java/util/Collections EMPTY_MAP Ljava/util/Map; java/util/Collections$EmptyMap
+instanceKlass jdk/internal/reflect/FieldAccessorImpl
+instanceKlass jdk/internal/reflect/ConstructorAccessorImpl
+instanceKlass jdk/internal/reflect/MethodAccessorImpl
+ciInstanceKlass jdk/internal/reflect/MagicAccessorImpl 1 1 16 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/DirectMethodHandleAccessor
+ciInstanceKlass jdk/internal/reflect/MethodAccessorImpl 1 1 38 10 7 12 1 1 1 10 100 12 1 1 1 100 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/MethodAccessor 1 0 17 100 1 100 1 1 1 1 100 1 100 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/SerializationConstructorAccessorImpl
+instanceKlass jdk/internal/reflect/DirectConstructorHandleAccessor$NativeAccessor
+instanceKlass jdk/internal/reflect/DirectConstructorHandleAccessor
+instanceKlass jdk/internal/reflect/NativeConstructorAccessorImpl
+ciInstanceKlass jdk/internal/reflect/ConstructorAccessorImpl 1 1 27 10 7 12 1 1 1 100 1 100 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass jdk/internal/reflect/ConstructorAccessor 1 0 16 100 1 100 1 1 1 1 100 1 100 1 100 1 1 1
+ciInstanceKlass jdk/internal/reflect/DelegatingClassLoader 1 1 18 10 7 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/CallerSensitive 1 0 17 100 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/NativeConstructorAccessorImpl 0 0 125 10 7 12 1 1 1 9 7 12 1 1 1 100 1 10 12 1 9 12 1 1 9 12 1 1 10 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 1 10 12 1 7 1 10 12 1 1 10 12 1 1 8 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 100 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/ConstantPool 1 1 142 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 8 11 7 12 1 1 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/UnsafeStaticFieldAccessorImpl 0 0 47 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 8 11 100 12 1 1 1 10 100 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/reflect/FieldAccessor 1 0 48 100 1 100 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/MethodHandleFieldAccessorImpl
+instanceKlass jdk/internal/reflect/UnsafeFieldAccessorImpl
+ciInstanceKlass jdk/internal/reflect/FieldAccessorImpl 1 1 269 10 7 12 1 1 1 9 7 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 7 1 10 10 12 1 1 10 12 1 1 8 1 10 10 12 1 100 1 8 1 10 12 1 8 1 10 12 1 8 1 10 12 1 100 1 10 12 1 1 10 8 1 10 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 8 1 10 7 12 1 1 10 12 1 1 8 1 10 12 1 1 10 100 12 1 1 1 8 1 10 12 1 8 1 8 1 8 1 8 1 10 7 12 1 1 1 8 1 8 1 8 1 10 12 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass jdk/internal/reflect/UnsafeStaticFieldAccessorImpl
+ciInstanceKlass jdk/internal/reflect/UnsafeFieldAccessorImpl 0 0 62 10 100 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 1 9 100 12 1 1 10 12 1 9 12 1 1 10 100 12 1 1 1 9 12 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/invoke/VolatileCallSite
+instanceKlass java/lang/invoke/MutableCallSite
+instanceKlass java/lang/invoke/ConstantCallSite
+ciInstanceKlass java/lang/invoke/CallSite 1 1 296 10 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 7 1 10 12 1 1 10 12 1 1 9 100 12 1 1 1 10 7 12 1 1 10 12 1 1 100 1 7 1 10 10 7 12 1 1 1 10 12 1 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 10 100 12 1 1 10 12 1 1 9 12 1 9 100 12 1 1 1 8 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 1 9 12 1 8 1 100 1 10 12 1 10 12 1 100 1 8 1 10 10 12 1 10 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 8 10 12 1 1 9 12 1 1 100 1 10 10 12 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 7 1 8 1 10 10 12 10 12 1 1 7 1 7 1 7 1 8 1 10 12 1 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 7 1 1 1
+staticfield java/lang/invoke/CallSite $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/ConstantCallSite 1 1 65 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 10 7 12 1 1 1 10 12 1 100 1 10 12 9 12 1 1 100 1 10 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/ConstantCallSite UNSAFE Ljdk/internal/misc/Unsafe; jdk/internal/misc/Unsafe
+instanceKlass java/lang/invoke/DirectMethodHandle$StaticAccessor
+instanceKlass java/lang/invoke/DirectMethodHandle$Special
+instanceKlass java/lang/invoke/DirectMethodHandle$Interface
+instanceKlass java/lang/invoke/DirectMethodHandle$Constructor
+instanceKlass java/lang/invoke/DirectMethodHandle$Accessor
+ciInstanceKlass java/lang/invoke/DirectMethodHandle 1 1 923 7 1 7 1 100 1 7 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 12 1 10 12 1 1 10 7 12 1 1 10 12 1 1 10 12 1 10 12 1 7 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 9 12 1 1 100 1 10 9 12 1 1 9 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 7 1 10 12 1 7 1 10 10 12 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 1 7 1 10 12 1 10 12 1 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 10 7 12 1 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 7 12 1 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 1 8 1 10 12 1 10 12 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 8 1 9 7 12 1 1 1 8 1 9 12 1 9 12 1 8 1 9 12 1 9 12 1 8 1 9 12 1 9 12 1 8 1 10 12 1 10 12 1 1 9 12 1 1 7 1 10 12 1 1 7 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 10 12 1 1 7 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 10 7 1 9 12 9 12 1 10 7 12 1 1 1 10 12 1 7 1 7 1 7 1 9 12 1 1 10 7 12 1 1 1 10 12 10 12 1 7 1 10 12 1 10 12 1 1 8 1 9 12 1 9 12 1 10 12 1 1 9 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 9 12 1 1 10 12 1 1 9 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 8 1 9 12 1 1 9 12 1 1 10 12 1 10 12 1 1 9 7 1 10 12 1 9 12 1 1 10 12 10 12 1 10 12 1 10 12 1 10 12 1 10 8 1 8 1 8 1 8 1 10 12 1 1 9 12 1 1 10 12 1 10 100 12 1 1 1 8 9 12 1 1 10 12 1 1 8 1 8 8 9 12 1 8 1 8 8 8 8 8 1 8 10 12 1 7 1 10 12 1 8 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 7 1 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 3 1 3 1 1 1 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield java/lang/invoke/DirectMethodHandle IMPL_NAMES Ljava/lang/invoke/MemberName$Factory; java/lang/invoke/MemberName$Factory
+staticfield java/lang/invoke/DirectMethodHandle FT_UNCHECKED_REF I 8
+staticfield java/lang/invoke/DirectMethodHandle ACCESSOR_FORMS [Ljava/lang/invoke/LambdaForm; 132 [Ljava/lang/invoke/LambdaForm;
+staticfield java/lang/invoke/DirectMethodHandle ALL_WRAPPERS [Lsun/invoke/util/Wrapper; 10 [Lsun/invoke/util/Wrapper;
+staticfield java/lang/invoke/DirectMethodHandle NFS [Ljava/lang/invoke/LambdaForm$NamedFunction; 12 [Ljava/lang/invoke/LambdaForm$NamedFunction;
+staticfield java/lang/invoke/DirectMethodHandle OBJ_OBJ_TYPE Ljava/lang/invoke/MethodType; java/lang/invoke/MethodType
+staticfield java/lang/invoke/DirectMethodHandle LONG_OBJ_TYPE Ljava/lang/invoke/MethodType; java/lang/invoke/MethodType
+staticfield java/lang/invoke/DirectMethodHandle $assertionsDisabled Z 1
+ciInstanceKlass java/lang/invoke/MutableCallSite 0 0 63 10 100 12 1 1 1 10 12 1 9 100 12 1 1 1 10 12 1 10 12 1 1 9 12 1 1 10 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/lang/invoke/VolatileCallSite 0 0 37 10 100 12 1 1 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/ResolvedMethodName 1 1 16 10 100 12 1 1 1 100 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/invoke/MethodHandleNatives 1 1 685 100 1 10 7 12 1 1 1 9 7 12 1 1 1 10 12 1 1 100 1 10 10 12 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 7 1 10 7 12 1 1 1 10 7 12 1 1 1 7 1 10 10 12 1 1 8 1 10 12 1 8 1 10 12 1 1 8 1 10 12 1 1 9 7 12 1 1 1 8 1 10 100 12 1 1 1 7 1 10 12 100 1 100 1 8 1 7 1 10 10 12 1 7 1 9 7 12 1 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 9 12 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 7 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 8 1 10 12 1 8 1 8 1 8 1 7 1 10 12 1 8 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 10 10 12 1 1 10 12 1 10 100 12 1 1 1 100 1 8 1 10 100 12 1 1 1 7 1 8 1 10 12 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 7 1 10 12 1 7 1 7 1 10 12 1 10 12 1 8 1 8 1 10 10 12 1 1 10 12 1 1 8 1 10 7 12 1 1 8 1 8 1 10 12 1 1 10 7 12 1 1 1 100 1 10 12 1 1 7 1 9 12 1 1 10 7 12 1 1 1 10 10 12 1 9 12 1 10 12 1 9 12 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 7 1 7 1 10 12 1 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 7 12 1 1 1 10 12 1 1 100 1 8 1 10 9 7 12 1 1 1 10 12 1 1 10 12 1 1 7 1 10 12 1 1 10 12 1 1 100 1 100 1 10 10 100 1 100 1 10 100 1 10 10 12 1 1 10 7 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 8 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 10 7 12 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+staticfield java/lang/invoke/MethodHandleNatives $assertionsDisabled Z 1
+ciInstanceKlass jdk/internal/foreign/abi/NativeEntryPoint 0 0 194 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 100 1 8 1 10 12 1 10 12 1 1 100 1 10 100 12 1 1 1 10 12 1 9 12 1 1 18 12 1 1 10 100 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 8 1 10 12 1 1 7 1 8 1 10 12 1 10 12 1 1 10 12 1 9 12 1 1 18 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 10 100 12 1 1 1 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 1 15 10 12 16 1 16 15 10 12 15 10 100 12 1 1 1 1 1 100 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/ABIDescriptor 0 0 55 10 100 12 1 1 1 9 100 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass jdk/internal/foreign/abi/VMStorage 0 0 91 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 1 9 12 1 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 18 12 1 18 12 1 1 18 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 8 1 15 15 15 15 15 10 100 12 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/foreign/abi/UpcallLinker$CallRegs 0 0 66 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 18 12 1 1 18 12 1 1 18 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 8 1 15 15 15 10 100 12 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass java/lang/StackWalker 1 1 271 9 7 12 1 1 1 7 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 11 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 12 1 10 12 1 10 7 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 10 7 12 1 1 1 11 12 1 1 100 1 8 1 10 10 7 12 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 18 12 1 1 100 1 8 1 10 8 1 10 12 1 1 10 100 12 1 1 1 10 12 1 1 9 7 12 1 1 11 100 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 16 15 10 12 16 1 15 10 100 12 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/lang/StackWalker DEFAULT_EMPTY_OPTION Ljava/util/EnumSet; java/util/RegularEnumSet
+staticfield java/lang/StackWalker DEFAULT_WALKER Ljava/lang/StackWalker; java/lang/StackWalker
+ciInstanceKlass java/lang/StackWalker$StackFrame 1 1 41 100 1 10 12 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+instanceKlass java/lang/LiveStackFrameInfo
+ciInstanceKlass java/lang/StackFrameInfo 1 1 142 10 7 12 1 1 1 9 7 12 1 1 1 9 7 1 9 12 1 1 11 7 12 1 1 1 9 12 1 1 11 12 1 1 10 12 1 1 10 7 12 1 1 1 10 12 1 11 12 1 11 12 1 1 11 12 1 10 12 1 1 9 12 1 1 10 12 1 1 10 7 12 1 1 10 12 1 1 11 12 1 1 9 12 1 1 10 7 1 10 12 1 9 12 1 1 10 12 1 1 100 1 8 1 10 12 1 10 7 12 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 7 1 1 1 1 1 1
+staticfield java/lang/StackFrameInfo JLIA Ljdk/internal/access/JavaLangInvokeAccess; java/lang/invoke/MethodHandleImpl$1
+ciInstanceKlass java/lang/LiveStackFrameInfo 0 0 97 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 9 12 1 9 12 1 9 12 1 1 7 1 10 12 1 1 10 12 1 8 1 10 12 1 1 8 1 8 1 8 1 10 100 1 10 12 1 100 1 10 12 1 7 1 7 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciInstanceKlass java/lang/LiveStackFrame 0 0 135 100 1 10 100 12 1 1 1 11 7 12 1 1 1 11 12 1 10 7 12 1 1 1 100 1 8 1 10 12 1 1 10 7 12 1 1 1 9 100 12 1 1 1 10 7 12 1 1 1 10 7 12 1 1 1 11 12 1 10 12 1 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 100 1 8 1 1 12 10 1 1 1 8 1 1 1 8 1 1 1 8 1 1 1 8 1 1 8 1 1 1 8 1 1 8 1
+instanceKlass java/lang/StackStreamFactory$StackFrameTraverser
+ciInstanceKlass java/lang/StackStreamFactory$AbstractStackWalker 1 1 375 7 1 7 1 3 10 7 12 1 1 1 10 7 12 1 1 10 7 12 1 1 1 9 12 1 1 10 12 1 1 9 12 1 1 9 12 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 9 7 12 1 1 1 10 12 1 1 10 12 1 9 12 1 1 10 7 12 1 1 1 10 12 1 1 9 12 1 1 9 7 12 1 1 1 7 1 10 8 1 10 12 1 1 10 12 1 8 1 10 12 1 1 10 100 12 1 1 1 100 1 8 1 10 12 1 8 1 10 12 10 7 12 1 1 9 12 1 8 1 5 0 8 1 8 1 9 12 1 1 10 12 1 1 18 12 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 10 12 1 9 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 10 12 1 10 12 1 10 12 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 7 12 1 1 1 10 12 1 10 12 1 9 12 1 8 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 7 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 15 10 100 12 1 1 1 1 1 1 1 1 100 1 100 1 1
+ciInstanceKlass jdk/internal/module/Modules 1 1 504 10 7 12 1 1 1 9 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 1 11 12 1 1 11 12 1 11 12 1 11 12 1 11 12 1 11 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 18 12 1 1 10 7 12 1 1 1 7 1 10 7 12 1 1 1 10 100 12 1 1 1 10 100 12 1 1 10 12 1 1 11 12 1 9 12 1 1 11 7 12 1 1 1 10 12 1 1 10 10 12 1 10 9 12 1 1 10 100 12 1 1 10 12 1 1 10 100 12 1 1 100 1 11 100 12 1 1 1 10 100 12 1 1 1 11 100 12 1 1 10 12 1 1 10 100 12 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 11 12 1 1 18 12 1 1 11 100 12 1 1 10 100 12 1 1 1 11 100 12 1 1 1 7 1 11 12 1 1 11 7 12 1 1 1 11 12 1 1 10 12 1 1 10 100 12 1 1 18 12 1 1 11 12 1 1 18 12 1 1 11 12 1 1 10 12 1 18 18 10 12 1 1 9 12 1 1 11 7 12 1 1 1 100 1 10 11 12 1 11 12 1 1 11 12 1 1 10 100 1 10 12 1 1 10 100 12 1 1 10 12 1 1 11 12 10 12 1 1 7 1 10 18 12 1 10 12 1 1 7 1 8 1 10 12 1 10 100 12 1 1 18 12 1 11 11 12 10 12 1 10 10 100 1 18 12 1 10 10 10 7 12 1 1 10 7 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 10 12 1 16 16 15 10 12 1 16 1 16 1 15 10 12 1 16 1 16 1 15 10 12 16 1 15 10 16 1 15 10 12 16 1 15 10 12 16 15 10 12 16 15 10 12 15 10 100 12 1 1 1 1 1 1 100 1 100 1 1
+staticfield jdk/internal/module/Modules JLA Ljdk/internal/access/JavaLangAccess; java/lang/System$2
+staticfield jdk/internal/module/Modules JLMA Ljdk/internal/access/JavaLangModuleAccess; java/lang/module/ModuleDescriptor$1
+staticfield jdk/internal/module/Modules $assertionsDisabled Z 1
+instanceKlass org/apache/maven/artifact/versioning/ComparableVersion$ListItem
+ciInstanceKlass java/util/ArrayList 1 1 509 10 7 12 1 1 1 7 1 9 7 12 1 1 1 9 12 1 100 1 7 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 9 12 1 11 7 12 1 1 1 9 12 1 1 11 12 1 1 7 10 7 12 1 1 1 9 12 1 10 12 1 10 12 1 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 100 1 7 1 10 12 1 10 10 7 12 1 1 1 10 7 12 1 1 10 12 1 100 1 10 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 10 12 1 1 7 1 10 12 1 1 10 12 1 1 10 12 1 100 1 10 11 12 1 1 11 7 12 1 1 1 11 12 1 10 12 1 10 12 1 10 12 1 1 100 1 10 12 1 1 10 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 1 11 12 1 7 1 10 100 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 10 12 1 10 100 12 1 1 1 11 100 12 1 1 1 10 12 1 100 1 8 1 10 7 1 10 12 1 7 1 10 12 1 10 12 1 1 7 1 10 12 1 10 12 1 1 11 7 12 1 1 7 1 10 12 1 10 12 1 1 11 7 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 11 100 12 1 1 10 12 1 1 7 1 7 1 7 1 1 1 1 5 0 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 1 1 1 1
+staticfield java/util/ArrayList EMPTY_ELEMENTDATA [Ljava/lang/Object; 0 [Ljava/lang/Object;
+staticfield java/util/ArrayList DEFAULTCAPACITY_EMPTY_ELEMENTDATA [Ljava/lang/Object; 0 [Ljava/lang/Object;
+ciInstanceKlass java/util/RandomAccess 1 0 7 100 1 100 1 1 1
+ciMethod java/util/ArrayList add (Ljava/lang/Object;)Z 518 0 9273 0 1360
+ciMethod java/util/ArrayList iterator ()Ljava/util/Iterator; 512 0 5856 0 200
+ciMethod java/util/ArrayList remove (I)Ljava/lang/Object; 518 0 1556 0 -1
+ciMethod java/util/ArrayList <init> ()V 182 0 10202 0 112
+ciMethod java/util/ArrayList add (Ljava/lang/Object;[Ljava/lang/Object;I)V 518 0 9273 0 -1
+ciInstanceKlass java/util/regex/Pattern 1 1 1575 7 1 10 12 1 1 9 12 1 1 9 12 1 1 10 12 1 1 7 1 10 12 1 9 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 7 1 10 12 10 12 1 10 12 1 1 10 12 1 11 7 12 1 1 1 11 12 1 1 10 12 1 1 11 12 1 7 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 11 7 12 1 1 1 7 1 8 1 10 12 1 1 7 1 10 8 1 10 12 1 1 10 10 7 1 3 10 12 1 10 12 1 8 1 10 12 1 10 100 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 7 1 9 12 1 1 10 12 1 9 12 1 9 12 1 10 7 1 100 1 8 1 10 12 1 1 10 12 1 7 1 8 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 9 12 1 100 1 10 10 7 12 1 1 1 10 12 1 1 8 1 10 12 10 12 1 10 100 12 1 1 1 10 12 1 1 9 100 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 7 12 1 1 10 12 1 100 1 10 11 100 1 10 12 1 1 8 1 18 12 1 1 11 12 1 1 10 10 12 1 1 8 1 9 12 1 10 12 1 8 1 10 12 1 10 12 10 12 1 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 7 1 8 1 10 10 10 7 12 1 1 1 10 100 12 1 1 9 12 1 9 12 1 1 10 7 12 1 1 10 12 1 100 1 8 1 10 12 1 10 12 1 10 100 12 1 1 1 10 12 1 10 12 9 12 1 9 12 1 10 12 1 10 12 1 9 12 1 7 1 9 12 1 1 9 12 1 1 10 9 12 1 1 10 12 1 1 9 7 12 1 1 10 12 1 1 9 12 1 10 12 1 8 1 8 1 8 1 7 1 10 7 12 1 1 7 1 10 7 1 7 1 9 12 1 11 12 1 1 11 7 12 1 1 11 12 1 7 1 9 12 1 7 1 10 10 12 1 1 11 7 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 12 1 3 10 12 1 1 10 12 1 7 1 10 10 7 12 1 10 12 1 10 12 10 12 1 1 100 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 100 1 10 100 1 10 10 100 1 10 12 1 7 1 10 7 1 10 12 1 1 10 10 12 1 10 12 1 8 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 100 12 1 1 1 10 12 1 100 1 10 12 1 100 1 10 10 12 1 10 12 1 10 12 1 1 100 1 10 10 7 12 1 1 10 12 1 1 9 12 1 1 11 7 12 1 1 100 1 10 10 12 1 11 7 1 10 12 1 100 1 10 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 100 1 10 100 1 10 10 12 1 8 1 10 12 1 11 12 1 8 1 8 1 10 12 1 10 12 1 10 12 1 100 1 10 8 1 7 1 10 11 12 1 1 8 1 8 1 11 12 1 8 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 10 12 1 10 12 1 8 1 10 12 1 10 12 1 1 10 12 1 10 12 1 8 1 8 1 9 100 12 1 1 1 10 12 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 10 12 1 1 10 12 1 10 12 1 1 8 1 8 1 8 1 8 1 10 12 1 1 8 1 10 12 1 10 12 1 8 1 8 1 7 1 10 12 1 8 1 10 12 1 8 1 11 10 12 1 1 100 1 10 100 1 10 7 1 9 7 12 1 1 1 10 12 1 11 12 1 8 1 8 1 10 12 1 11 12 1 1 9 7 12 1 1 1 7 1 10 10 12 1 1 9 12 1 8 1 10 12 1 1 100 1 9 12 1 9 12 1 10 12 1 100 1 10 100 1 10 7 1 10 11 11 12 1 8 1 10 12 1 8 1 8 1 10 12 1 9 12 1 9 12 1 9 12 1 7 1 9 7 1 7 1 9 12 1 9 12 1 9 12 1 9 12 1 10 12 1 9 10 12 3 11 100 1 10 7 1 10 12 1 9 9 9 12 1 8 1 10 10 9 12 1 1 10 12 1 9 12 1 10 12 1 1 7 1 10 12 1 7 1 10 12 1 10 12 1 10 12 1 1 8 1 8 1 8 1 8 1 8 1 10 12 1 10 12 1 3 8 1 8 1 8 1 8 1 10 12 1 10 12 1 10 12 10 12 1 10 12 1 1 10 12 1 8 1 10 12 1 8 1 8 1 8 1 11 100 1 10 12 1 100 1 10 100 1 10 7 1 10 100 1 10 10 9 12 1 9 12 1 10 12 1 18 12 1 1 18 12 1 18 18 18 12 1 18 12 1 18 12 18 12 18 18 12 18 18 18 12 18 12 18 12 18 3 3 18 18 12 18 18 18 12 1 1 18 7 1 10 100 1 10 7 12 1 1 1 10 7 12 1 1 1 10 12 1 1 11 12 10 7 12 1 1 10 9 12 7 1 10 7 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1 16 1 15 10 12 16 16 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 15 10 12 16 15 10 12 16 15 10 12 15 10 7 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 100 1 1
+staticfield java/util/regex/Pattern accept Ljava/util/regex/Pattern$Node; java/util/regex/Pattern$Node
+staticfield java/util/regex/Pattern lastAccept Ljava/util/regex/Pattern$Node; java/util/regex/Pattern$LastNode
+staticfield java/util/regex/Pattern $assertionsDisabled Z 1
+ciMethod java/util/regex/Pattern compile ()V 48 1292 22 0 -1
+ciMethod java/util/regex/Pattern matcher (Ljava/lang/CharSequence;)Ljava/util/regex/Matcher; 380 0 403 0 -1
+ciInstanceKlass java/util/regex/Matcher 1 1 489 10 7 12 1 1 1 7 1 9 12 1 1 9 12 1 9 12 1 9 12 1 9 12 1 9 12 1 1 9 12 1 9 12 1 1 9 12 1 1 9 7 12 1 1 10 7 12 1 1 1 9 12 1 1 9 12 1 9 12 1 9 12 1 7 1 9 12 1 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 11 7 12 1 1 1 11 12 1 1 100 1 10 12 1 10 100 12 1 1 10 12 1 1 10 12 1 11 12 1 10 12 1 100 1 8 1 10 12 1 9 12 1 9 12 1 10 12 1 9 12 1 10 12 1 9 12 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 1 100 1 8 1 10 10 7 12 1 1 1 7 1 10 10 10 12 1 1 10 12 1 1 10 10 7 1 10 12 1 10 12 1 1 10 12 1 10 10 12 1 10 8 1 11 7 12 1 1 8 1 10 100 12 1 1 10 12 1 10 12 1 8 1 8 1 10 12 1 1 8 1 10 12 1 8 1 11 7 12 1 1 1 7 1 8 1 8 1 10 12 1 8 1 10 12 1 10 12 1 11 12 1 100 1 100 1 10 12 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 10 100 12 1 1 11 100 12 1 1 100 1 10 100 1 10 12 1 100 1 10 100 12 1 1 1 10 100 12 1 1 1 100 1 8 1 10 8 8 8 1 8 1 8 1 10 12 1 1 10 12 1 8 1 10 12 1 10 12 1 10 12 1 8 1 10 12 9 12 1 9 12 1 9 12 1 1 10 7 12 1 1 9 12 1 11 8 1 10 12 1 8 1 8 1 8 1 100 1 8 1 10 10 7 1 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod java/util/regex/Matcher <init> (Ljava/util/regex/Pattern;Ljava/lang/CharSequence;)V 514 0 409 0 -1
+ciMethod java/util/regex/Matcher group (I)Ljava/lang/String; 88 0 247 0 -1
+ciMethod java/util/regex/Matcher reset ()Ljava/util/regex/Matcher; 400 8266 421 0 -1
+ciMethod java/util/regex/Matcher matches ()Z 288 0 296 0 -1
+ciMethod java/util/regex/Matcher find ()Z 1024 0 2338 0 -1
+ciMethod java/util/regex/Matcher getTextLength ()I 422 0 432 0 -1
+ciInstanceKlass java/lang/annotation/Annotation 1 0 17 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/function/BiFunction 1 1 65 10 100 12 1 1 1 18 12 1 1 11 7 12 1 1 11 100 12 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 16 15 11 12 15 10 100 12 1 1 1 1 100 1 100 1 1
+instanceKlass java/util/ArrayList$ListItr
+ciInstanceKlass java/util/ArrayList$Itr 1 1 104 9 7 12 1 1 1 10 7 12 1 1 1 9 12 1 1 9 7 12 1 1 9 12 1 9 12 1 9 12 1 10 12 1 100 1 10 9 12 1 1 100 1 10 100 1 10 10 12 1 1 100 1 10 100 12 1 1 1 10 12 1 1 11 100 12 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciMethod java/util/ArrayList$Itr remove ()V 18 0 8 0 0
+ciMethod java/util/ArrayList$Itr hasNext ()Z 512 0 7373 0 120
+ciMethod java/util/ArrayList$Itr next ()Ljava/lang/Object; 522 0 5654 0 256
+ciMethod java/util/ArrayList$Itr <init> (Ljava/util/ArrayList;)V 514 0 5862 0 0
+ciMethod java/util/ArrayList$Itr checkForComodification ()V 530 0 5664 0 0
+ciMethod java/util/Iterator remove ()V 0 0 1 0 -1
+ciInstanceKlass jdk/internal/util/Preconditions$4 1 1 61 9 7 12 1 1 1 10 7 12 1 1 1 10 100 12 1 1 1 11 100 12 1 1 1 100 1 100 1 100 1 10 12 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 1 1 1 1
+ciInstanceKlass java/util/Arrays$ArrayList 1 1 149 10 7 12 1 1 1 10 7 12 1 1 1 7 1 9 7 12 1 1 10 7 12 1 1 1 10 12 1 1 10 7 12 1 1 1 10 100 12 1 1 1 10 12 1 1 10 12 1 1 100 1 10 100 12 1 1 1 11 100 12 1 1 1 11 100 12 1 1 10 12 1 1 7 1 10 12 1 100 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/util/Collections$UnmodifiableRandomAccessList
+ciInstanceKlass java/util/Collections$UnmodifiableList 1 1 127 10 7 12 1 1 1 9 7 12 1 1 1 11 7 12 1 1 1 11 12 1 1 11 12 1 1 100 1 10 12 1 11 12 1 1 11 12 1 10 12 1 1 100 1 10 12 1 11 12 1 1 10 12 1 100 1 100 1 10 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 100 1 1 1 1 1
+ciMethod java/util/Collections$UnmodifiableList <init> (Ljava/util/List;)V 548 0 4285 0 -1
+ciInstanceKlass java/util/Collections$UnmodifiableRandomAccessList 1 1 52 10 7 12 1 1 1 7 1 9 12 1 1 11 7 12 1 1 1 10 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1
+ciMethod java/util/Collections$UnmodifiableRandomAccessList <init> (Ljava/util/List;)V 548 0 4282 0 -1
+ciInstanceKlass java/util/Collections$UnmodifiableCollection$1 1 1 71 9 7 12 1 1 1 10 7 12 1 1 1 9 7 12 1 1 1 11 7 12 1 1 1 9 12 1 1 11 7 12 1 1 1 11 12 1 1 100 1 10 11 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 1
+ciInstanceKlass java/util/regex/IntHashSet 1 1 54 10 7 12 1 1 1 9 7 12 1 1 1 9 12 1 1 9 12 1 10 7 12 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1
+ciMethod java/util/regex/IntHashSet clear ()V 0 0 1 0 -1
+ciMethod java/util/Collections unmodifiableList (Ljava/util/List;)Ljava/util/List; 548 0 1870 0 0
+ciMethod jdk/internal/util/Preconditions outOfBoundsCheckFromIndexSize (Ljava/util/function/BiFunction;III)Ljava/lang/RuntimeException; 0 0 1 0 -1
+ciMethod jdk/internal/util/Preconditions checkFromIndexSize (IIILjava/util/function/BiFunction;)I 766 0 131259 0 168
+ciMethod jdk/internal/util/Preconditions checkIndex (IILjava/util/function/BiFunction;)I 934 0 4476 0 -1
+ciMethod java/lang/Integer valueOf (I)Ljava/lang/Integer; 152 0 3181 0 0
+ciMethod java/lang/Integer <init> (I)V 528 0 900 0 0
+ciMethod java/lang/Number <init> ()V 608 0 3716 0 0
+ciMethod java/lang/Character isValidCodePoint (I)Z 0 0 1 0 -1
+ciMethod java/lang/Character lowSurrogate (I)C 0 0 1 0 -1
+ciMethod java/lang/Character highSurrogate (I)C 0 0 1 0 -1
+ciMethod java/lang/Character valueOf (C)Ljava/lang/Character; 106 0 53 0 -1
+ciMethod jdk/internal/util/ArraysSupport vectorizedHashCode (Ljava/lang/Object;IIII)I 704 0 13500 0 -1
+ciMethod java/lang/Math max (II)I 516 0 42061 0 -1
+ciMethod java/lang/Math min (II)I 512 0 94298 0 -1
+ciMethod java/util/Iterator next ()Ljava/lang/Object; 0 0 1 0 -1
+ciMethod java/util/Iterator hasNext ()Z 0 0 1 0 -1
+ciMethod java/lang/String replace (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String; 512 0 8138 0 -1
+ciMethod java/lang/String checkBoundsBeginEnd (III)V 768 0 15926 0 -1
+ciMethod java/lang/String isLatin1 ()Z 770 0 669554 0 0
+ciMethod java/lang/String checkBoundsOffCount (III)I 668 0 61724 0 160
+ciMethod java/lang/String rangeCheck ([CII)Ljava/lang/Void; 712 0 8329 0 0
+ciMethod java/lang/String coder ()B 686 0 389377 0 88
+ciMethod java/lang/String indexOf (II)I 522 0 6744 0 536
+ciMethod java/lang/String checkIndex (II)V 934 0 600929 0 120
+ciMethod java/lang/String <init> ([CII)V 242 0 8329 0 1056
+ciMethod java/lang/String <init> ([CIILjava/lang/Void;)V 922 0 8857 0 896
+ciMethod java/lang/CharSequence length ()I 0 0 1 0 -1
+ciMethod java/lang/StringBuilder append (Ljava/lang/String;)Ljava/lang/StringBuilder; 14 0 67318 0 -1
+ciMethod java/lang/StringBuilder <init> ()V 12 0 15116 0 -1
+ciMethod java/lang/StringBuilder <init> (Ljava/lang/String;)V 512 0 9948 0 -1
+ciMethod java/lang/Object getClass ()Ljava/lang/Class; 256 0 128 0 -1
+ciMethod java/lang/Object <init> ()V 1024 0 491975 0 136
+ciInstanceKlass lombok/patcher/TargetMatcher 1 0 15 100 1 100 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass lombok/patcher/MethodTarget 1 1 305 7 1 7 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 8 1 1 1 1 1 1 1 1 10 7 1 12 1 1 9 12 8 1 9 12 8 1 9 12 1 1 1 1 9 12 10 7 1 12 1 1 100 1 10 12 1 1 10 12 1 1 10 12 1 1 8 1 10 12 1 1 9 12 10 12 1 1 1 1 1 1 1 1 1 1 1 9 12 1 1 1 9 12 1 1 9 12 1 10 12 1 1 1 1 1 1 8 1 10 12 1 1 10 100 1 12 1 10 12 100 1 8 10 8 8 8 8 1 10 12 1 1 8 1 100 1 8 1 10 10 7 1 12 1 1 10 7 1 12 1 1 1 1 1 10 12 1 1 10 7 1 12 1 8 1 7 1 10 10 12 1 11 7 1 12 1 10 12 1 1 1 1 1 1 1 1 1 10 12 1 1 1 1 1 10 12 1 1 1 10 12 10 12 1 1 10 12 11 12 1 1 11 7 1 12 1 1 10 12 1 11 12 1 1 1 1 1 8 1 10 12 1 1 10 12 1 1 10 12 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 1 1 1 1 1 8 1 10 12 1 1 1 10 12 11 1 10 12 1 1 11 1 1 1 8 1 8 1 8 1 8 1 10 12 1 8 1 10 12 1 8 1 1 1
+staticfield lombok/patcher/MethodTarget PARAM_SPEC Ljava/util/regex/Pattern; java/util/regex/Pattern
+staticfield lombok/patcher/MethodTarget COMPLETE_SPEC Ljava/util/regex/Pattern; java/util/regex/Pattern
+staticfield lombok/patcher/MethodTarget BRACE_PAIRS Ljava/util/regex/Pattern; java/util/regex/Pattern
+ciInstanceKlass lombok/patcher/scripts/AddFieldScript$1 1 1 80 7 1 7 1 1 1 1 1 1 1 1 9 12 10 12 1 9 12 1 1 1 1 1 1 1 1 1 1 10 7 1 12 1 1 10 7 1 12 1 1 10 12 1 1 1 1 1 1 1 1 1 9 12 1 10 12 1 1 10 12 1 10 12 1 1 10 7 1 12 10 1 1 1 1 1 12 1 1 1
+ciInstanceKlass lombok/patcher/Hook 1 1 233 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 10 12 1 8 1 8 1 11 7 1 12 1 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 10 7 1 12 1 1 9 12 1 1 1 1 1 10 100 1 8 1 10 12 1 8 8 8 9 12 9 12 9 12 7 1 10 11 7 1 12 1 1 10 12 1 1 9 12 1 1 1 1 1 1 1 8 10 7 1 12 1 1 1 1 1 1 1 1 1 10 12 1 1 1 7 1 10 8 1 10 12 1 1 11 12 1 1 11 7 1 12 1 1 10 12 1 11 12 1 8 1 10 12 1 1 1 1 10 12 1 1 10 12 1 1 8 1 8 1 10 12 1 1 11 12 1 1 8 1 10 12 1 1 8 1 10 12 1 1 10 1 1 10 12 11 1 10 12 1 1 11 1 1 1 8 1 10 8 1 8 1 8 1 10 12 1 8 1 1 1
+staticfield lombok/patcher/Hook PRIMITIVES Ljava/util/Map; java/util/Collections$UnmodifiableMap
+instanceKlass lombok/patcher/scripts/AddFieldScript$1
+instanceKlass lombok/patcher/PatchScript$MethodPatcher
+instanceKlass org/lombokweb/asm/ClassWriter
+instanceKlass lombok/patcher/PatchScript$NoopClassVisitor
+ciInstanceKlass org/lombokweb/asm/ClassVisitor 1 1 175 1 7 1 7 1 1 100 1 100 1 1 1 1 1 1 1 1 12 10 1 1 12 10 3 3 3 3 3 3 3 1 100 1 1 1 100 10 1 8 1 1 12 10 1 12 10 1 1 12 10 12 10 1 12 10 1 100 1 1 12 10 12 9 12 9 1 1 1 1 1 3 1 100 1 8 10 12 10 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 1 1 8 12 10 1 1 8 12 10 1 1 1 12 10 1 1 1 1 12 10 1 1 1 1 1 8 12 10 1 1 1 1 1 12 10 1 1 1 1 8 12 10 1 1 1 8 12 10 1 1 1 12 10 1 1 1 1 1 8 12 10 1 1 12 10 1 1 1 1 12 10 1 1 12 10 1 1 1 1 1
+instanceKlass lombok/patcher/PatchScript$FixedClassWriter
+ciInstanceKlass org/lombokweb/asm/ClassWriter 1 1 581 1 7 1 7 1 1 100 1 100 1 1 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 3 12 10 12 9 1 7 1 12 10 1 12 10 12 9 1 12 10 1 1 1 1 1 1 12 9 12 9 3 1 1 12 10 12 9 1 1 12 10 12 9 1 1 12 10 1 7 1 12 9 12 9 12 9 12 9 12 9 1 1 1 1 1 1 1 1 1 12 9 1 7 1 12 10 3 1 1 12 10 12 9 1 1 1 1 1 100 1 12 10 1 12 10 12 9 1 1 12 9 1 1 1 12 9 1 1 12 10 12 9 1 1 1 1 12 9 1 7 1 1 12 10 12 9 1 1 1 1 12 9 1 12 10 12 9 1 1 1 1 1 12 9 1 12 9 1 1 12 9 12 9 1 1 12 10 1 1 12 9 12 9 1 1 1 12 9 1 12 9 12 9 1 1 1 1 1 1 1 100 1 12 10 12 9 12 9 1 1 12 9 1 1 1 1 7 1 12 10 12 9 12 9 1 1 12 9 1 1 1 1 1 1 7 1 12 10 12 9 12 9 1 1 12 9 1 1 1 1 1 1 1 12 10 1 12 10 1 12 9 1 8 1 8 1 8 1 8 1 8 1 8 3 1 8 1 8 1 12 10 1 8 1 8 1 8 1 12 10 1 12 10 1 12 10 1 8 1 8 1 8 3 1 12 10 1 8 10 1 12 10 1 12 10 1 12 10 1 100 1 1 12 10 1 12 10 10 3 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 9 1 1 12 10 1 1 12 10 1 12 10 1 12 10 1 12 10 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 12 10 1 100 1 12 10 1 1 12 10 12 10 1 1 1 10 1 12 10 1 1 12 10 10 10 1 12 10 1 1 1 1 1 1 12 10 1 1 1 1 12 10 1 1 1 1 1 12 10 1 1 1 1 1 12 10 1 1 1 12 10 1 1 1 1 1 12 10 1 1 1 1 1 1 12 10 1 1 1 1 12 10 1 1 1 1 12 10 1 1 1 1 100 1 1 12 10 1 100 1 1 12 10 1 100 1 1 12 10 1 100 1 12 10 1 1 12 10 12 10 1 8 1 1 12 10 1 12 10 1 1 1 1 1 1 1 1 1 1 100 1 12 10 10 1 1 1 1 1
+ciInstanceKlass lombok/patcher/PatchScript$FixedClassWriter 1 1 35 100 1 7 1 1 1 1 10 12 1 1 1 1 1 1 1 1 1 1 10 12 8 1 100 1 1 1 1 1 1 1 100 1 1
+instanceKlass lombok/patcher/scripts/SetSymbolDuringMethodCallScript$2
+ciInstanceKlass lombok/patcher/PatchScript$MethodPatcher 1 1 184 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 10 12 1 7 1 10 12 1 9 12 9 12 9 12 9 12 1 1 1 1 1 1 1 1 9 12 1 1 11 7 1 12 1 1 1 1 1 1 9 12 10 12 1 1 1 1 1 1 1 1 1 100 1 8 1 10 12 1 1 1 11 12 1 1 11 7 1 12 1 1 7 1 7 1 8 1 10 10 12 1 10 7 1 12 1 1 8 1 10 12 1 1 10 12 1 11 7 1 12 1 1 9 12 10 7 1 12 1 1 11 12 1 1 1 1 1 10 12 10 12 1 10 12 1 10 12 1 11 12 1 7 1 11 12 1 1 7 1 10 12 1 11 7 1 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass lombok/patcher/PatchScript$MethodPatcherFactory 1 0 13 100 1 100 1 1 1 1 1 1 100 1 1
+ciInstanceKlass org/lombokweb/asm/ClassReader 1 1 1073 1 7 1 7 1 1 100 1 100 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 1 12 10 1 1 1 12 10 12 9 12 9 1 1 12 10 1 100 1 1 1 100 10 1 8 1 1 12 10 1 12 10 1 1 12 10 12 10 1 12 10 1 1 12 10 12 9 1 7 12 9 10 12 9 12 9 1 100 12 9 1 1 12 10 12 9 1 1 1 1 1 1 1 1 1 1 1 100 1 1 12 10 12 10 1 1 1 1 12 10 1 1 1 8 12 10 1 100 1 1 12 10 1 1 1 100 1 8 10 1 1 12 10 1 100 10 1 100 1 1 12 10 1 12 10 1 12 10 1 12 10 10 1 1 12 10 1 1 1 1 1 1 1 1 12 10 1 100 1 1 12 10 1 1 1 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 7 1 12 10 1 1 1 1 7 10 1 1 12 9 12 9 12 9 1 12 10 1 12 10 1 12 10 1 8 1 1 12 10 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 3 1 8 1 8 1 1 12 10 1 8 1 8 1 8 3 1 8 1 8 1 8 1 8 1 1 12 10 1 1 12 9 1 7 1 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 12 9 1 1 12 9 1 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 12 10 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 12 10 1 100 1 12 10 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 10 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 100 10 10 10 10 1 1 1 1 1 1 8 1 1 12 10 1 1 12 10 1 7 10 10 10 10 1 1 1 1 1 1 1 12 9 1 12 9 1 12 9 1 8 1 8 1 8 1 8 1 8 1 8 12 10 1 1 12 10 1 7 1 1 12 10 1 1 12 10 1 12 10 1 7 1 1 12 10 1 1 12 10 1 1 12 10 1 100 10 10 10 1 1 12 10 10 1 12 10 1 1 12 10 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 12 9 1 1 12 10 1 1 12 10 1 8 1 1 12 10 1 8 1 8 1 1 12 10 1 1 12 10 1 8 1 8 1 12 9 1 12 9 1 12 9 1 12 9 1 1 12 9 1 12 9 1 12 9 1 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 7 1 1 12 10 1 1 12 10 1 12 10 1 100 10 1 12 10 1 1 12 10 1 1 12 10 1 12 9 1 12 9 1 12 9 1 1 12 10 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 10 12 10 1 1 12 9 1 1 100 1 12 10 1 12 10 1 1 1 1 1 1 1 1 3 3 3 1 1 12 10 1 1 12 10 1 1 1 1 1 1 1 100 1 1 12 10 1 12 10 1 100 1 12 10 1 100 1 12 10 1 100 1 1 12 9 1 12 9 1 12 10 1 7 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 100 1 1 12 10 1 100 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 8 1 7 1 1 12 9 1 1 12 10 1 12 9 1 12 9 1 12 9 1 12 9 1 1 12 10 1 1 1 1 1 1 1 12 10 1 1 1 1 1 1 1 1 1 1 12 9 1 12 9 1 1 1 1 1 1 12 9 1 12 10 10 1 1 1 1 1 1 1 1 1 100 1 1 12 10 5 0 1 1 1 1 1 12 10 1 1 1 1 1 1 12 10 1 1 12 10 1 1 1 7 1 12 10 1 12 10 1 7 1 12 10 1 12 10 1 12 10 1 12 10 12 10 12 10 1 1
+instanceKlass org/lombokweb/asm/AnnotationWriter
+ciInstanceKlass org/lombokweb/asm/AnnotationVisitor 1 1 98 1 100 1 100 1 1 100 1 100 1 1 1 1 1 1 1 1 12 10 1 1 12 10 3 3 3 3 3 3 3 1 100 1 1 1 100 10 1 8 1 1 12 10 1 12 10 1 1 12 10 12 10 1 12 10 1 100 1 1 12 10 12 9 12 9 1 1 1 1 1 12 10 1 1 1 1 1 1 12 10 1 1 1 12 10 1 1 12 10 1 12 10 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/AnnotationWriter 1 1 254 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 12 10 12 9 12 9 12 9 1 100 1 12 9 12 9 12 9 12 9 1 1 1 1 12 10 1 100 1 1 12 10 1 1 12 10 12 10 1 1 1 1 100 1 1 12 10 1 100 1 1 12 10 1 1 1 1 1 1 12 9 1 100 1 1 12 10 1 100 1 1 12 10 1 1 12 10 1 100 1 12 9 1 100 1 1 12 10 1 100 1 1 12 10 1 100 1 1 12 10 1 100 1 1 12 10 1 100 1 100 1 100 1 100 1 100 1 100 1 1 12 10 1 100 1 1 12 10 1 100 1 1 12 10 1 1 12 10 1 8 1 12 9 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 9 1 1 1 1 1 1 8 12 10 1 8 1 8 1 8 1 1 1 1 1 1 12 10 1 12 10 1 1 12 10 1 1 1 1 1 1 12 10 1 1 1 1 1 1 1 1 1 12 10 1 1 1 1
+instanceKlass lombok/patcher/scripts/SetSymbolDuringMethodCallScript$WrapWithSymbol
+instanceKlass lombok/patcher/scripts/ReplaceMethodCallScript$ReplaceMethodCall
+instanceKlass lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues
+instanceKlass lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly
+instanceKlass org/lombokweb/asm/MethodWriter
+ciInstanceKlass org/lombokweb/asm/MethodVisitor 1 1 262 1 7 1 7 1 1 100 1 100 1 1 1 1 8 1 1 1 1 1 1 1 12 10 1 1 12 10 3 3 3 3 3 3 3 1 100 1 1 1 100 10 1 8 1 1 12 10 1 12 10 1 1 12 10 12 10 1 12 10 1 100 1 1 12 10 12 9 12 9 1 1 1 1 1 1 100 10 12 10 1 1 1 1 12 10 1 1 12 10 1 1 1 1 1 12 10 1 1 1 1 1 12 10 1 1 1 12 10 1 1 1 12 10 1 1 1 12 10 1 1 12 10 1 1 1 1 1 1 1 12 10 1 1 1 12 10 1 1 12 10 1 1 1 12 10 1 1 12 10 1 1 1 1 12 10 1 1 8 12 10 1 1 1 12 10 1 1 1 1 1 12 10 1 1 1 1 12 10 1 1 100 1 100 1 1 12 10 1 100 1 8 12 10 1 1 1 12 10 1 1 1 12 10 1 1 1 1 1 1 1 12 10 1 1 1 12 10 1 1 12 10 1 1 12 10 1 1 1 1 12 10 1 1 12 10 1 1 1 1 12 10 1 12 10 1 1 12 10 1 1 1 12 10 1 1 1 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/MethodWriter 1 1 809 1 7 1 7 1 1 100 1 7 1 1 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 12 10 1 7 1 12 10 12 9 12 9 8 1 7 1 1 12 10 3 12 9 1 7 1 1 12 10 12 9 12 9 12 9 12 9 12 9 12 9 12 9 1 1 12 10 1 7 1 12 9 12 9 1 7 1 12 10 12 9 12 9 1 7 10 12 9 1 1 12 10 1 1 1 1 1 1 1 1 1 1 12 9 12 9 1 1 12 9 12 9 1 1 12 10 1 1 12 9 1 7 1 12 10 1 1 12 9 1 1 12 10 12 9 1 1 1 12 9 1 12 10 12 9 1 1 1 1 1 12 9 12 9 1 1 1 12 9 1 12 10 12 9 1 1 1 1 1 12 10 12 9 1 12 9 12 9 1 1 1 1 12 9 1 1 12 9 1 100 12 10 1 100 1 1 12 10 1 1 12 10 1 1 12 10 12 9 10 1 12 9 1 1 12 10 12 9 1 1 12 10 1 12 10 1 1 12 10 1 100 1 8 1 12 10 12 9 12 9 1 100 10 1 12 10 1 1 12 10 10 12 9 1 7 1 1 12 9 1 12 9 12 9 12 9 1 7 1 1 12 10 1 1 1 1 1 1 1 1 1 1 12 9 1 1 12 10 12 9 1 12 10 1 1 1 1 1 1 12 10 1 12 10 1 1 1 1 12 9 1 12 9 12 9 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 12 10 12 10 1 1 1 1 1 1 1 1 12 10 1 1 1 1 1 1 1 12 9 1 1 12 10 1 1 12 10 1 12 10 12 9 1 1 1 1 1 1 12 9 1 1 12 10 12 9 12 9 12 9 1 12 9 1 1 1 12 10 1 12 9 1 12 9 1 1 1 1 1 1 1 1 1 1 1 12 10 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 3 12 9 12 9 1 1 1 7 1 12 10 12 9 1 12 9 1 1 1 1 1 1 1 12 9 12 9 12 9 12 9 1 1 1 100 1 12 10 1 1 12 9 12 9 1 1 1 12 10 1 12 10 1 12 9 1 8 1 1 12 10 1 12 9 1 12 9 1 12 9 1 100 1 1 12 9 1 12 10 1 12 9 1 12 9 1 12 10 1 12 9 1 12 9 1 1 12 10 1 12 9 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 3 1 1 12 10 1 12 9 1 12 10 1 12 9 1 1 1 1 1 1 1 1 1 1 1 12 10 1 12 10 1 1 1 1 12 10 1 7 1 12 10 1 12 10 1 1 1 1 12 10 3 1 7 1 1 12 10 1 1 1 1 1 1 1 1 12 9 12 9 1 1 1 3 1 100 1 1 12 10 1 12 10 1 8 1 1 12 10 1 8 1 8 1 8 1 8 1 8 1 8 1 12 10 1 8 1 1 12 10 1 8 1 12 10 1 12 10 1 8 1 1 12 10 1 8 1 8 1 8 1 12 10 1 1 1 12 9 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 10 1 12 10 1 1 1 1 1 1 1 1 1 12 10 1 1 1 1 1 1
+staticfield org/lombokweb/asm/MethodWriter STACK_SIZE_DELTA [I 202
+ciInstanceKlass org/lombokweb/asm/SymbolTable 1 1 638 1 7 1 7 1 1 7 1 1 100 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 12 9 12 9 12 9 12 9 1 7 10 12 9 1 1 1 1 7 1 1 12 9 1 1 12 10 1 12 9 1 1 12 10 1 12 10 1 1 12 10 1 12 10 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 100 10 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 8 1 7 1 1 12 10 12 9 12 9 1 1 12 10 1 12 10 3 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 12 9 1 1 12 9 1 1 1 1 12 10 1 7 1 12 9 1 1 1 12 9 1 1 1 1 12 10 1 12 9 1 1 1 12 10 1 1 12 10 1 1 1 1 12 9 12 9 1 1 12 9 1 1 1 1 1 1 1 1 1 1 7 1 12 10 1 1 12 10 1 7 10 1 7 1 1 12 10 1 7 10 1 7 1 1 12 10 1 7 1 1 12 10 1 1 12 10 1 7 1 1 12 10 1 1 12 10 1 7 1 1 12 10 1 1 12 10 1 12 10 1 7 1 12 10 1 12 10 1 12 10 1 12 10 1 7 1 12 10 1 12 10 1 12 10 1 12 10 1 12 10 1 12 10 1 100 10 10 1 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 1 1 100 10 1 8 1 1 12 10 1 12 10 12 10 1 12 10 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 12 10 1 1 1 1 1 1 1 1 12 10 12 10 12 9 12 9 12 9 12 9 1 12 10 1 1 12 10 1 12 10 12 10 1 12 10 1 1 12 10 1 1 12 10 1 12 9 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 1 12 10 1 12 10 9 12 10 12 10 1 1 12 10 1 12 10 1 1 12 10 1 12 10 12 10 1 12 10 12 10 1 1 1 1 12 10 1 12 10 1 1 1 1 1 1 1 12 10 1 1 1 1 1 1 1 12 10 12 10 10 1 12 10 1 1 1 1 1 1 1 1 1 1 12 9 1 1 1 12 9 1 1 12 9 1 12 9 1 1 12 10 1 1 1 12 10 1 12 10 1 1 1 1 1 12 10 9 1 1 1 12 9 1 100 1 1 12 10 12 10 1 1 1 1 1 1 100 1 1 12 10 1 12 9 1 1 12 10 1 12 9 12 9 1 12 10 1 1 1 10 1 1 1 1 1 1 1 1 1
+instanceKlass org/lombokweb/asm/SymbolTable$Entry
+ciInstanceKlass org/lombokweb/asm/Symbol 1 1 93 1 7 1 7 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 12 10 12 9 12 9 12 9 12 9 12 9 12 9 1 1 1 1 12 9 1 7 1 12 10 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/SymbolTable$Entry 1 1 38 1 7 1 7 1 1 100 1 1 1 1 1 1 1 1 12 10 12 9 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/ByteVector 1 1 107 1 7 1 7 1 1 1 1 1 1 1 12 10 12 9 1 1 1 1 1 12 9 1 1 1 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 7 12 10 3 1 100 1 8 1 12 10 1 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 1 7 1 1 12 10 1 1 1 100 1 8 1 12 10 1 1 1 1 1 1 1
+ciInstanceKlass java/util/NoSuchElementException 0 0 34 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass java/lang/StringIndexOutOfBoundsException
+instanceKlass org/objectweb/asm/MethodTooLargeException
+instanceKlass org/objectweb/asm/ClassTooLargeException
+instanceKlass org/lombokweb/asm/MethodTooLargeException
+instanceKlass org/lombokweb/asm/ClassTooLargeException
+instanceKlass java/lang/ArrayIndexOutOfBoundsException
+ciInstanceKlass java/lang/IndexOutOfBoundsException 0 0 49 10 100 12 1 1 1 10 12 1 100 1 10 8 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/lang/AssertionError 0 0 79 10 100 12 1 1 1 10 12 1 10 100 12 1 1 1 10 100 1 100 1 10 12 1 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 10 12 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+instanceKlass org/eclipse/m2e/core/internal/project/registry/StaleMutableProjectRegistryException
+instanceKlass java/util/concurrent/CancellationException
+instanceKlass java/nio/channels/OverlappingFileLockException
+ciInstanceKlass java/lang/IllegalStateException 1 0 35 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass lombok/patcher/scripts/ExitFromMethodEarlyScript$1 1 1 90 7 1 7 1 100 1 1 1 1 1 1 1 1 9 12 9 12 10 12 1 1 1 1 1 1 1 10 7 1 12 1 1 10 12 1 1 10 7 1 12 1 1 100 1 100 1 8 1 10 12 1 10 12 1 1 8 1 8 1 10 12 1 1 10 7 1 10 12 1 1 1 1 1 1 1 1 1 1 12 1 1 1 100 1 100 1 1 1 1
+ciInstanceKlass lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1 1 160 7 1 7 1 1 1 1 1 1 1 1 1 1 9 12 3 10 12 1 9 12 9 12 1 1 1 1 1 1 1 1 10 7 1 12 1 1 10 7 1 12 1 1 9 12 10 12 1 1 10 12 1 10 12 1 1 9 7 1 12 1 1 11 7 1 12 1 1 10 12 1 1 9 12 1 1 11 7 1 12 1 1 11 7 1 12 1 1 10 12 1 10 12 1 11 12 1 1 10 12 1 1 10 12 1 1 10 12 1 10 7 1 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 7 1 10 12 10 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 1 1 1 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/Attribute 1 1 155 1 100 1 100 1 1 100 1 1 1 1 1 1 1 1 1 1 12 10 12 9 1 1 1 1 1 1 1 1 100 1 1 12 10 1 7 1 100 1 1 12 10 1 12 10 12 9 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 12 10 1 1 1 1 12 10 1 1 1 1 1 1 1 1 12 10 12 9 1 12 9 1 100 1 1 12 10 1 1 1 1 12 9 1 1 1 1 12 10 1 1 1 7 12 9 1 1 12 10 1 1 1 12 10 1 8 1 8 3 1 8 1 1 1 1 1 12 10 1 1 1 12 10 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/Context 1 1 43 1 100 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 1 1 1
+instanceKlass org/lombokweb/asm/CurrentFrame
+ciInstanceKlass org/lombokweb/asm/Frame 0 0 504 1 100 1 100 1 1 100 1 100 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 3 1 3 1 3 1 1 3 1 3 1 3 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 12 9 1 1 1 1 12 9 12 9 12 9 12 9 12 9 12 9 12 9 12 9 1 1 1 1 100 1 1 12 10 1 100 1 100 1 1 12 10 1 1 12 10 1 1 12 10 1 100 1 12 9 1 8 1 12 9 1 100 1 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 12 10 1 12 10 1 1 12 10 1 100 1 12 10 1 1 1 100 10 1 8 1 1 12 10 1 12 10 12 10 1 12 10 1 1 8 12 10 1 1 1 1 1 1 3 1 12 10 1 1 12 10 1 1 1 1 1 1 1 1 12 10 1 100 1 12 9 12 9 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 12 10 1 100 1 1 12 10 1 1 1 1 1 12 9 1 1 1 1 1 12 10 12 10 1 1 1 1 12 10 12 10 1 1 1 1 1 1 1 3 1 1 12 10 1 100 1 12 9 1 1 1 1 1 1 12 9 1 8 8 1 8 1 8 12 10 1 100 10 12 10 12 10 12 10 1 8 12 10 1 12 9 12 10 3 3 3 3 3 3 3 3 10 1 1 8 12 10 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 12 10 1 12 10 1 1 1 1 1 3 1 12 10 8 1 12 10 1 1 1 1 1 1 1 1 1 1 1 1 100 1 1 12 10 1 12 10 1 12 10 1 1 1 1 1 1 1 1 1 1 1 100 1 1 12 10 1 1 12 10 1 12 9 1 12 10 1 1 12 9 1 1 12 10 1 1 12 10 1 12 10 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/Type 1 1 379 1 7 1 7 1 1 100 1 100 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 8 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 12 9 12 9 12 9 12 9 1 1 1 1 7 1 1 12 10 1 1 12 10 1 1 1 1 100 1 1 12 10 1 100 1 1 12 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 9 12 9 1 100 10 1 1 12 10 12 10 1 1 1 1 1 1 12 10 1 1 1 1 1 1 12 10 1 1 1 1 1 12 10 1 1 1 1 12 10 12 10 1 1 1 1 1 12 10 1 1 1 1 1 1 12 10 1 12 10 1 1 12 10 1 1 12 10 1 7 1 12 10 1 1 1 1 1 1 1 100 1 1 12 10 12 10 1 1 1 1 1 1 12 10 1 12 10 1 12 10 1 100 1 1 1 100 10 1 8 1 1 12 10 1 12 10 12 10 1 12 10 1 1 1 1 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 1 8 12 10 12 10 10 1 8 1 1 12 10 1 1 12 10 1 1 1 1 1 12 10 1 1 8 1 8 12 10 1 1 12 10 1 1 12 10 1 100 10 1 8 1 1 1 12 10 1 1 12 10 1 1 12 10 1 12 10 12 10 1 1 1 1 1 1 1 12 10 1 1 1 1 1 1 100 10 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+staticfield org/lombokweb/asm/Type VOID_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type BOOLEAN_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type CHAR_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type BYTE_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type SHORT_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type INT_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type FLOAT_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type LONG_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+staticfield org/lombokweb/asm/Type DOUBLE_TYPE Lorg/lombokweb/asm/Type; org/lombokweb/asm/Type
+ciInstanceKlass org/lombokweb/asm/Label 1 1 231 1 7 1 7 1 1 100 1 100 1 1 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 3 1 1 3 1 3 1 3 1 3 1 3 1 3 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 12 9 1 100 1 8 1 12 10 12 9 1 1 12 9 1 100 1 12 9 1 1 12 9 12 9 1 7 1 1 12 10 1 1 1 1 1 7 1 1 12 10 3 1 1 12 10 1 1 1 1 1 1 1 1 7 1 12 9 1 1 12 10 1 1 12 10 1 12 10 1 1 1 1 1 1 12 9 1 1 1 1 1 1 1 1 12 9 1 1 1 1 1 1 1 12 9 12 9 12 9 1 1 12 10 1 1 1 1 100 12 9 12 9 1 12 9 1 12 10 1 1 1 1 12 9 1 1 1 1 1 1 1 1 12 10 1 1 1 100 10 1 8 1 1 12 10 1 12 10 12 10 12 10 1 10 1 1 1 1 1 1
+staticfield org/lombokweb/asm/Label EMPTY_LIST Lorg/lombokweb/asm/Label; org/lombokweb/asm/Label
+ciInstanceKlass lombok/patcher/MethodLogistics 1 1 169 7 1 7 1 1 1 1 1 1 1 1 1 1 1 1 1 1 10 12 1 9 12 10 7 1 12 1 1 11 7 1 12 1 1 11 7 1 12 1 1 7 1 10 12 1 1 9 12 10 12 1 9 12 7 1 10 10 7 1 12 1 1 11 12 1 1 10 12 1 11 12 1 1 10 7 1 12 1 1 9 12 9 12 9 12 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 11 12 1 1 1 11 12 1 1 10 12 1 10 7 1 12 1 1 1 1 1 1 10 12 10 12 1 1 1 1 1 1 1 1 10 12 1 1 100 1 8 1 10 12 1 100 1 100 1 8 1 10 10 12 1 1 10 12 1 1 10 1 1
+ciInstanceKlass lombok/patcher/scripts/WrapReturnValuesScript$1 1 1 54 7 1 7 1 100 1 1 1 1 1 1 1 1 9 12 9 12 10 12 1 1 1 1 1 1 1 7 1 10 12 1 1 1 1 1 1 1 1 1 1 100 1 12 1 1 1 100 1 100 1 1 1 1
+ciInstanceKlass lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 1 1 155 7 1 7 1 1 1 1 1 1 1 1 1 1 1 9 12 3 10 12 1 9 12 9 12 10 7 1 12 1 1 9 12 1 1 1 1 1 1 1 1 1 10 7 1 12 1 1 10 12 10 12 1 1 9 7 1 12 1 1 11 7 1 12 1 1 10 12 1 1 9 12 10 12 1 1 10 12 1 9 12 1 10 12 1 9 12 1 1 11 7 1 12 1 1 11 7 1 12 1 1 10 12 1 10 12 1 11 12 1 1 10 12 1 10 12 1 1 10 12 1 1 10 12 1 10 7 1 12 1 1 10 12 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1
+ciInstanceKlass org/lombokweb/asm/Handle 1 1 93 1 7 1 7 1 1 100 1 100 1 1 1 1 1 1 1 1 1 1 1 1 1 12 10 1 1 1 12 10 12 9 12 9 12 9 12 9 12 9 1 1 1 1 1 1 1 1 1 1 7 12 10 1 1 1 1 12 10 1 1 8 1 8 1 1 1 100 10 1 1 12 10 1 8 1 8 1 12 10 1 8 12 10 12 10 1 1 1 1 1 1 1
+ciInstanceKlass lombok/patcher/scripts/ReplaceMethodCallScript$ReplaceMethodCall 1 1 134 7 1 7 1 1 1 1 1 1 1 1 1 1 9 12 3 10 12 1 9 12 9 12 1 1 1 1 1 1 1 1 10 7 1 12 1 1 10 7 1 12 1 1 10 7 1 12 1 1 10 12 1 10 12 1 10 12 1 1 9 7 1 12 1 1 11 7 1 12 1 9 12 10 7 1 12 1 1 9 12 1 1 11 7 1 12 1 1 11 7 1 12 1 1 10 12 1 1 10 12 1 11 12 1 1 10 12 1 1 10 12 1 10 12 1 1 10 12 1 10 12 1 1 1 1 1 1 1 1 1 1 1 1
+ciInstanceKlass java/util/ConcurrentModificationException 0 0 34 10 100 12 1 1 1 10 12 1 10 12 1 10 12 1 100 1 1 1 1 5 0 1 1 1 1 1 1 1 1 1 1 1
+ciMethodData java/lang/Object <init> ()V 2 491463 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 4 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/String isLatin1 ()Z 2 669169 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 18 0x30007 0x0 0x58 0xa35f1 0x80000006000a0007 0x8 0x38 0xa35ed 0xe0003 0xa35ed 0x18 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/String hashCode ()I 2 6781 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 42 0x60007 0x158f 0x108 0x4ee 0xd0007 0x3 0xe8 0x4eb 0x110005 0x4eb 0x0 0x0 0x0 0x0 0x0 0x140007 0x0 0x48 0x4eb 0x1b0002 0x4eb 0x1e0003 0x4eb 0x28 0x250002 0x0 0x2a0007 0x4ea 0x38 0x1 0x320003 0x1 0x18 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0xe oops 0 methods 0
+ciMethodData java/lang/StringLatin1 hashCode ([B)I 2 5196 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 25 0x20008 0x6 0x1447 0x70 0x1 0x40 0x4 0x58 0x1d0003 0x1 0x40 0x270003 0x4 0x28 0x300002 0x1447 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0xffffffffffffffff oops 0 methods 0
+ciMethodData java/lang/String equals (Ljava/lang/Object;)Z 2 7732 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 49 0x20007 0x1a93 0x20 0x3a1 0x80104 0x0 0x0 0x13a1b7a9048 0x1a92 0x0 0x0 0xb0007 0x1 0xe0 0x1a92 0xf0004 0x0 0x0 0x13a1b7a9048 0x1a92 0x0 0x0 0x160007 0x0 0x40 0x1a92 0x210007 0x0 0x68 0x1a92 0x2c0002 0x1a92 0x2f0007 0x19b4 0x38 0xde 0x330003 0xde 0x18 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 2 7 java/lang/String 18 java/lang/String methods 0
+ciMethodData java/util/AbstractCollection <init> ()V 2 41374 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 7 0x10002 0xa19e 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/String coder ()B 2 389051 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 14 0x30007 0x0 0x38 0x5efbb 0xa0003 0x5efbc 0x18 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/String length ()I 2 307707 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 16 0x60005 0x4b1fb 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0xffffffffffffffff oops 0 methods 0
+ciMethodData java/lang/String charAt (I)C 2 599810 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 25 0x10005 0x92702 0x0 0x0 0x0 0x0 0x0 0x40007 0x1 0x30 0x92702 0xc0002 0x92702 0x150002 0x1 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringLatin1 charAt ([BI)C 2 599829 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 12 0x30002 0x92715 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/String checkIndex (II)V 2 600554 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 12 0x50002 0x929ea 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringUTF16 charAt ([BI)C 1 11 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 14 0x20002 0xb 0x70002 0xb 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringUTF16 length ([B)I 1 87 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 6 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/StringLatin1 canEncode (I)Z 2 41940 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 11 0x8000000600040007 0x4 0x38 0xa3d2 0x80003 0xa3d2 0x18 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/String indexOf (II)I 2 6483 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 43 0x10005 0x1953 0x0 0x0 0x0 0x0 0x0 0x40007 0x1 0x80 0x1953 0xe0005 0x1953 0x0 0x0 0x0 0x0 0x0 0x110002 0x1953 0x140003 0x1953 0x60 0x1e0005 0x1 0x0 0x0 0x0 0x0 0x0 0x210002 0x1 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0xffffffffffffffff 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringLatin1 indexOf ([BIII)I 2 6482 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 28 0x10002 0x1952 0x40007 0x1952 0x20 0x0 0xb0002 0x1952 0x120002 0x1952 0x180007 0x1931 0x20 0x21 0x210002 0x1931 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringUTF16 indexOf ([BIII)I 1 1 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 28 0x20002 0x1 0xb0002 0x1 0x110007 0x1 0x20 0x0 0x190007 0x0 0x30 0x1 0x200002 0x1 0x280002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/String checkBoundsOffCount (III)I 2 61390 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 13 0x60002 0xefce 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData jdk/internal/util/Preconditions checkFromIndexSize (IIILjava/util/function/BiFunction;)I 2 130876 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 22 0x50007 0x0 0x40 0x1ff3c 0xc0007 0x1ff3c 0x30 0x0 0x130002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/String <init> ([CII)V 2 8208 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 16 0x70002 0x2010 0xa0002 0x2010 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/String rangeCheck ([CII)Ljava/lang/Void; 2 7973 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 13 0x40002 0x1f25 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/String <init> ([CIILjava/lang/Void;)V 2 8396 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 31 0x10002 0x20cc 0x50007 0x20bb 0x20 0x11 0x1e0007 0x0 0x50 0x20bb 0x240002 0x20bb 0x2b0007 0x1 0x20 0x20ba 0x430002 0x1 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x5 0xc 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringUTF16 compress ([CII)[B 2 13478 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 17 0x90002 0x34a7 0xd0007 0x1 0x20 0x34a6 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 0 methods 0
+ciMethod java/lang/IllegalStateException <init> ()V 0 0 1 0 -1
+ciMethodData java/lang/Integer valueOf (I)Ljava/lang/Integer; 2 3105 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 17 0x30007 0xc8 0x40 0xb59 0xa0007 0x1ae 0x20 0x9ab 0x1c0002 0x276 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/lang/Integer <init> (I)V 1 636 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 10 0x10002 0x27c 0x0 0x0 0x0 0x0 0x9 0x2 0x6 0x0 oops 0 methods 0
+ciMethodData java/lang/Number <init> ()V 2 3412 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 7 0x10002 0xd54 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/util/ArrayList$Itr hasNext ()Z 2 7117 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 14 0xb0007 0x5ed 0x38 0x15e0 0xf0003 0x15e0 0x18 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/util/ArrayList add (Ljava/lang/Object;)Z 2 9121 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 17 0x140005 0x23a1 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0xe 0x0 oops 0 methods 0
+ciMethodData java/util/ArrayList <init> ()V 2 10111 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 9 0x10002 0x277f 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/util/AbstractList <init> ()V 2 25470 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 9 0x10002 0x637e 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/util/ArrayList iterator ()Ljava/util/Iterator; 2 5600 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 8 0x50002 0x15e0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/util/ArrayList$Itr <init> (Ljava/util/ArrayList;)V 2 5605 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 10 0x60002 0x15e5 0x0 0x0 0x0 0x0 0x9 0x2 0xc 0x0 oops 0 methods 0
+ciMethodData java/util/ArrayList$Itr next ()Ljava/lang/Object; 2 5393 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 28 0x10005 0x1511 0x0 0x0 0x0 0x0 0x0 0x110007 0x1511 0x30 0x0 0x180002 0x0 0x270007 0x1511 0x30 0x0 0x2e0002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x6 oops 0 methods 0
+ciMethodData java/util/ArrayList$Itr checkForComodification ()V 2 5399 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 13 0xb0007 0x1517 0x30 0x0 0x120002 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData java/util/Collections unmodifiableList (Ljava/util/List;)Ljava/util/List; 2 1605 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 49 0x10005 0x3f 0x0 0x13a1b7aca18 0x601 0x13a20547488 0x5 0x80007 0x0 0x78 0x645 0xc0005 0x3f 0x0 0x13a1b7aca18 0x601 0x13a20547488 0x5 0x130007 0x610 0x20 0x35 0x190004 0xfffffffffffffffd 0x0 0x13a20547488 0x6 0x13a1b7aca18 0x603 0x1c0007 0x3 0x48 0x60d 0x240002 0x60d 0x270003 0x60d 0x28 0x2f0002 0x3 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0xffffffffffffffff oops 6 3 java/util/ArrayList 5 java/util/Arrays$ArrayList 14 java/util/ArrayList 16 java/util/Arrays$ArrayList 25 java/util/Arrays$ArrayList 27 java/util/ArrayList methods 0
+ciMethodData java/lang/String replace (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String; 2 7882 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 178 0x10005 0x0 0x0 0x13a1b7a9048 0x1eca 0x0 0x0 0x80005 0x0 0x0 0x13a1b7a9048 0x1eca 0x0 0x0 0x100005 0x1eca 0x0 0x0 0x0 0x0 0x0 0x160005 0x1eca 0x0 0x0 0x0 0x0 0x0 0x1d0005 0x1eca 0x0 0x0 0x0 0x0 0x0 0x240007 0x0 0x268 0x1eca 0x80000006002a0007 0x1 0xe8 0x1eca 0x300007 0x0 0xc8 0x1eca 0x360005 0x1eca 0x0 0x0 0x0 0x0 0x0 0x3c0005 0x1eca 0x0 0x0 0x0 0x0 0x0 0x3f0005 0x1eca 0x0 0x0 0x0 0x0 0x0 0x440005 0x1 0x0 0x0 0x0 0x0 0x0 0x4a0005 0x1 0x0 0x0 0x0 0x0 0x0 0x510005 0x1 0x0 0x0 0x0 0x0 0x0 0x580007 0x0 0x88 0x1 0x5d0007 0x0 0x68 0x1 0x620007 0x0 0x48 0x1 0x780002 0x1 0x7b0003 0x1 0x28 0x970002 0x0 0x9e0007 0x1 0x20 0x0 0xab0002 0x0 0xb00002 0x0 0xb30002 0x0 0xb80003 0x0 0x28 0xc40002 0x0 0xce0002 0x0 0xd70005 0x0 0x0 0x0 0x0 0x0 0x0 0xe20007 0x0 0xe0 0x0 0xea0005 0x0 0x0 0x0 0x0 0x0 0x0 0xed0005 0x0 0x0 0x0 0x0 0x0 0x0 0xf20005 0x0 0x0 0x0 0x0 0x0 0x0 0xf90003 0x0 0xffffffffffffff38 0xfe0005 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 2 3 java/lang/String 10 java/lang/String methods 0
+ciMethodData java/util/regex/Matcher <init> (Ljava/util/regex/Pattern;Ljava/lang/CharSequence;)V 1 152 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 25 0x10002 0x98 0x370002 0x98 0x5a0005 0x98 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x3fe 0x0 0x0 oops 0 methods 0
+ciMethod java/util/ConcurrentModificationException <init> ()V 0 0 1 0 -1
+ciMethod lombok/patcher/TargetMatcher matches (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z 0 0 1 0 -1
+ciMethod lombok/patcher/MethodTarget decomposeFullDesc (Ljava/lang/String;)Ljava/util/List; 142 232 58 0 0
+ciMethod lombok/patcher/MethodTarget classMatches (Ljava/lang/String;)Z 40 0 42 0 0
+ciMethod lombok/patcher/MethodTarget matches (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z 1024 0 6567 0 0
+ciMethod lombok/patcher/MethodTarget descriptorMatch (Ljava/lang/String;)Z 36 28 40 0 0
+ciMethod lombok/patcher/MethodTarget typeSpecMatch (Ljava/lang/String;Ljava/lang/String;)Z 170 122 75 0 -1
+ciMethod lombok/patcher/MethodTarget typeMatches (Ljava/lang/String;Ljava/lang/String;)Z 568 0 37033 0 -1
+ciMethod lombok/patcher/Hook getMethodName ()Ljava/lang/String; 1390 0 695 0 0
+ciMethod lombok/patcher/Hook getMethodDescriptor ()Ljava/lang/String; 278 454 167 0 0
+ciMethod lombok/patcher/Hook toSpec (Ljava/lang/String;)Ljava/lang/String; 528 26 444 0 -1
+ciMethod org/lombokweb/asm/ClassVisitor visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 1024 0 5600 0 0
+ciMethod org/lombokweb/asm/ClassWriter visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 928 0 6202 0 0
+ciMethod lombok/patcher/PatchScript$MethodPatcher visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 994 2048 5684 0 0
+ciMethod lombok/patcher/PatchScript$MethodPatcherFactory createMethodVisitor (Ljava/lang/String;Ljava/lang/String;Lorg/lombokweb/asm/MethodVisitor;Llombok/patcher/MethodLogistics;)Lorg/lombokweb/asm/MethodVisitor; 0 0 1 0 -1
+ciMethodData lombok/patcher/MethodTarget typeMatches (Ljava/lang/String;Ljava/lang/String;)Z 2 36750 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 24 0x60005 0x8f8f 0x0 0x0 0x0 0x0 0x0 0xa0005 0x8f94 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0xffffffffffffffff 0x0 oops 0 methods 0
+ciMethod org/lombokweb/asm/ClassReader readTypeAnnotations (Lorg/lombokweb/asm/MethodVisitor;Lorg/lombokweb/asm/Context;IZ)[I 0 0 1 0 -1
+ciMethod org/lombokweb/asm/ClassReader readMethod (Lorg/lombokweb/asm/ClassVisitor;Lorg/lombokweb/asm/Context;I)I 706 1186 5505 0 -1
+ciMethod org/lombokweb/asm/ClassReader readCode (Lorg/lombokweb/asm/MethodVisitor;Lorg/lombokweb/asm/Context;I)V 12 5296 22 0 0
+ciMethod org/lombokweb/asm/ClassReader readBytecodeInstructionOffset (I)V 1024 0 1675 0 -1
+ciMethod org/lombokweb/asm/ClassReader createLabel (I[Lorg/lombokweb/asm/Label;)Lorg/lombokweb/asm/Label; 556 0 793 0 -1
+ciMethod org/lombokweb/asm/ClassReader createDebugLabel (I[Lorg/lombokweb/asm/Label;)V 1024 0 1330 0 -1
+ciMethod org/lombokweb/asm/ClassReader getTypeAnnotationBytecodeOffset ([II)I 128 0 52 0 -1
+ciMethod org/lombokweb/asm/ClassReader readTypeAnnotationTarget (Lorg/lombokweb/asm/Context;I)I 0 0 1 0 0
+ciMethod org/lombokweb/asm/ClassReader readParameterAnnotations (Lorg/lombokweb/asm/MethodVisitor;Lorg/lombokweb/asm/Context;IZ)V 0 0 1 0 0
+ciMethod org/lombokweb/asm/ClassReader readElementValues (Lorg/lombokweb/asm/AnnotationVisitor;IZ[C)I 0 0 1 0 0
+ciMethod org/lombokweb/asm/ClassReader readElementValue (Lorg/lombokweb/asm/AnnotationVisitor;ILjava/lang/String;[C)I 0 0 1 0 0
+ciMethod org/lombokweb/asm/ClassReader computeImplicitFrame (Lorg/lombokweb/asm/Context;)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/ClassReader readStackMapFrame (IZZLorg/lombokweb/asm/Context;)I 540 2012 275 0 -1
+ciMethod org/lombokweb/asm/ClassReader readAttribute ([Lorg/lombokweb/asm/Attribute;Ljava/lang/String;II[CI[Lorg/lombokweb/asm/Label;)Lorg/lombokweb/asm/Attribute; 0 0 1 0 0
+ciMethod org/lombokweb/asm/ClassReader readByte (I)I 70 0 996 0 0
+ciMethod org/lombokweb/asm/ClassReader readBytes (II)[B 0 0 1 0 -1
+ciMethod org/lombokweb/asm/ClassReader readUnsignedShort (I)I 1024 0 9515 0 184
+ciMethod org/lombokweb/asm/ClassReader readShort (I)S 758 0 811 0 -1
+ciMethod org/lombokweb/asm/ClassReader readInt (I)I 788 0 2336 0 208
+ciMethod org/lombokweb/asm/ClassReader readLong (I)J 38 0 271 0 -1
+ciMethod org/lombokweb/asm/ClassReader readUTF8 (I[C)Ljava/lang/String; 792 0 50370 0 2456
+ciMethod org/lombokweb/asm/ClassReader readUtf (I[C)Ljava/lang/String; 1024 0 13278 0 2288
+ciMethod org/lombokweb/asm/ClassReader readUtf (II[C)Ljava/lang/String; 360 9792 1610 0 1744
+ciMethod org/lombokweb/asm/ClassReader readStringish (I[C)Ljava/lang/String; 1008 0 17741 0 -1
+ciMethod org/lombokweb/asm/ClassReader readClass (I[C)Ljava/lang/String; 1008 0 17735 0 2616
+ciMethod org/lombokweb/asm/ClassReader readConst (I[C)Ljava/lang/Object; 668 0 2546 0 -1
+ciMethod org/lombokweb/asm/AnnotationVisitor visit (Ljava/lang/String;Ljava/lang/Object;)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/AnnotationVisitor visitEnum (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/AnnotationVisitor visitAnnotation (Ljava/lang/String;Ljava/lang/String;)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/AnnotationVisitor visitArray (Ljava/lang/String;)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/AnnotationVisitor visitEnd ()V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/AnnotationWriter visitEnd ()V 0 0 1 0 0
+ciMethod org/lombokweb/asm/MethodVisitor <init> (I)V 928 0 6202 0 0
+ciMethod org/lombokweb/asm/MethodVisitor <init> (ILorg/lombokweb/asm/MethodVisitor;)V 934 0 6220 0 0
+ciMethod org/lombokweb/asm/MethodVisitor stringConcat$0 (I)Ljava/lang/String; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitParameter (Ljava/lang/String;I)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitAnnotationDefault ()Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitAnnotation (Ljava/lang/String;Z)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitTypeAnnotation (ILorg/lombokweb/asm/TypePath;Ljava/lang/String;Z)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitAnnotableParameterCount (IZ)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitParameterAnnotation (ILjava/lang/String;Z)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitAttribute (Lorg/lombokweb/asm/Attribute;)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitCode ()V 50 0 17 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitFrame (II[Ljava/lang/Object;I[Ljava/lang/Object;)V 518 0 229 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitInsn (I)V 598 0 524 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitIntInsn (II)V 150 0 38 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitVarInsn (II)V 522 0 1189 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitTypeInsn (ILjava/lang/String;)V 282 0 108 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitFieldInsn (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V 1024 0 521 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitMethodInsn (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V 694 0 372 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitInvokeDynamicInsn (Ljava/lang/String;Ljava/lang/String;Lorg/lombokweb/asm/Handle;[Ljava/lang/Object;)V 4 0 2 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitJumpInsn (ILorg/lombokweb/asm/Label;)V 598 0 341 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitLabel (Lorg/lombokweb/asm/Label;)V 828 0 905 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitLdcInsn (Ljava/lang/Object;)V 216 0 38 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitIincInsn (II)V 60 0 4 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitTableSwitchInsn (IILorg/lombokweb/asm/Label;[Lorg/lombokweb/asm/Label;)V 4 0 2 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitLookupSwitchInsn (Lorg/lombokweb/asm/Label;[I[Lorg/lombokweb/asm/Label;)V 10 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitMultiANewArrayInsn (Ljava/lang/String;I)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitInsnAnnotation (ILorg/lombokweb/asm/TypePath;Ljava/lang/String;Z)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitTryCatchBlock (Lorg/lombokweb/asm/Label;Lorg/lombokweb/asm/Label;Lorg/lombokweb/asm/Label;Ljava/lang/String;)V 22 0 11 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitLocalVariable (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/lombokweb/asm/Label;Lorg/lombokweb/asm/Label;I)V 652 0 155 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitLocalVariableAnnotation (ILorg/lombokweb/asm/TypePath;[Lorg/lombokweb/asm/Label;[Lorg/lombokweb/asm/Label;[ILjava/lang/String;Z)Lorg/lombokweb/asm/AnnotationVisitor; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitMaxs (II)V 50 0 19 0 -1
+ciMethod org/lombokweb/asm/MethodVisitor visitEnd ()V 50 0 17 0 -1
+ciMethod org/lombokweb/asm/MethodWriter <init> (Lorg/lombokweb/asm/SymbolTable;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;I)V 928 304 6202 0 0
+ciMethod org/lombokweb/asm/MethodWriter visitLabel (Lorg/lombokweb/asm/Label;)V 486 0 6486 0 -1
+ciMethod org/lombokweb/asm/MethodWriter addSuccessorToCurrentBasicBlock (ILorg/lombokweb/asm/Label;)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/MethodWriter canCopyMethodAttributes (Lorg/lombokweb/asm/ClassReader;ZZIII)Z 682 186 5675 0 0
+ciMethod org/lombokweb/asm/MethodWriter setMethodAttributesSource (II)V 676 0 5673 0 0
+ciMethod org/lombokweb/asm/SymbolTable getSource ()Lorg/lombokweb/asm/ClassReader; 424 0 212 0 0
+ciMethod org/lombokweb/asm/SymbolTable getMajorVersion ()I 382 0 191 0 0
+ciMethod org/lombokweb/asm/SymbolTable get (I)Lorg/lombokweb/asm/SymbolTable$Entry; 572 0 16894 0 176
+ciMethod org/lombokweb/asm/SymbolTable put (Lorg/lombokweb/asm/SymbolTable$Entry;)Lorg/lombokweb/asm/SymbolTable$Entry; 332 0 370 0 0
+ciMethod org/lombokweb/asm/SymbolTable addConstantClass (Ljava/lang/String;)Lorg/lombokweb/asm/Symbol; 776 0 1385 0 0
+ciMethod org/lombokweb/asm/SymbolTable addConstantUtf8 (Ljava/lang/String;)I 382 126 13854 0 1080
+ciMethod org/lombokweb/asm/SymbolTable addConstantUtf8Reference (ILjava/lang/String;)Lorg/lombokweb/asm/Symbol; 730 666 1479 0 0
+ciMethod org/lombokweb/asm/SymbolTable hash (ILjava/lang/String;)I 832 0 41887 0 0
+ciMethod org/lombokweb/asm/Symbol <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V 844 0 6919 0 136
+ciMethod org/lombokweb/asm/SymbolTable$Entry <init> (IILjava/lang/String;I)V 774 0 25538 0 128
+ciMethod org/lombokweb/asm/ByteVector <init> ()V 552 0 6308 0 0
+ciMethod org/lombokweb/asm/ByteVector <init> ([B)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/ByteVector putByte (I)Lorg/lombokweb/asm/ByteVector; 946 0 3416 0 0
+ciMethod org/lombokweb/asm/ByteVector put12 (II)Lorg/lombokweb/asm/ByteVector; 348 0 1283 0 -1
+ciMethod org/lombokweb/asm/ByteVector putUTF8 (Ljava/lang/String;)Lorg/lombokweb/asm/ByteVector; 250 4560 195 0 0
+ciMethod org/lombokweb/asm/ByteVector encodeUtf8 (Ljava/lang/String;II)Lorg/lombokweb/asm/ByteVector; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/ByteVector enlarge (I)V 22 0 125 0 -1
+ciMethodData org/lombokweb/asm/ClassReader readUnsignedShort (I)I 2 9003 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 8 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readUtf (II[C)Ljava/lang/String; 2 1430 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 33 0x160007 0x596 0xa8 0x8098 0x290007 0x0 0x38 0x8098 0x390003 0x8098 0x50 0x450007 0x0 0x38 0x0 0x640003 0x0 0x18 0x920003 0x8098 0xffffffffffffff70 0x9d0002 0x596 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readUtf (I[C)Ljava/lang/String; 2 12766 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 36 0x80007 0xde3 0x20 0x23fc 0x220005 0x0 0x0 0x13a201958e0 0xde3 0x0 0x0 0x260005 0xde3 0x0 0x0 0x0 0x0 0x0 0x2a0004 0x0 0x0 0x13a1b7a9048 0xde3 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 2 7 org/lombokweb/asm/ClassReader 21 java/lang/String methods 0
+ciMethodData org/lombokweb/asm/Symbol <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V 2 6497 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 16 0x10002 0x1961 0x0 0x0 0x0 0x0 0x9 0x8 0x3e 0x0 0x0 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethod org/lombokweb/asm/Attribute <init> (Ljava/lang/String;)V 0 0 1 0 -1
+ciMethod org/lombokweb/asm/Attribute read (Lorg/lombokweb/asm/ClassReader;II[CI[Lorg/lombokweb/asm/Label;)Lorg/lombokweb/asm/Attribute; 0 0 1 0 -1
+ciMethodData org/lombokweb/asm/ClassReader readUTF8 (I[C)Ljava/lang/String; 2 50501 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 33 0x20005 0x0 0x0 0x13a201958e0 0xc545 0x0 0x0 0x70007 0x26 0x40 0xc51f 0xb0007 0xc519 0x20 0x6 0x130005 0xc519 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 1 3 org/lombokweb/asm/ClassReader methods 0
+ciMethod org/lombokweb/asm/Type getType (Ljava/lang/String;)Lorg/lombokweb/asm/Type; 0 0 1 0 -1
+ciMethod org/lombokweb/asm/Type getArgumentsAndReturnSizes (Ljava/lang/String;)I 316 332 5987 0 0
+ciMethod lombok/patcher/MethodLogistics <init> (ILjava/lang/String;)V 8 10 18 0 0
+ciMethod org/lombokweb/asm/Label <init> ()V 488 0 6718 0 0
+ciMethod org/lombokweb/asm/Label addLineNumber (I)V 546 0 922 0 -1
+ciMethod org/lombokweb/asm/Label accept (Lorg/lombokweb/asm/MethodVisitor;Z)V 778 0 1018 0 -1
+ciMethod org/lombokweb/asm/Label resolve ([BLorg/lombokweb/asm/ByteVector;I)Z 1024 74 6498 0 -1
+ciMethod lombok/patcher/MethodLogistics loadOpcodeFor (Ljava/lang/String;)I 68 0 24 0 0
+ciMethod lombok/patcher/MethodLogistics returnOpcodeFor (Ljava/lang/String;)I 54 0 19 0 0
+ciMethod lombok/patcher/MethodLogistics sizeOf (Ljava/lang/String;)I 122 0 43 0 0
+ciMethodData org/lombokweb/asm/SymbolTable hash (ILjava/lang/String;)I 2 41471 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 17 0x40005 0xa1ff 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0xe oops 0 methods 0
+ciMethodData org/lombokweb/asm/SymbolTable get (I)Lorg/lombokweb/asm/SymbolTable$Entry; 2 16608 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 8 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/SymbolTable$Entry <init> (IILjava/lang/String;I)V 2 25151 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 13 0x70002 0x623f 0x0 0x0 0x0 0x0 0x9 0x5 0x7e 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ByteVector putByte (I)Lorg/lombokweb/asm/ByteVector; 2 3106 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 21 0xd0007 0xbfb 0x58 0x27 0x120005 0x27 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x6 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/SymbolTable addConstantUtf8Reference (ILjava/lang/String;)Lorg/lombokweb/asm/Symbol; 2 1114 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 69 0x20002 0x45a 0x80005 0x45a 0x0 0x0 0x0 0x0 0x0 0xf0007 0x1d 0xd0 0x648 0x180007 0x1f2 0x98 0x456 0x210007 0x19 0x78 0x43d 0x2a0005 0x43d 0x0 0x0 0x0 0x0 0x0 0x2d0007 0x0 0x20 0x43d 0x3a0003 0x20b 0xffffffffffffff48 0x440005 0x1d 0x0 0x0 0x0 0x0 0x0 0x470005 0x1d 0x0 0x0 0x0 0x0 0x0 0x5e0002 0x1d 0x610005 0x1d 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x4c 0x0 0xffffffffffffffff oops 0 methods 0
+ciMethodData org/lombokweb/asm/SymbolTable addConstantUtf8 (Ljava/lang/String;)I 2 13663 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 68 0x20002 0x355f 0x80005 0x355f 0x0 0x0 0x0 0x0 0x0 0xd0007 0x59 0xd0 0x47bd 0x150007 0xcc6 0x98 0x3af7 0x1d0007 0x5f1 0x78 0x3506 0x250005 0x3506 0x0 0x0 0x0 0x0 0x0 0x280007 0x0 0x20 0x3506 0x350003 0x12b7 0xffffffffffffff48 0x3d0005 0x0 0x0 0x13a20ef17d0 0x59 0x0 0x0 0x410005 0x0 0x0 0x13a20ef17d0 0x59 0x0 0x0 0x580002 0x59 0x5b0005 0x59 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x4c 0xffffffffffffffff oops 2 38 org/lombokweb/asm/ByteVector 45 org/lombokweb/asm/ByteVector methods 0
+ciMethodData org/lombokweb/asm/SymbolTable put (Lorg/lombokweb/asm/SymbolTable$Entry;)Lorg/lombokweb/asm/SymbolTable$Entry; 1 204 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 46 0xd0007 0xcb 0xc8 0x1 0x290007 0x1 0xa8 0x34e 0x370007 0x34e 0x70 0x27b 0x5a0004 0x0 0x0 0x13a211b7b60 0x27b 0x0 0x0 0x5f0003 0x27b 0xffffffffffffffa8 0x650003 0x34e 0xffffffffffffff70 0x940004 0x0 0x0 0x13a211b7b60 0xcc 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x44 0x40 oops 2 15 org/lombokweb/asm/SymbolTable$Entry 28 org/lombokweb/asm/SymbolTable$Entry methods 0
+ciMethodData org/lombokweb/asm/ClassReader readClass (I[C)Ljava/lang/String; 2 18544 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 18 0x30005 0x4870 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0xffffffffffffffff 0x0 0xffffffffffffffff oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readStringish (I[C)Ljava/lang/String; 2 18544 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 25 0x70005 0x0 0x0 0x13a201958e0 0x4870 0x0 0x0 0xc0005 0x0 0x0 0x13a201958e0 0x4870 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 2 3 org/lombokweb/asm/ClassReader 10 org/lombokweb/asm/ClassReader methods 0
+ciMethodData org/lombokweb/asm/SymbolTable addConstantClass (Ljava/lang/String;)Lorg/lombokweb/asm/Symbol; 1 997 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 17 0x40005 0x3e5 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ByteVector putUTF8 (Ljava/lang/String;)Lorg/lombokweb/asm/ByteVector; 1 70 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 67 0x10005 0x46 0x0 0x0 0x0 0x0 0x0 0x80007 0x46 0x30 0x0 0x110002 0x0 0x240007 0x46 0x58 0x0 0x2b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4f0007 0x46 0x100 0x7f5 0x550005 0x7f5 0x0 0x0 0x0 0x0 0x0 0x5d0007 0x0 0x58 0x7f5 0x640007 0x0 0x38 0x7f5 0x710003 0x7f5 0x50 0x7f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x860003 0x7f5 0xffffffffffffff18 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0xffffffffffffffff 0xffffffffffffffff oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readInt (I)I 2 1942 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 8 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData java/util/regex/Matcher reset ()Ljava/util/regex/Matcher; 2 221 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 53 0x170007 0xdd 0x38 0x1144 0x240003 0x1144 0xffffffffffffffe0 0x2f0007 0xdd 0x38 0x1d0 0x3c0003 0x1d0 0xffffffffffffffe0 0x470007 0xdd 0x90 0x3b 0x500007 0x3b 0x58 0x0 0x590005 0x0 0x0 0x0 0x0 0x0 0x0 0x5f0003 0x3b 0xffffffffffffff88 0x6e0005 0xdd 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x7e oops 0 methods 0
+ciMethodData java/util/regex/Matcher getTextLength ()I 1 221 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 16 0x40005 0x0 0x0 0x13a1b7a9048 0xdd 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 1 3 java/lang/String methods 0
+ciMethodData java/util/regex/Pattern matcher (Ljava/lang/CharSequence;)Ljava/util/regex/Matcher; 1 219 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 30 0x40007 0xdb 0x90 0x0 0xf0007 0x0 0x58 0x0 0x130005 0x0 0x0 0x0 0x0 0x0 0x0 0x180003 0x0 0x18 0x260002 0xdb 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData java/lang/StringUTF16 getChar ([BI)C 2 11015 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 26 0x30007 0x2b08 0x80 0x0 0x70007 0x0 0x50 0x0 0xc0002 0x0 0xf0007 0x0 0x30 0x0 0x180002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ByteVector <init> ()V 2 6032 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 9 0x10002 0x1790 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readMethod (Lorg/lombokweb/asm/ClassVisitor;Lorg/lombokweb/asm/Context;I)I 2 5189 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 683 0xd0005 0x0 0x0 0x13a201958e0 0x1430 0x0 0x0 0x1b0005 0x0 0x0 0x13a201958e0 0x1430 0x0 0x0 0x290005 0x0 0x0 0x13a201958e0 0x1430 0x0 0x0 0x5f0005 0x0 0x0 0x13a201958e0 0x1430 0x0 0x0 0x6c0007 0x1430 0x7c8 0x14c0 0x740005 0x0 0x0 0x13a201958e0 0x14c0 0x0 0x0 0x7e0005 0x0 0x0 0x13a201958e0 0x14c0 0x0 0x0 0x8b0005 0x14c0 0x0 0x0 0x0 0x0 0x0 0x8e0007 0xa7 0x58 0x1419 0x970007 0x0 0x6c8 0x1419 0x9e0003 0x1419 0x6a8 0xa60005 0xa7 0x0 0x0 0x0 0x0 0x0 0xa90007 0x25 0x118 0x82 0xb30005 0x0 0x0 0x13a201958e0 0x82 0x0 0x0 0xc90007 0x82 0xa8 0x82 0xd50005 0x0 0x0 0x13a201958e0 0x82 0x0 0x0 0xd80004 0x0 0x0 0x13a1b7a9048 0x82 0x0 0x0 0xdf0003 0x82 0xffffffffffffff70 0xe20003 0x82 0x558 0xea0005 0x25 0x0 0x0 0x0 0x0 0x0 0xed0007 0x12 0x70 0x13 0xf30005 0x0 0x0 0x13a201958e0 0x13 0x0 0x0 0xf80003 0x13 0x4b0 0x1000005 0x12 0x0 0x0 0x0 0x0 0x0 0x1030007 0x0 0x38 0x12 0x1120003 0x12 0x440 0x11a0005 0x0 0x0 0x0 0x0 0x0 0x0 0x11d0007 0x0 0x38 0x0 0x1240003 0x0 0x3d0 0x12c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x12f0007 0x0 0x38 0x0 0x1360003 0x0 0x360 0x13e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1410007 0x0 0x38 0x0 0x1480003 0x0 0x2f0 0x1500005 0x0 0x0 0x0 0x0 0x0 0x0 0x1530007 0x0 0x38 0x0 0x1650003 0x0 0x280 0x16d0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1700007 0x0 0x38 0x0 0x1770003 0x0 0x210 0x17f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1820007 0x0 0x38 0x0 0x1890003 0x0 0x1a0 0x1910005 0x0 0x0 0x0 0x0 0x0 0x0 0x1940007 0x0 0x38 0x0 0x19b0003 0x0 0x130 0x1a30005 0x0 0x0 0x0 0x0 0x0 0x0 0x1a60007 0x0 0x38 0x0 0x1ad0003 0x0 0xc0 0x1b50005 0x0 0x0 0x0 0x0 0x0 0x0 0x1b80007 0x0 0x38 0x0 0x1bf0003 0x0 0x50 0x1d10005 0x0 0x0 0x0 0x0 0x0 0x0 0x1e80003 0x14c0 0xfffffffffffff850 0x1fa0007 0x13 0x38 0x141d 0x1fe0003 0x141d 0x50 0x2060005 0x13 0x0 0x0 0x0 0x0 0x0 0x20b0005 0x2f 0x0 0x13a20197290 0x11d 0x13a20197340 0x12e4 0x2120007 0x1403 0x20 0x2d 0x21a0004 0xfffffffffffffff2 0x0 0x13a201973f0 0x13f4 0x0 0x0 0x21d0007 0xe 0x158 0x13f4 0x2220004 0x0 0x0 0x13a201973f0 0x13f4 0x0 0x0 0x2340007 0x13e2 0x38 0x12 0x2380003 0x12 0x18 0x2400005 0x0 0x0 0x13a201958e0 0x13f5 0x0 0x0 0x2470005 0x13f5 0x0 0x0 0x0 0x0 0x0 0x24a0007 0x2 0x58 0x13f3 0x2540005 0x13f3 0x0 0x0 0x0 0x0 0x0 0x25c0007 0x10 0x158 0x0 0x2650007 0x0 0x138 0x0 0x26b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x27b0007 0x0 0xe0 0x0 0x2850005 0x0 0x0 0x0 0x0 0x0 0x0 0x28d0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2900005 0x0 0x0 0x0 0x0 0x0 0x0 0x2960003 0x0 0xffffffffffffff38 0x29b0007 0x10 0xe8 0x0 0x2a00005 0x0 0x0 0x0 0x0 0x0 0x0 0x2ad0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2b30007 0x0 0x58 0x0 0x2b80005 0x0 0x0 0x0 0x0 0x0 0x0 0x2bd0007 0x10 0x138 0x0 0x2c30005 0x0 0x0 0x0 0x0 0x0 0x0 0x2d30007 0x0 0xe0 0x0 0x2db0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2e90005 0x0 0x0 0x0 0x0 0x0 0x0 0x2f10005 0x0 0x0 0x0 0x0 0x0 0x0 0x2f60003 0x0 0xffffffffffffff38 0x2fb0007 0x10 0x138 0x0 0x3010005 0x0 0x0 0x0 0x0 0x0 0x0 0x3110007 0x0 0xe0 0x0 0x3190005 0x0 0x0 0x0 0x0 0x0 0x0 0x3270005 0x0 0x0 0x0 0x0 0x0 0x0 0x32f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3340003 0x0 0xffffffffffffff38 0x3390007 0x10 0x170 0x0 0x33f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x34f0007 0x0 0x118 0x0 0x3560005 0x0 0x0 0x0 0x0 0x0 0x0 0x3600005 0x0 0x0 0x0 0x0 0x0 0x0 0x3760005 0x0 0x0 0x0 0x0 0x0 0x0 0x37e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3830003 0x0 0xffffffffffffff00 0x3880007 0x10 0x170 0x0 0x38e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x39e0007 0x0 0x118 0x0 0x3a50005 0x0 0x0 0x0 0x0 0x0 0x0 0x3af0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3c50005 0x0 0x0 0x0 0x0 0x0 0x0 0x3cd0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3d20003 0x0 0xffffffffffffff00 0x3d70007 0x10 0x58 0x0 0x3e10005 0x0 0x0 0x0 0x0 0x0 0x0 0x3e60007 0x10 0x58 0x0 0x3f00005 0x0 0x0 0x0 0x0 0x0 0x0 0x3f50007 0x10 0x70 0x0 0x4090005 0x0 0x0 0x0 0x0 0x0 0x0 0x4100003 0x0 0xffffffffffffffa8 0x4150007 0x0 0x90 0x10 0x41a0005 0x7 0x0 0x13a201974a0 0x7 0x13a201973f0 0x2 0x4230005 0x10 0x0 0x0 0x0 0x0 0x0 0x4280005 0x7 0x0 0x13a201974a0 0x7 0x13a201973f0 0x2 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 19 3 org/lombokweb/asm/ClassReader 10 org/lombokweb/asm/ClassReader 17 org/lombokweb/asm/ClassReader 24 org/lombokweb/asm/ClassReader 35 org/lombokweb/asm/ClassReader 42 org/lombokweb/asm/ClassReader 78 org/lombokweb/asm/ClassReader 89 org/lombokweb/asm/ClassReader 96 java/lang/String 120 org/lombokweb/asm/ClassReader 294 lombok/patcher/scripts/AddFieldScript$1 296 lombok/patcher/PatchScript$MethodPatcher 305 org/lombokweb/asm/MethodWriter 316 org/lombokweb/asm/MethodWriter 330 org/lombokweb/asm/ClassReader 637 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 639 org/lombokweb/asm/MethodWriter 651 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 653 org/lombokweb/asm/MethodWriter methods 0
+ciMethodData org/lombokweb/asm/ClassReader readAttribute ([Lorg/lombokweb/asm/Attribute;Ljava/lang/String;II[CI[Lorg/lombokweb/asm/Label;)Lorg/lombokweb/asm/Attribute; 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 50 0xf0007 0x0 0xc8 0x0 0x1f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x220007 0x0 0x58 0x0 0x310005 0x0 0x0 0x0 0x0 0x0 0x0 0x380003 0x0 0xffffffffffffff50 0x400002 0x0 0x4a0005 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x8 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/MethodWriter setMethodAttributesSource (II)V 2 6639 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 9 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/MethodWriter canCopyMethodAttributes (Lorg/lombokweb/asm/ClassReader;ZZIII)Z 2 6643 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 106 0x50005 0x19f3 0x0 0x0 0x0 0x0 0x0 0x80007 0x4 0xb8 0x19ef 0x110007 0x0 0x98 0x19ef 0x1a0007 0x0 0x78 0x19ef 0x260007 0x19dd 0x38 0x12 0x2a0003 0x12 0x18 0x2e0007 0x19ef 0x20 0x0 0x370005 0x19ef 0x0 0x0 0x0 0x0 0x0 0x3c0007 0x19ef 0x58 0x0 0x470007 0x0 0x38 0x0 0x4b0003 0x0 0x18 0x540007 0x19ef 0x20 0x0 0x5b0007 0x74 0x40 0x197b 0x620007 0x197b 0x108 0x0 0x6a0005 0x0 0x0 0x13a201958e0 0x74 0x0 0x0 0x710007 0x0 0xb0 0x74 0x830007 0x74 0x90 0x74 0x890005 0x0 0x0 0x13a201958e0 0x74 0x0 0x0 0x930007 0x74 0x20 0x0 0x9e0003 0x74 0xffffffffffffff88 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x7 0x0 0x0 0x0 0x0 0x0 0x0 0x0 oops 2 63 org/lombokweb/asm/ClassReader 78 org/lombokweb/asm/ClassReader methods 0
+ciMethodData org/lombokweb/asm/ClassReader readByte (I)I 2 1072 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 8 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readElementValue (Lorg/lombokweb/asm/AnnotationVisitor;ILjava/lang/String;[C)I 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 749 0x40007 0x0 0xe0 0x0 0x120008 0x8 0x0 0xc0 0x0 0x50 0x0 0x88 0x0 0x50 0x420005 0x0 0x0 0x0 0x0 0x0 0x0 0x4f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x660008 0x6a 0x0 0x1540 0x0 0x968 0x0 0x1540 0x0 0x360 0x0 0x430 0x0 0x500 0x0 0x1540 0x0 0x500 0x0 0x1540 0x0 0x1540 0x0 0x500 0x0 0x500 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x5c0 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x690 0x0 0xa28 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x8d0 0x0 0x1540 0x0 0x810 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x1540 0x0 0x788 0x14e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1520005 0x0 0x0 0x0 0x0 0x0 0x0 0x1560002 0x0 0x1590005 0x0 0x0 0x0 0x0 0x0 0x0 0x15f0003 0x0 0x1138 0x16c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1700005 0x0 0x0 0x0 0x0 0x0 0x0 0x1740002 0x0 0x1770005 0x0 0x0 0x0 0x0 0x0 0x0 0x17d0003 0x0 0x1068 0x1860005 0x0 0x0 0x0 0x0 0x0 0x0 0x18b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x18e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1940003 0x0 0xfa8 0x1a10005 0x0 0x0 0x0 0x0 0x0 0x0 0x1a50005 0x0 0x0 0x0 0x0 0x0 0x0 0x1a90002 0x0 0x1ac0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1b20003 0x0 0xed8 0x1bf0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1c30005 0x0 0x0 0x0 0x0 0x0 0x0 0x1c60007 0x0 0x38 0x0 0x1cc0003 0x0 0x18 0x1d20005 0x0 0x0 0x0 0x0 0x0 0x0 0x1d80003 0x0 0xde0 0x1e20005 0x0 0x0 0x0 0x0 0x0 0x0 0x1e50005 0x0 0x0 0x0 0x0 0x0 0x0 0x1eb0003 0x0 0xd58 0x1f50005 0x0 0x0 0x0 0x0 0x0 0x0 0x1ff0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2020005 0x0 0x0 0x0 0x0 0x0 0x0 0x2080003 0x0 0xc98 0x2120005 0x0 0x0 0x0 0x0 0x0 0x0 0x2150002 0x0 0x2180005 0x0 0x0 0x0 0x0 0x0 0x0 0x21e0003 0x0 0xc00 0x2290005 0x0 0x0 0x0 0x0 0x0 0x0 0x22c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2360005 0x0 0x0 0x0 0x0 0x0 0x0 0x23b0003 0x0 0xb40 0x2410005 0x0 0x0 0x0 0x0 0x0 0x0 0x24b0007 0x0 0x90 0x0 0x2510005 0x0 0x0 0x0 0x0 0x0 0x0 0x25b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x26a0008 0x34 0x0 0x9c8 0x0 0x1b0 0x0 0x4d0 0x0 0x8c0 0x0 0x9c8 0x0 0x7b8 0x0 0x9c8 0x0 0x9c8 0x0 0x5c8 0x0 0x6c0 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x3d8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x9c8 0x0 0x2a8 0x2e90007 0x0 0xa8 0x0 0x2fa0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2fe0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3090003 0x0 0xffffffffffffff70 0x3100005 0x0 0x0 0x0 0x0 0x0 0x0 0x3130003 0x0 0x7d0 0x3230007 0x0 0xe0 0x0 0x3340005 0x0 0x0 0x0 0x0 0x0 0x0 0x3380005 0x0 0x0 0x0 0x0 0x0 0x0 0x33b0007 0x0 0x38 0x0 0x33f0003 0x0 0x18 0x34a0003 0x0 0xffffffffffffff38 0x3510005 0x0 0x0 0x0 0x0 0x0 0x0 0x3540003 0x0 0x6a0 0x3640007 0x0 0xa8 0x0 0x3750005 0x0 0x0 0x0 0x0 0x0 0x0 0x3790005 0x0 0x0 0x0 0x0 0x0 0x0 0x3840003 0x0 0xffffffffffffff70 0x38b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x38e0003 0x0 0x5a8 0x39e0007 0x0 0xa8 0x0 0x3af0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3b30005 0x0 0x0 0x0 0x0 0x0 0x0 0x3be0003 0x0 0xffffffffffffff70 0x3c50005 0x0 0x0 0x0 0x0 0x0 0x0 0x3c80003 0x0 0x4b0 0x3d80007 0x0 0xa8 0x0 0x3e90005 0x0 0x0 0x0 0x0 0x0 0x0 0x3ed0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3f70003 0x0 0xffffffffffffff70 0x3fe0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4010003 0x0 0x3b8 0x4110007 0x0 0xa8 0x0 0x4220005 0x0 0x0 0x0 0x0 0x0 0x0 0x4260005 0x0 0x0 0x0 0x0 0x0 0x0 0x4300003 0x0 0xffffffffffffff70 0x4370005 0x0 0x0 0x0 0x0 0x0 0x0 0x43a0003 0x0 0x2c0 0x44a0007 0x0 0xb8 0x0 0x45b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x45f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4620002 0x0 0x46c0003 0x0 0xffffffffffffff60 0x4730005 0x0 0x0 0x0 0x0 0x0 0x0 0x4760003 0x0 0x1b8 0x4860007 0x0 0xb8 0x0 0x4970005 0x0 0x0 0x0 0x0 0x0 0x0 0x49b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x49e0002 0x0 0x4a80003 0x0 0xffffffffffffff60 0x4af0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4b20003 0x0 0xb0 0x4b80005 0x0 0x0 0x0 0x0 0x0 0x0 0x4c20005 0x0 0x0 0x0 0x0 0x0 0x0 0x4c70003 0x0 0x28 0x4ce0002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x5 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/AnnotationWriter visitEnd ()V 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 11 0x50007 0x0 0x20 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readElementValues (Lorg/lombokweb/asm/AnnotationVisitor;IZ[C)I 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 70 0x60005 0x0 0x0 0x0 0x0 0x0 0x0 0xf0007 0x0 0xc8 0x0 0x170007 0x0 0x118 0x0 0x1f0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x330003 0x0 0xffffffffffffff70 0x3b0007 0x0 0x70 0x0 0x450005 0x0 0x0 0x0 0x0 0x0 0x0 0x4a0003 0x0 0xffffffffffffffa8 0x4e0007 0x0 0x58 0x0 0x520005 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x5 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readTypeAnnotationTarget (Lorg/lombokweb/asm/Context;I)I 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 276 0x40005 0x0 0x0 0x0 0x0 0x0 0x0 0xe0008 0x9a 0x0 0x768 0x0 0x4e0 0x0 0x4e0 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x738 0x0 0x738 0x0 0x738 0x0 0x4f8 0x0 0x4f8 0x0 0x4f8 0x0 0x4e0 0x0 0x738 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x768 0x0 0x510 0x0 0x510 0x0 0x738 0x0 0x750 0x0 0x750 0x0 0x750 0x0 0x750 0x0 0x720 0x0 0x720 0x0 0x720 0x0 0x720 0x0 0x720 0x1570003 0x0 0x298 0x1650003 0x0 0x280 0x1740005 0x0 0x0 0x0 0x0 0x0 0x0 0x19d0007 0x0 0x1c0 0x0 0x1a20005 0x0 0x0 0x0 0x0 0x0 0x0 0x1ab0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1b40005 0x0 0x0 0x0 0x0 0x0 0x0 0x1c90005 0x0 0x0 0x0 0x0 0x0 0x0 0x1cc0004 0x0 0x0 0x0 0x0 0x0 0x0 0x1dd0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1e00004 0x0 0x0 0x0 0x0 0x0 0x0 0x1ed0003 0x0 0xfffffffffffffe58 0x1f00003 0x0 0x70 0x1fe0003 0x0 0x58 0x20c0003 0x0 0x40 0x21a0003 0x0 0x28 0x2210002 0x0 0x22d0005 0x0 0x0 0x0 0x0 0x0 0x0 0x2350007 0x0 0x38 0x0 0x2390003 0x0 0x28 0x2450002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readParameterAnnotations (Lorg/lombokweb/asm/MethodVisitor;Lorg/lombokweb/asm/Context;IZ)V 1 0 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 62 0x180005 0x0 0x0 0x0 0x0 0x0 0x0 0x280007 0x0 0x150 0x0 0x2e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x3b0007 0x0 0xe0 0x0 0x430005 0x0 0x0 0x0 0x0 0x0 0x0 0x530005 0x0 0x0 0x0 0x0 0x0 0x0 0x5b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x600003 0x0 0xffffffffffffff38 0x660003 0x0 0xfffffffffffffec8 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x5 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/MethodWriter <init> (Lorg/lombokweb/asm/SymbolTable;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;I)V 2 5738 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 116 0x30002 0x166a 0xb0002 0x166a 0x1a0005 0x166a 0x0 0x0 0x0 0x0 0x0 0x1d0007 0x164f 0x38 0x1b 0x240003 0x1b 0x18 0x2e0005 0x166a 0x0 0x0 0x0 0x0 0x0 0x3d0005 0x166a 0x0 0x0 0x0 0x0 0x0 0x4c0007 0xf 0x38 0x165b 0x500003 0x165b 0x50 0x560005 0xf 0x0 0x0 0x0 0x0 0x0 0x5e0007 0x162d 0xc8 0x3d 0x640007 0x0 0xa8 0x3d 0x810007 0x3d 0x70 0x3d 0x900005 0x3d 0x0 0x0 0x0 0x0 0x0 0x9a0003 0x3d 0xffffffffffffffa8 0x9d0003 0x3d 0x18 0xb20007 0xa5 0x98 0x15c5 0xb70002 0x15c5 0xc20007 0x1467 0x20 0x15e 0xd90002 0x15c5 0xe40005 0x15c5 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x8 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/MethodVisitor <init> (I)V 2 5738 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 8 0x30002 0x166a 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/MethodVisitor <init> (ILorg/lombokweb/asm/MethodVisitor;)V 2 5753 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 51 0x10002 0x1679 0x70007 0x1679 0x100 0x0 0xd0007 0x0 0xe0 0x0 0x130007 0x0 0xc0 0x0 0x190007 0x0 0xa0 0x0 0x1f0007 0x0 0x80 0x0 0x250007 0x0 0x60 0x0 0x2b0007 0x0 0x40 0x0 0x330002 0x0 0x360002 0x0 0x3d0007 0x1679 0x30 0x0 0x410002 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0xffffffffffffffff 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/Type getArgumentsAndReturnSizes (Ljava/lang/String;)I 2 5829 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 97 0x60005 0x16c5 0x0 0x0 0x0 0x0 0x0 0xd0007 0x16c5 0x1d8 0x1100 0x130007 0x18 0x40 0x10e8 0x190007 0x10e8 0x38 0x0 0x220003 0x18 0x128 0x270005 0x1313 0x0 0x0 0x0 0x0 0x0 0x2c0007 0x10e8 0x38 0x22b 0x320003 0x22b 0xffffffffffffffa8 0x3a0005 0x10e8 0x0 0x0 0x0 0x0 0x0 0x3f0007 0x766 0x68 0x982 0x460005 0x982 0x0 0x0 0x0 0x0 0x0 0x500002 0x982 0x590005 0x1100 0x0 0x0 0x0 0x0 0x0 0x5d0003 0x1100 0xfffffffffffffe40 0x640005 0x16c5 0x0 0x0 0x0 0x0 0x0 0x6b0007 0x3e3 0x20 0x12e2 0x750007 0x0 0x40 0x3e3 0x7b0007 0x3e3 0x38 0x0 0x7f0003 0x0 0x18 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/Label <init> ()V 2 6486 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 7 0x10002 0x1956 0x0 0x0 0x9 0x1 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassReader readCode (Lorg/lombokweb/asm/MethodVisitor;Lorg/lombokweb/asm/Context;I)V 2 20 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 2691 0x120005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x1c0005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x260005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x380007 0x14 0x30 0x0 0x3f0002 0x0 0x600007 0x14 0x1440 0xc46 0x770008 0x1bc 0x0 0x13f8 0x0 0xdf0 0x3e 0xdf0 0x8 0xdf0 0x3a 0xdf0 0x4a 0xdf0 0x6 0xdf0 0x5 0xdf0 0x2 0xdf0 0x0 0xdf0 0x2 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x1c 0x1398 0xa 0x13b0 0x5 0x1398 0x1f 0x13b0 0x6 0x13b0 0x68 0x1398 0x1 0x1398 0x0 0x1398 0x0 0x1398 0xfc 0x1398 0x0 0xdf0 0x10 0xdf0 0x24 0xdf0 0xb 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x175 0xdf0 0xb7 0xdf0 0xd 0xdf0 0x7 0xdf0 0x14 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x12 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x2d 0x1398 0x1 0x1398 0x0 0x1398 0x0 0x1398 0x6c 0x1398 0x0 0xdf0 0x3 0xdf0 0x6 0xdf0 0xd 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x1 0xdf0 0x4 0xdf0 0x4 0xdf0 0xd 0xdf0 0xc 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0xd 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x9 0xdf0 0x0 0xdf0 0x45 0xdf0 0xe 0xdf0 0x0 0xdf0 0xc 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0xe 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x1b 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x2 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x18 0xdf0 0x3 0xdf0 0xc 0xdf0 0x2 0xdf0 0x0 0xdf0 0x0 0xdf0 0x4 0x13b0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x3 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x87 0xe08 0x39 0xe08 0x1 0xe08 0x2 0xe08 0x0 0xe08 0x3 0xe08 0x1 0xe08 0xa 0xe08 0x4 0xe08 0x0 0xe08 0x0 0xe08 0x3 0xe08 0x1 0xe08 0x6 0xe08 0x54 0xe08 0x0 0xe08 0x0 0x1398 0x2 0x10c0 0x0 0x1248 0xc 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0xb 0xdf0 0x1d 0xdf0 0x21 0x13b0 0x1e 0x13b0 0x174 0x13b0 0x57 0x13b0 0xe9 0x13b0 0x15 0x13b0 0x40 0x13b0 0x1e 0x13c8 0x2 0x13c8 0x15 0x13b0 0x0 0x1398 0xd 0x13b0 0xa 0xdf0 0x7 0xdf0 0x1f 0x13b0 0x26 0x13b0 0x0 0xdf0 0x0 0xdf0 0x0 0xfa0 0x0 0x13e0 0x1a 0xe08 0xe 0xe08 0x0 0xf18 0x0 0xf18 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xf18 0x3fb0003 0x4c7 0x618 0x4060005 0x0 0x0 0x13a201958e0 0x15b 0x0 0x0 0x40c0005 0x15b 0x0 0x0 0x0 0x0 0x0 0x4130003 0x15b 0x590 0x41e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4240005 0x0 0x0 0x0 0x0 0x0 0x0 0x42b0003 0x0 0x508 0x4360005 0x0 0x0 0x0 0x0 0x0 0x0 0x43c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x4430003 0x0 0x480 0x4510008 0x1a 0x0 0x110 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xe0 0x0 0xf8 0x0 0xe0 0x4bf0003 0x0 0x388 0x4c50003 0x0 0x370 0x4cc0002 0x0 0x4e10005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x4e70005 0x2 0x0 0x0 0x0 0x0 0x0 0x4f10005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x4f90005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x5090007 0x2 0x268 0x11 0x5120005 0x0 0x0 0x13a201958e0 0x11 0x0 0x0 0x5180005 0x11 0x0 0x0 0x0 0x0 0x0 0x51f0003 0x11 0xffffffffffffff70 0x5330005 0x0 0x0 0x0 0x0 0x0 0x0 0x5390005 0x0 0x0 0x0 0x0 0x0 0x0 0x5420005 0x0 0x0 0x0 0x0 0x0 0x0 0x54f0007 0x0 0x118 0x0 0x55a0005 0x0 0x0 0x0 0x0 0x0 0x0 0x5600005 0x0 0x0 0x0 0x0 0x0 0x0 0x5670003 0x0 0xffffffffffffff70 0x56d0003 0x220 0x70 0x5730003 0x3e2 0x58 0x5790003 0x20 0x40 0x57f0003 0x0 0x28 0x5860002 0x0 0x58a0003 0xc46 0xffffffffffffebd8 0x5900005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x59d0007 0x14 0x230 0xe 0x5a40005 0x0 0x0 0x13a201958e0 0xe 0x0 0x0 0x5a90005 0xe 0x0 0x0 0x0 0x0 0x0 0x5b40005 0x0 0x0 0x13a201958e0 0xe 0x0 0x0 0x5b90005 0xe 0x0 0x0 0x0 0x0 0x0 0x5c40005 0x0 0x0 0x13a201958e0 0xe 0x0 0x0 0x5c90005 0xe 0x0 0x0 0x0 0x0 0x0 0x5d90005 0x0 0x0 0x13a201958e0 0xe 0x0 0x0 0x5df0005 0x0 0x0 0x13a201958e0 0xe 0x0 0x0 0x5f00005 0x3 0x0 0x13a201974a0 0x6 0x13a20c44b10 0x5 0x5f30003 0xe 0xfffffffffffffde8 0x6110005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x61e0007 0x14 0x780 0x39 0x6260005 0x0 0x0 0x13a201958e0 0x39 0x0 0x0 0x6300005 0x0 0x0 0x13a201958e0 0x39 0x0 0x0 0x63d0005 0x39 0x0 0x0 0x0 0x0 0x0 0x6400007 0x25 0x1a8 0x14 0x6490007 0x0 0x680 0x14 0x6570005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x6640007 0x14 0x118 0x9c 0x66a0005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x6740005 0x9c 0x0 0x0 0x0 0x0 0x0 0x67c0005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x6890005 0x9c 0x0 0x0 0x0 0x0 0x0 0x68f0003 0x9c 0xffffffffffffff00 0x6920003 0x14 0x510 0x69a0005 0x25 0x0 0x0 0x0 0x0 0x0 0x69d0007 0x25 0x38 0x0 0x6a40003 0x0 0x4a0 0x6ac0005 0x25 0x0 0x0 0x0 0x0 0x0 0x6af0007 0x11 0x1a8 0x14 0x6b80007 0x0 0x430 0x14 0x6c20005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x6cf0007 0x14 0x118 0x339 0x6d50005 0x0 0x0 0x13a201958e0 0x339 0x0 0x0 0x6df0005 0x0 0x0 0x13a201958e0 0x339 0x0 0x0 0x6ec0005 0x339 0x0 0x0 0x0 0x0 0x0 0x6f60005 0x339 0x0 0x0 0x0 0x0 0x0 0x6f90003 0x339 0xffffffffffffff00 0x6fc0003 0x14 0x2c0 0x7040005 0x11 0x0 0x0 0x0 0x0 0x0 0x7070007 0x11 0x70 0x0 0x7100005 0x0 0x0 0x0 0x0 0x0 0x0 0x7150003 0x0 0x218 0x71d0005 0x11 0x0 0x0 0x0 0x0 0x0 0x7200007 0x11 0x70 0x0 0x7290005 0x0 0x0 0x0 0x0 0x0 0x0 0x72e0003 0x0 0x170 0x7360005 0x11 0x0 0x0 0x0 0x0 0x0 0x7390007 0x0 0x58 0x11 0x7420007 0x0 0x100 0x11 0x7520003 0x11 0xe0 0x75a0005 0x0 0x0 0x0 0x0 0x0 0x0 0x75d0007 0x0 0x58 0x0 0x7660007 0x0 0x70 0x0 0x7790003 0x0 0x50 0x78c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x7a30003 0x39 0xfffffffffffff898 0x7ad0007 0x14 0x38 0x0 0x7b10003 0x0 0x18 0x7b90007 0x3 0x1a0 0x11 0x7e90007 0x11 0x58 0x0 0x7ee0005 0x0 0x0 0x0 0x0 0x0 0x0 0x7fb0007 0x11 0x128 0x70e 0x8050007 0x6fe 0xf0 0x10 0x80d0005 0x0 0x0 0x13a201958e0 0x10 0x0 0x0 0x8140007 0x0 0x98 0x10 0x81b0007 0x8 0x78 0x8 0x82d0007 0x0 0x58 0x8 0x8350005 0x8 0x0 0x0 0x0 0x0 0x0 0x83c0003 0x70e 0xfffffffffffffef0 0x8410007 0x14 0x78 0x0 0x84c0007 0x0 0x58 0x0 0x8560005 0x0 0x0 0x0 0x0 0x0 0x0 0x8600005 0x14 0x0 0x0 0x0 0x0 0x0 0x86c0005 0x14 0x0 0x0 0x0 0x0 0x0 0x87c0007 0x0 0x38 0x14 0x8810003 0x14 0x18 0x88f0007 0x14 0x2710 0xc46 0x89c0005 0x0 0x0 0x13a201958e0 0xc46 0x0 0x0 0x8a80007 0x8c3 0x90 0x383 0x8b40007 0x0 0x38 0x383 0x8b80003 0x383 0x18 0x8bc0005 0x383 0x0 0x0 0x0 0x0 0x0 0x8c10007 0xaf 0x1d0 0xc94 0x8ca0007 0xec 0x40 0xba8 0x8d20007 0xb97 0x190 0x11 0x8da0007 0x11 0xe8 0xec 0x8df0007 0x0 0x40 0xec 0x8e40007 0xec 0x70 0x0 0x8f90005 0x0 0x0 0x0 0x0 0x0 0x0 0x8fc0003 0x0 0x50 0x9140005 0x70 0x0 0x13a201974a0 0x74 0x13a201973f0 0x8 0x91e0007 0x11 0x70 0xec 0x9290005 0xec 0x0 0x0 0x0 0x0 0x0 0x92e0003 0xec 0xfffffffffffffe60 0x9340003 0x11 0xfffffffffffffe48 0x9390007 0xc46 0x78 0x0 0x9430007 0x0 0x58 0x0 0x94e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x9610008 0x1bc 0x0 0x2058 0x0 0xdf0 0x3e 0xdf0 0x8 0xdf0 0x3a 0xdf0 0x4a 0xdf0 0x6 0xdf0 0x5 0xdf0 0x2 0xdf0 0x0 0xdf0 0x2 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x1c 0x1768 0xa 0x17b8 0x5 0x1840 0x1f 0x18c8 0x6 0x18c8 0x68 0x1718 0x1 0x1718 0x0 0x1718 0x0 0x1718 0xfc 0x1718 0x0 0xe40 0x10 0xe40 0x24 0xe40 0xb 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x0 0xe40 0x175 0xe40 0xb7 0xe40 0xd 0xe40 0x7 0xe40 0x14 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x12 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x2d 0x1718 0x1 0x1718 0x0 0x1718 0x0 0x1718 0x6c 0x1718 0x0 0xe90 0x3 0xe90 0x6 0xe90 0xd 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x0 0xe90 0x1 0xe90 0x4 0xe90 0x4 0xe90 0xd 0xe90 0xc 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0xd 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x9 0xdf0 0x0 0xdf0 0x45 0xdf0 0xe 0xdf0 0x0 0xdf0 0xc 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0xe 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x1b 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x2 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x18 0xdf0 0x3 0xdf0 0xc 0xdf0 0x2 0xdf0 0x0 0xdf0 0x0 0xdf0 0x4 0x1f80 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x3 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0x87 0xee0 0x39 0xee0 0x1 0xee0 0x2 0xee0 0x0 0xee0 0x3 0xee0 0x1 0xee0 0xa 0xee0 0x4 0xee0 0x0 0xee0 0x0 0xee0 0x3 0xee0 0x1 0xee0 0x6 0xee0 0x54 0xee0 0x0 0xee0 0x0 0x1718 0x2 0x13d8 0x0 0x1578 0xc 0xdf0 0x0 0xdf0 0x0 0xdf0 0x0 0xdf0 0xb 0xdf0 0x1d 0xdf0 0x21 0x1988 0x1e 0x1988 0x174 0x1988 0x57 0x1988 0xe9 0x1988 0x15 0x1988 0x40 0x1988 0x1e 0x1988 0x2 0x1bd0 0x15 0x1ef8 0x0 0x1768 0xd 0x1ef8 0xa 0xdf0 0x7 0xdf0 0x1f 0x1ef8 0x26 0x1ef8 0x0 0xdf0 0x0 0xdf0 0x0 0x1270 0x0 0x1fd0 0x1a 0xee0 0xe 0xee0 0x0 0xf68 0x0 0xf68 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0xff0 0x0 0x11e8 0xce70005 0xe0 0x0 0x13a201974a0 0x128 0x13a201973f0 0x14 0xced0003 0x21c 0x1240 0xcff0005 0xf4 0x0 0x13a201974a0 0x17f 0x13a201973f0 0xc 0xd050003 0x27f 0x11f0 0xd170005 0x17 0x0 0x13a201974a0 0x12 0x13a201973f0 0x3 0xd1d0003 0x2c 0x11a0 0xd2c0005 0x0 0x0 0x13a201958e0 0x15b 0x0 0x0 0xd310005 0x9e 0x0 0x13a201974a0 0xb6 0x13a201973f0 0x7 0xd370003 0x15b 0x1118 0xd490005 0x0 0x0 0x0 0x0 0x0 0x0 0xd4e0005 0x0 0x0 0x0 0x0 0x0 0x0 0xd540003 0x0 0x1090 0xd5c0007 0x0 0x38 0x0 0xd640003 0x0 0x18 0xd770005 0x0 0x0 0x0 0x0 0x0 0x0 0xd830007 0x0 0x40 0x0 0xd8b0007 0x0 0x70 0x0 0xd960005 0x0 0x0 0x0 0x0 0x0 0x0 0xd990003 0x0 0xf8 0xda10007 0x0 0x38 0x0 0xdac0003 0x0 0x18 0xdbc0005 0x0 0x0 0x0 0x0 0x0 0x0 0xdc60005 0x0 0x0 0x0 0x0 0x0 0x0 0xdcf0005 0x0 0x0 0x0 0x0 0x0 0x0 0xdd80003 0x0 0xe98 0xde80005 0x0 0x0 0x0 0x0 0x0 0x0 0xded0005 0x0 0x0 0x0 0x0 0x0 0x0 0xdf60003 0x0 0xe10 0xe0b0007 0x0 0xe0 0x0 0xe140005 0x0 0x0 0x0 0x0 0x0 0x0 0xe1c0005 0x0 0x0 0x0 0x0 0x0 0x0 0xe1f0005 0x0 0x0 0x0 0x0 0x0 0x0 0xe250003 0x0 0xd30 0xe300005 0x0 0x0 0x0 0x0 0x0 0x0 0xe330005 0x0 0x0 0x0 0x0 0x0 0x0 0xe390003 0x0 0xca8 0xe4e0005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0xe5a0005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0xe650005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0xe810007 0x2 0xa8 0x11 0xe8f0005 0x0 0x0 0x13a201958e0 0x11 0x0 0x0 0xe940004 0x0 0x0 0x13a21560120 0x11 0x0 0x0 0xe9b0003 0x11 0xffffffffffffff70 0xea70005 0x0 0x0 0x13a20c44b10 0x2 0x0 0x0 0xeaa0003 0x2 0xb08 0xebf0005 0x0 0x0 0x0 0x0 0x0 0x0 0xecb0005 0x0 0x0 0x0 0x0 0x0 0x0 0xee70007 0x0 0xe0 0x0 0xef10005 0x0 0x0 0x0 0x0 0x0 0x0 0xf020005 0x0 0x0 0x0 0x0 0x0 0x0 0xf070004 0x0 0x0 0x0 0x0 0x0 0x0 0xf0e0003 0x0 0xffffffffffffff38 0xf180005 0x0 0x0 0x0 0x0 0x0 0x0 0xf1b0003 0x0 0x968 0xf2c0005 0x52 0x0 0x13a201974a0 0xc0 0x13a20c44b10 0xed 0xf320003 0x1ff 0x918 0xf3f0005 0x2 0x0 0x13a201974a0 0x7 0x13a20c44b10 0x13 0xf450003 0x1c 0x8c8 0xf500005 0x0 0x0 0x13a201958e0 0xa 0x0 0x0 0xf530005 0x0 0x0 0x13a201974a0 0x8 0x13a20c44bc0 0x2 0xf590003 0xa 0x840 0xf6b0005 0x0 0x0 0x13a201958e0 0x5 0x0 0x0 0xf6e0005 0x0 0x0 0x13a201973f0 0x3 0x13a20c44b10 0x2 0xf740003 0x5 0x7b8 0xf7e0005 0x0 0x0 0x13a201958e0 0x25 0x0 0x0 0xf830005 0x0 0x0 0x13a201958e0 0x25 0x0 0x0 0xf860005 0xb 0x0 0x13a201974a0 0x19 0x13a201973f0 0x1 0xf8c0003 0x25 0x6f8 0xf980005 0x0 0x0 0x13a201958e0 0x366 0x0 0x0 0xfa70005 0x0 0x0 0x13a201958e0 0x366 0x0 0x0 0xfb20005 0x0 0x0 0x13a201958e0 0x366 0x0 0x0 0xfbc0005 0x0 0x0 0x13a201958e0 0x366 0x0 0x0 0xfc80005 0x0 0x0 0x13a201958e0 0x366 0x0 0x0 0xfd20007 0x15c 0x70 0x20a 0xfde0005 0x5a 0x0 0x13a201974a0 0x131 0x13a20c44b10 0x7f 0xfe10003 0x20a 0x88 0xfed0007 0x13e 0x38 0x1e 0xff10003 0x1e 0x18 0x10020005 0xc6 0x0 0x13a201974a0 0x8c 0x13a201973f0 0xa 0x100a0007 0x348 0x38 0x1e 0x10100003 0x1e 0x4c8 0x10160003 0x348 0x4b0 0x10220005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10310005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x103c0005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10480005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10540005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x105e0005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10630005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10660004 0x0 0x0 0x13a20c61d40 0x2 0x0 0x0 0x10700005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10830007 0x2 0xe0 0x2 0x108e0005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10930005 0x0 0x0 0x13a201958e0 0x2 0x0 0x0 0x10960004 0x0 0x0 0x13a1b7a9048 0x2 0x0 0x0 0x109d0003 0x2 0xffffffffffffff38 0x10a90005 0x0 0x0 0x13a201974a0 0x2 0x0 0x0 0x10af0003 0x2 0x188 0x10bc0005 0x0 0x0 0x13a201958e0 0x67 0x0 0x0 0x10bf0005 0x28 0x0 0x13a201974a0 0x3e 0x13a201973f0 0x1 0x10c50003 0x67 0x100 0x10db0005 0x0 0x0 0x13a20c44b10 0x3 0x13a201974a0 0x1 0x10e10003 0x4 0xb0 0x10ec0005 0x0 0x0 0x0 0x0 0x0 0x0 0x10fa0005 0x0 0x0 0x0 0x0 0x0 0x0 0x11000003 0x0 0x28 0x11070002 0x0 0x110d0007 0xc46 0x1b0 0x0 0x11150007 0x0 0x190 0x0 0x111c0007 0x0 0x170 0x0 0x11230007 0x0 0x100 0x0 0x112d0005 0x0 0x0 0x0 0x0 0x0 0x0 0x11370005 0x0 0x0 0x0 0x0 0x0 0x0 0x114c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x11540005 0x0 0x0 0x0 0x0 0x0 0x0 0x11600005 0x0 0x0 0x0 0x0 0x0 0x0 0x11650003 0x0 0xfffffffffffffe68 0x116a0007 0xc46 0x1b0 0x0 0x11720007 0x0 0x190 0x0 0x11790007 0x0 0x170 0x0 0x11800007 0x0 0x100 0x0 0x118a0005 0x0 0x0 0x0 0x0 0x0 0x0 0x11940005 0x0 0x0 0x0 0x0 0x0 0x0 0x11a90005 0x0 0x0 0x0 0x0 0x0 0x0 0x11b10005 0x0 0x0 0x0 0x0 0x0 0x0 0x11bd0005 0x0 0x0 0x0 0x0 0x0 0x0 0x11c20003 0x0 0xfffffffffffffe68 0x11c50003 0xc46 0xffffffffffffd908 0x11cd0007 0x1 0x58 0x13 0x11d60005 0x6 0x0 0x13a201974a0 0x9 0x13a201973f0 0x4 0x11db0007 0x0 0x3e8 0x14 0x11e40007 0x0 0x3c8 0x14 0x11ec0007 0x14 0x100 0x0 0x11f20005 0x0 0x0 0x0 0x0 0x0 0x0 0x12080007 0x0 0xa8 0x0 0x12250005 0x0 0x0 0x0 0x0 0x0 0x0 0x12330005 0x0 0x0 0x0 0x0 0x0 0x0 0x123a0003 0x0 0xffffffffffffff70 0x12400005 0x0 0x0 0x13a201958e0 0x14 0x0 0x0 0x12500007 0x14 0x270 0x9c 0x12560005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x12600005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x126c0005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x12790005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x12840005 0x0 0x0 0x13a201958e0 0x9c 0x0 0x0 0x12910007 0x9c 0xe8 0x0 0x129c0007 0x0 0xc8 0x0 0x12a60007 0x0 0x90 0x0 0x12b20007 0x0 0x70 0x0 0x12bf0005 0x0 0x0 0x0 0x0 0x0 0x0 0x12c40003 0x0 0x30 0x12ca0003 0x0 0xffffffffffffff50 0x12e30005 0x55 0x0 0x13a201974a0 0x3f 0x13a201973f0 0x8 0x12e60003 0x9c 0xfffffffffffffda8 0x12eb0007 0x14 0x1b0 0x0 0x12fe0007 0x0 0x190 0x0 0x130b0005 0x0 0x0 0x0 0x0 0x0 0x0 0x13140007 0x0 0x40 0x0 0x131b0007 0x0 0x100 0x0 0x13220005 0x0 0x0 0x0 0x0 0x0 0x0 0x132c0005 0x0 0x0 0x0 0x0 0x0 0x0 0x134d0005 0x0 0x0 0x0 0x0 0x0 0x0 0x13550005 0x0 0x0 0x0 0x0 0x0 0x0 0x135c0003 0x0 0xfffffffffffffe88 0x13610007 0x14 0x1b0 0x0 0x13740007 0x0 0x190 0x0 0x13810005 0x0 0x0 0x0 0x0 0x0 0x0 0x138a0007 0x0 0x40 0x0 0x13910007 0x0 0x100 0x0 0x13980005 0x0 0x0 0x0 0x0 0x0 0x0 0x13a20005 0x0 0x0 0x0 0x0 0x0 0x0 0x13c30005 0x0 0x0 0x0 0x0 0x0 0x0 0x13cb0005 0x0 0x0 0x0 0x0 0x0 0x0 0x13d20003 0x0 0xfffffffffffffe88 0x13d70007 0x14 0x70 0x0 0x13ea0005 0x0 0x0 0x0 0x0 0x0 0x0 0x13f10003 0x0 0xffffffffffffffa8 0x13f90005 0x7 0x0 0x13a201974a0 0x9 0x13a201973f0 0x4 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 97 3 org/lombokweb/asm/ClassReader 10 org/lombokweb/asm/ClassReader 17 org/lombokweb/asm/ClassReader 483 org/lombokweb/asm/ClassReader 570 org/lombokweb/asm/ClassReader 584 org/lombokweb/asm/ClassReader 591 org/lombokweb/asm/ClassReader 602 org/lombokweb/asm/ClassReader 678 org/lombokweb/asm/ClassReader 689 org/lombokweb/asm/ClassReader 703 org/lombokweb/asm/ClassReader 717 org/lombokweb/asm/ClassReader 731 org/lombokweb/asm/ClassReader 738 org/lombokweb/asm/ClassReader 745 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 747 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 755 org/lombokweb/asm/ClassReader 766 org/lombokweb/asm/ClassReader 773 org/lombokweb/asm/ClassReader 795 org/lombokweb/asm/ClassReader 806 org/lombokweb/asm/ClassReader 820 org/lombokweb/asm/ClassReader 869 org/lombokweb/asm/ClassReader 880 org/lombokweb/asm/ClassReader 887 org/lombokweb/asm/ClassReader 1032 org/lombokweb/asm/ClassReader 1101 org/lombokweb/asm/ClassReader 1160 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1162 org/lombokweb/asm/MethodWriter 1645 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1647 org/lombokweb/asm/MethodWriter 1655 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1657 org/lombokweb/asm/MethodWriter 1665 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1667 org/lombokweb/asm/MethodWriter 1675 org/lombokweb/asm/ClassReader 1682 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1684 org/lombokweb/asm/MethodWriter 1834 org/lombokweb/asm/ClassReader 1841 org/lombokweb/asm/ClassReader 1848 org/lombokweb/asm/ClassReader 1859 org/lombokweb/asm/ClassReader 1866 org/lombokweb/asm/Label 1876 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 1938 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1940 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 1948 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1950 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 1958 org/lombokweb/asm/ClassReader 1965 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 1967 lombok/patcher/scripts/ReplaceMethodCallScript$ReplaceMethodCall 1975 org/lombokweb/asm/ClassReader 1982 org/lombokweb/asm/MethodWriter 1984 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 1992 org/lombokweb/asm/ClassReader 1999 org/lombokweb/asm/ClassReader 2006 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2008 org/lombokweb/asm/MethodWriter 2016 org/lombokweb/asm/ClassReader 2023 org/lombokweb/asm/ClassReader 2030 org/lombokweb/asm/ClassReader 2037 org/lombokweb/asm/ClassReader 2044 org/lombokweb/asm/ClassReader 2055 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2057 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 2072 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2074 org/lombokweb/asm/MethodWriter 2089 org/lombokweb/asm/ClassReader 2096 org/lombokweb/asm/ClassReader 2103 org/lombokweb/asm/ClassReader 2110 org/lombokweb/asm/ClassReader 2117 org/lombokweb/asm/ClassReader 2124 org/lombokweb/asm/ClassReader 2131 org/lombokweb/asm/ClassReader 2138 org/lombokweb/asm/Handle 2145 org/lombokweb/asm/ClassReader 2156 org/lombokweb/asm/ClassReader 2163 org/lombokweb/asm/ClassReader 2170 java/lang/String 2180 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2190 org/lombokweb/asm/ClassReader 2197 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2199 org/lombokweb/asm/MethodWriter 2207 lombok/patcher/scripts/WrapReturnValuesScript$WrapReturnValues 2209 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2351 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2353 org/lombokweb/asm/MethodWriter 2398 org/lombokweb/asm/ClassReader 2409 org/lombokweb/asm/ClassReader 2416 org/lombokweb/asm/ClassReader 2423 org/lombokweb/asm/ClassReader 2430 org/lombokweb/asm/ClassReader 2437 org/lombokweb/asm/ClassReader 2473 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2475 org/lombokweb/asm/MethodWriter 2605 lombok/patcher/scripts/ExitFromMethodEarlyScript$ExitEarly 2607 org/lombokweb/asm/MethodWriter methods 0
+ciMethodData org/lombokweb/asm/MethodWriter visitLabel (Lorg/lombokweb/asm/Label;)V 2 7162 orig 80 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 121 0x180005 0x1bfa 0x0 0x0 0x0 0x0 0x0 0x250007 0x1973 0x20 0x288 0x2e0007 0x1973 0x100 0x0 0x350007 0x0 0x78 0x0 0x430007 0x0 0x20 0x0 0x680005 0x0 0x0 0x0 0x0 0x0 0x0 0x6f0007 0x0 0x40 0x0 0x7d0007 0x0 0x20 0x0 0xbf0002 0x0 0xc50003 0x0 0x178 0xcd0007 0x1973 0x70 0x0 0xd40007 0x0 0x38 0x0 0xdc0003 0x0 0x120 0xea0003 0x0 0x108 0xf20007 0x1973 0xb0 0x0 0xf90007 0x0 0x58 0x0 0x10e0005 0x0 0x0 0x0 0x0 0x0 0x0 0x1240007 0x0 0x20 0x0 0x1340003 0x0 0x58 0x13c0007 0x0 0x40 0x1973 0x1430007 0x10f 0x20 0x1864 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassWriter visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 2 5738 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 23 0x130002 0x166a 0x1c0007 0x1657 0x38 0x13 0x250003 0x13 0x18 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x6 0x0 0x0 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData org/lombokweb/asm/ClassVisitor visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 2 5685 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 25 0x40007 0x0 0x58 0x1636 0x120005 0x0 0x0 0x13a20eea6b0 0x1636 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x6 0x0 0x0 0x0 0x0 0x0 0x0 oops 1 7 lombok/patcher/PatchScript$FixedClassWriter methods 0
+ciMethodData lombok/patcher/MethodTarget matches (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z 2 6055 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 36 0x50005 0x17a8 0x0 0x0 0x0 0x0 0x0 0x80007 0x24 0x20 0x1784 0xf0005 0x24 0x0 0x0 0x0 0x0 0x0 0x120007 0x24 0x20 0x0 0x190002 0x24 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x4 0x0 0x0 0x0 0x0 oops 0 methods 0
+ciMethodData lombok/patcher/PatchScript$MethodPatcher visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 2 5187 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 149 0x80002 0x1443 0x110005 0x0 0x0 0x13a1b7aca18 0x1443 0x0 0x0 0x180003 0x1443 0x1e0 0x1d0005 0x0 0x0 0x13a20f55548 0xb5d 0x0 0x0 0x220004 0x0 0x0 0x13a20f546e8 0xb5d 0x0 0x0 0x290005 0x0 0x0 0x13a20f546e8 0xb5d 0x0 0x0 0x2d0005 0xb5d 0x0 0x0 0x0 0x0 0x0 0x300007 0xb5b 0xe8 0x2 0x350005 0x0 0x0 0x13a20f546e8 0x2 0x0 0x0 0x390005 0x2 0x0 0x0 0x0 0x0 0x0 0x3c0007 0x0 0x58 0x2 0x410005 0x0 0x0 0x13a20f55548 0x2 0x0 0x0 0x480005 0x0 0x0 0x13a20f55548 0x1fa0 0x0 0x0 0x4d0007 0xb5d 0xfffffffffffffe00 0x1443 0x540005 0x0 0x0 0x13a1b7aca18 0x1443 0x0 0x0 0x5b0003 0x1443 0x128 0x600005 0x0 0x0 0x13a20f55548 0x1454 0x0 0x0 0x650004 0x0 0x0 0x13a20f555f8 0x1454 0x0 0x0 0x720005 0x0 0x0 0x13a20f555f8 0x1454 0x0 0x0 0x770007 0x1445 0x68 0xf 0x880002 0xf 0x8b0005 0x1 0x0 0x13a20f556a8 0x8 0x13a20f55758 0x6 0x930005 0x0 0x0 0x13a20f55548 0x2888 0x0 0x0 0x980007 0x1453 0xfffffffffffffeb8 0x1435 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x6 0x0 0x0 0x0 0x0 0x0 0x0 oops 14 5 java/util/ArrayList 15 java/util/ArrayList$Itr 22 lombok/patcher/Hook 29 lombok/patcher/Hook 47 lombok/patcher/Hook 65 java/util/ArrayList$Itr 72 java/util/ArrayList$Itr 83 java/util/ArrayList 93 java/util/ArrayList$Itr 100 lombok/patcher/MethodTarget 107 lombok/patcher/MethodTarget 120 lombok/patcher/scripts/ExitFromMethodEarlyScript$1 122 lombok/patcher/scripts/WrapReturnValuesScript$1 127 java/util/ArrayList$Itr methods 0
+ciMethodData lombok/patcher/MethodLogistics <init> (ILjava/lang/String;)V 1 15 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 118 0x10002 0xf 0x90007 0xd 0x38 0x2 0xd0003 0x2 0x18 0x150002 0xf 0x1a0005 0x0 0x0 0x13a1b7aca18 0xf 0x0 0x0 0x230005 0x0 0x0 0x13a20f55548 0xf 0x0 0x0 0x280004 0x0 0x0 0x13a1b7a9048 0xf 0x0 0x0 0x300002 0xf 0x390002 0xf 0x490002 0xf 0x520002 0xf 0x5b0002 0xf 0x600003 0xf 0x180 0x650005 0x0 0x0 0x13a20f55548 0x13 0x0 0x0 0x6a0004 0x0 0x0 0x13a1b7a9048 0x13 0x0 0x0 0x710002 0x13 0x7a0002 0x13 0x7d0005 0x0 0x0 0x13a1b7aca18 0x13 0x0 0x0 0x870002 0x13 0x8a0005 0x0 0x0 0x13a1b7aca18 0x13 0x0 0x0 0x940002 0x13 0x970002 0x13 0x9a0005 0x0 0x0 0x13a1b7aca18 0x13 0x0 0x0 0xa90005 0x0 0x0 0x13a20f55548 0x22 0x0 0x0 0xae0007 0x13 0xfffffffffffffe60 0xf 0xb40002 0xf 0xbd0002 0xf 0xc60002 0xf 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x3 0x0 0x0 0x0 oops 9 14 java/util/ArrayList 21 java/util/ArrayList$Itr 28 java/lang/String 48 java/util/ArrayList$Itr 55 java/lang/String 66 java/util/ArrayList 75 java/util/ArrayList 86 java/util/ArrayList 93 java/util/ArrayList$Itr methods 0
+ciMethodData lombok/patcher/Hook getMethodDescriptor ()Ljava/lang/String; 1 33 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 85 0x40002 0x21 0xb0005 0x21 0x0 0x0 0x0 0x0 0x0 0x130005 0x0 0x0 0x13a204d47f8 0x21 0x0 0x0 0x190003 0x21 0xd0 0x1d0005 0x0 0x0 0x13a204d48a8 0x2d 0x0 0x0 0x220004 0x0 0x0 0x13a1b7a9048 0x2d 0x0 0x0 0x280002 0x2d 0x2b0005 0x2d 0x0 0x0 0x0 0x0 0x0 0x300005 0x0 0x0 0x13a204d48a8 0x4e 0x0 0x0 0x350007 0x2d 0xffffffffffffff10 0x21 0x3b0005 0x21 0x0 0x0 0x0 0x0 0x0 0x440002 0x21 0x470005 0x21 0x0 0x0 0x0 0x0 0x0 0x4c0005 0x21 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x1 0x0 oops 4 12 java/util/Collections$UnmodifiableRandomAccessList 22 java/util/Collections$UnmodifiableCollection$1 29 java/lang/String 45 java/util/Collections$UnmodifiableCollection$1 methods 0
+ciMethodData lombok/patcher/MethodTarget classMatches (Ljava/lang/String;)Z 1 23 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 12 0x50002 0x17 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0xffffffffffffffff oops 0 methods 0
+ciMethodData lombok/patcher/MethodTarget descriptorMatch (Ljava/lang/String;)Z 1 22 orig 80 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 data 131 0x40007 0x15 0x20 0x1 0xa0002 0x15 0xd0005 0x0 0x0 0x13a1b7aca18 0x15 0x0 0x0 0x140005 0x0 0x0 0x13a20f55548 0x15 0x0 0x0 0x190004 0x0 0x0 0x13a1b7a9048 0x15 0x0 0x0 0x200002 0x15 0x230007 0x13 0x20 0x2 0x2c0005 0x0 0x0 0x13a204d47f8 0x13 0x0 0x0 0x320003 0x13 0x128 0x360005 0x0 0x0 0x13a20f55548 0x16 0x0 0x0 0x3b0004 0x0 0x0 0x13a1b7a9048 0x16 0x0 0x0 0x3f0005 0x0 0x0 0x13a204d48a8 0x16 0x0 0x0 0x440004 0x0 0x0 0x13a1b7a9048 0x16 0x0 0x0 0x470002 0x16 0x4a0007 0x12 0x20 0x4 0x500005 0x0 0x0 0x13a20f55548 0x25 0x0 0x0 0x550007 0xf 0x78 0x16 0x590005 0x0 0x0 0x13a204d48a8 0x16 0x0 0x0 0x5e0007 0x16 0xfffffffffffffe60 0x0 0x620005 0x0 0x0 0x13a20f55548 0xf 0x0 0x0 0x670007 0x0 0x78 0xf 0x6b0005 0x0 0x0 0x13a204d48a8 0xf 0x0 0x0 0x700007 0x2 0x20 0xd 0x0 0x0 0x0 0x0 0x0 0x0 0x9 0x2 0x0 0x0 oops 12 9 java/util/ArrayList 16 java/util/ArrayList$Itr 23 java/lang/String 36 java/util/Collections$UnmodifiableRandomAccessList 46 java/util/ArrayList$Itr 53 java/lang/String 60 java/util/Collections$UnmodifiableCollection$1 67 java/lang/String 80 java/util/ArrayList$Itr 91 java/util/Collections$UnmodifiableCollection$1 102 java/util/ArrayList$Itr 113 java/util/Collections$UnmodifiableCollection$1 methods 0
+compile org/lombokweb/asm/ClassReader readMethod (Lorg/lombokweb/asm/ClassVisitor;Lorg/lombokweb/asm/Context;I)I -1 4 inline 147 0 -1 0 org/lombokweb/asm/ClassReader readMethod (Lorg/lombokweb/asm/ClassVisitor;Lorg/lombokweb/asm/Context;I)I 1 13 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 1 27 0 org/lombokweb/asm/ClassReader readUTF8 (I[C)Ljava/lang/String; 2 2 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 2 19 0 org/lombokweb/asm/ClassReader readUtf (I[C)Ljava/lang/String; 3 34 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 3 38 0 org/lombokweb/asm/ClassReader readUtf (II[C)Ljava/lang/String; 4 157 0 java/lang/String <init> ([CII)V 5 7 0 java/lang/String rangeCheck ([CII)Ljava/lang/Void; 6 4 0 java/lang/String checkBoundsOffCount (III)I 7 6 0 jdk/internal/util/Preconditions checkFromIndexSize (IIILjava/util/function/BiFunction;)I 5 10 0 java/lang/String <init> ([CIILjava/lang/Void;)V 6 1 0 java/lang/Object <init> ()V 6 36 0 java/lang/StringUTF16 compress ([CII)[B 1 41 0 org/lombokweb/asm/ClassReader readUTF8 (I[C)Ljava/lang/String; 2 2 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 2 19 0 org/lombokweb/asm/ClassReader readUtf (I[C)Ljava/lang/String; 3 34 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 3 38 0 org/lombokweb/asm/ClassReader readUtf (II[C)Ljava/lang/String; 4 157 0 java/lang/String <init> ([CII)V 5 7 0 java/lang/String rangeCheck ([CII)Ljava/lang/Void; 6 4 0 java/lang/String checkBoundsOffCount (III)I 7 6 0 jdk/internal/util/Preconditions checkFromIndexSize (IIILjava/util/function/BiFunction;)I 5 10 0 java/lang/String <init> ([CIILjava/lang/Void;)V 6 1 0 java/lang/Object <init> ()V 6 36 0 java/lang/StringUTF16 compress ([CII)[B 1 95 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 1 116 0 org/lombokweb/asm/ClassReader readUTF8 (I[C)Ljava/lang/String; 2 2 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 2 19 0 org/lombokweb/asm/ClassReader readUtf (I[C)Ljava/lang/String; 3 34 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 3 38 0 org/lombokweb/asm/ClassReader readUtf (II[C)Ljava/lang/String; 4 157 0 java/lang/String <init> ([CII)V 5 7 0 java/lang/String rangeCheck ([CII)Ljava/lang/Void; 6 4 0 java/lang/String checkBoundsOffCount (III)I 7 6 0 jdk/internal/util/Preconditions checkFromIndexSize (IIILjava/util/function/BiFunction;)I 5 10 0 java/lang/String <init> ([CIILjava/lang/Void;)V 6 1 0 java/lang/Object <init> ()V 6 36 0 java/lang/StringUTF16 compress ([CII)[B 1 126 0 org/lombokweb/asm/ClassReader readInt (I)I 1 139 0 java/lang/String equals (Ljava/lang/Object;)Z 1 179 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 1 523 0 lombok/patcher/PatchScript$MethodPatcher visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 2 8 0 org/lombokweb/asm/ClassVisitor visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 3 18 0 org/lombokweb/asm/ClassWriter visitMethod (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lorg/lombokweb/asm/MethodVisitor; 4 19 0 org/lombokweb/asm/MethodWriter <init> (Lorg/lombokweb/asm/SymbolTable;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;I)V 5 3 0 org/lombokweb/asm/MethodVisitor <init> (I)V 6 3 0 org/lombokweb/asm/MethodVisitor <init> (ILorg/lombokweb/asm/MethodVisitor;)V 7 1 0 java/lang/Object <init> ()V 5 11 0 org/lombokweb/asm/ByteVector <init> ()V 6 1 0 java/lang/Object <init> ()V 5 26 0 java/lang/String equals (Ljava/lang/Object;)Z 5 46 0 org/lombokweb/asm/SymbolTable addConstantUtf8 (Ljava/lang/String;)I 6 2 0 org/lombokweb/asm/SymbolTable hash (ILjava/lang/String;)I 7 4 0 java/lang/String hashCode ()I 8 17 0 java/lang/String isLatin1 ()Z 6 8 0 org/lombokweb/asm/SymbolTable get (I)Lorg/lombokweb/asm/SymbolTable$Entry; 6 37 0 java/lang/String equals (Ljava/lang/Object;)Z 6 88 0 org/lombokweb/asm/SymbolTable$Entry <init> (IILjava/lang/String;I)V 7 7 0 org/lombokweb/asm/Symbol <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V 8 1 0 java/lang/Object <init> ()V 5 61 0 org/lombokweb/asm/SymbolTable addConstantUtf8 (Ljava/lang/String;)I 6 2 0 org/lombokweb/asm/SymbolTable hash (ILjava/lang/String;)I 7 4 0 java/lang/String hashCode ()I 8 17 0 java/lang/String isLatin1 ()Z 6 8 0 org/lombokweb/asm/SymbolTable get (I)Lorg/lombokweb/asm/SymbolTable$Entry; 6 37 0 java/lang/String equals (Ljava/lang/Object;)Z 6 88 0 org/lombokweb/asm/SymbolTable$Entry <init> (IILjava/lang/String;I)V 7 7 0 org/lombokweb/asm/Symbol <init> (IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;J)V 8 1 0 java/lang/Object <init> ()V 5 144 0 org/lombokweb/asm/SymbolTable addConstantClass (Ljava/lang/String;)Lorg/lombokweb/asm/Symbol; 5 183 0 org/lombokweb/asm/Type getArgumentsAndReturnSizes (Ljava/lang/String;)I 6 6 0 java/lang/String charAt (I)C 7 1 0 java/lang/String isLatin1 ()Z 7 12 0 java/lang/StringLatin1 charAt ([BI)C 8 3 0 java/lang/String checkIndex (II)V 6 39 0 java/lang/String charAt (I)C 7 1 0 java/lang/String isLatin1 ()Z 7 12 0 java/lang/StringLatin1 charAt ([BI)C 8 3 0 java/lang/String checkIndex (II)V 6 58 0 java/lang/String charAt (I)C 7 1 0 java/lang/String isLatin1 ()Z 7 12 0 java/lang/StringLatin1 charAt ([BI)C 8 3 0 java/lang/String checkIndex (II)V 6 70 0 java/lang/String indexOf (II)I 7 1 0 java/lang/String isLatin1 ()Z 7 14 0 java/lang/String length ()I 8 6 0 java/lang/String coder ()B 7 17 0 java/lang/StringLatin1 indexOf ([BIII)I 8 1 0 java/lang/StringLatin1 canEncode (I)Z 6 89 0 java/lang/String charAt (I)C 7 1 0 java/lang/String isLatin1 ()Z 7 12 0 java/lang/StringLatin1 charAt ([BI)C 8 3 0 java/lang/String checkIndex (II)V 6 100 0 java/lang/String charAt (I)C 7 1 0 java/lang/String isLatin1 ()Z 7 12 0 java/lang/StringLatin1 charAt ([BI)C 8 3 0 java/lang/String checkIndex (II)V 5 217 0 org/lombokweb/asm/Label <init> ()V 6 1 0 java/lang/Object <init> ()V 2 17 0 java/util/ArrayList iterator ()Ljava/util/Iterator; 3 5 0 java/util/ArrayList$Itr <init> (Ljava/util/ArrayList;)V 4 6 0 java/lang/Object <init> ()V 2 72 0 java/util/ArrayList$Itr hasNext ()Z 2 29 0 java/util/ArrayList$Itr next ()Ljava/lang/Object; 3 1 0 java/util/ArrayList$Itr checkForComodification ()V 2 41 0 lombok/patcher/Hook getMethodName ()Ljava/lang/String; 2 45 0 java/lang/String equals (Ljava/lang/Object;)Z 2 84 0 java/util/ArrayList iterator ()Ljava/util/Iterator; 3 5 0 java/util/ArrayList$Itr <init> (Ljava/util/ArrayList;)V 4 6 0 java/lang/Object <init> ()V 2 147 0 java/util/ArrayList$Itr hasNext ()Z 2 96 0 java/util/ArrayList$Itr next ()Ljava/lang/Object; 3 1 0 java/util/ArrayList$Itr checkForComodification ()V 2 114 0 lombok/patcher/MethodTarget matches (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z 3 5 0 java/lang/String equals (Ljava/lang/Object;)Z 2 136 0 lombok/patcher/MethodLogistics <init> (ILjava/lang/String;)V 3 1 0 java/lang/Object <init> ()V 3 48 0 lombok/patcher/MethodLogistics sizeOf (Ljava/lang/String;)I 3 57 0 lombok/patcher/MethodLogistics returnOpcodeFor (Ljava/lang/String;)I 3 73 0 java/util/ArrayList <init> ()V 4 1 0 java/util/AbstractList <init> ()V 5 1 0 java/util/AbstractCollection <init> ()V 6 1 0 java/lang/Object <init> ()V 3 82 0 java/util/ArrayList <init> ()V 4 1 0 java/util/AbstractList <init> ()V 5 1 0 java/util/AbstractCollection <init> ()V 6 1 0 java/lang/Object <init> ()V 3 91 0 java/util/ArrayList <init> ()V 4 1 0 java/util/AbstractList <init> ()V 5 1 0 java/util/AbstractCollection <init> ()V 6 1 0 java/lang/Object <init> ()V 3 113 0 lombok/patcher/MethodLogistics sizeOf (Ljava/lang/String;)I 3 122 0 java/lang/Integer valueOf (I)Ljava/lang/Integer; 3 135 0 java/lang/Integer valueOf (I)Ljava/lang/Integer; 4 28 0 java/lang/Integer <init> (I)V 5 1 0 java/lang/Number <init> ()V 6 1 0 java/lang/Object <init> ()V 3 148 0 lombok/patcher/MethodLogistics loadOpcodeFor (Ljava/lang/String;)I 3 151 0 java/lang/Integer valueOf (I)Ljava/lang/Integer; 1 576 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 1 583 0 org/lombokweb/asm/MethodWriter canCopyMethodAttributes (Lorg/lombokweb/asm/ClassReader;ZZIII)Z 2 5 0 org/lombokweb/asm/SymbolTable getSource ()Lorg/lombokweb/asm/ClassReader; 2 55 0 org/lombokweb/asm/SymbolTable getMajorVersion ()I 2 106 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 2 137 0 org/lombokweb/asm/ClassReader readUnsignedShort (I)I 1 596 0 org/lombokweb/asm/MethodWriter setMethodAttributesSource (II)V

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -31,7 +31,7 @@ import io.javalin.http.NotFoundResponse;
 import umm3601.Controller;
 
 /**
- * Controller that manages requests for info about users.
+ * Controller that manages requests for info about todos.
  */
 public class TodoController implements Controller {
 
@@ -39,7 +39,7 @@ public class TodoController implements Controller {
   private static final String API_TODO_BY_ID = "/api/todos/{id}";
   static final String OWNER_KEY = "owner";
   static final String STATUS_KEY = "status";
-  static final String BODY_KEY = "body";
+  static final String BODY_KEY = "body"; //"contains?"
   static final String CATEGORY_KEY = "category";
   static final String LIMIT_KEY = "limit";
   static final String ORDER_KEY = "order";
@@ -140,20 +140,16 @@ public class TodoController implements Controller {
   private Bson constructFilter(Context ctx) {
     List<Bson> filters = new ArrayList<>(); // start with an empty list of filters
     if (ctx.queryParamMap().containsKey(CATEGORY_KEY)) {
-      String category = ctx.queryParamAsClass(CATEGORY_KEY, String.class)
-        .get();
+      String category = ctx.queryParam(CATEGORY_KEY);
       filters.add(eq(CATEGORY_KEY, category));
     }
 
     if (ctx.queryParamMap().containsKey(BODY_KEY)) {
-      String substring = ctx.queryParamAsClass(BODY_KEY, String.class)
-        .get();
+      String substring = ctx.queryParam(BODY_KEY);
       filters.add(regex(BODY_KEY, substring));
-
     }
     if (ctx.queryParamMap().containsKey(OWNER_KEY)) {
-      String owner = ctx.queryParamAsClass(OWNER_KEY, String.class)
-        .get();
+      String owner = ctx.queryParam(OWNER_KEY);
       filters.add(regex(OWNER_KEY, owner));
     }
     if (ctx.queryParamMap().containsKey(STATUS_KEY)) {

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -39,10 +39,10 @@ public class TodoController implements Controller {
   private static final String API_TODO_BY_ID = "/api/todos/{id}";
   static final String OWNER_KEY = "owner";
   static final String STATUS_KEY = "status";
-  static final String BODY_KEY = "body"; //"contains?"
+  static final String BODY_KEY = "contains"; //"body?"
   static final String CATEGORY_KEY = "category";
   static final String LIMIT_KEY = "limit";
-  static final String ORDER_KEY = "order";
+  static final String ORDER_KEY = "orderBy";
   static final String STATUS_REGEX = "^(complete|incomplete)$";
   // static final String AGE_KEY = "age";
   // static final String COMPANY_KEY = "company";
@@ -145,9 +145,10 @@ public class TodoController implements Controller {
     }
 
     if (ctx.queryParamMap().containsKey(BODY_KEY)) {
-      String substring = ctx.queryParam(BODY_KEY);
-      filters.add(regex(BODY_KEY, substring));
+      String body = ctx.queryParam(BODY_KEY);
+      filters.add(regex(BODY_KEY, body));
     }
+
     if (ctx.queryParamMap().containsKey(OWNER_KEY)) {
       String owner = ctx.queryParam(OWNER_KEY);
       filters.add(regex(OWNER_KEY, owner));

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -145,8 +145,8 @@ public class TodoController implements Controller {
     }
 
     if (ctx.queryParamMap().containsKey(BODY_KEY)) {
-      String body = ctx.queryParam(BODY_KEY);
-      filters.add(regex(BODY_KEY, body));
+      String substring = ctx.queryParam(BODY_KEY);
+      filters.add(regex("body", substring)); //the body parameter is now different from the Key.
     }
 
     if (ctx.queryParamMap().containsKey(OWNER_KEY)) {

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -2,6 +2,7 @@ package umm3601.todo;
 
 //import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 //import static org.junit.jupiter.api.Assertions.assertNotEquals;
 //import static org.junit.jupiter.api.Assertions.assertNotNull;
 //import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -17,13 +18,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-//import java.util.HashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 //import java.util.stream.Collectors;
 
 import org.bson.Document;
-//import org.bson.types.ObjectId;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,16 +46,21 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 import io.javalin.Javalin;
+import io.javalin.http.BadRequestResponse;
 //import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
 //import io.javalin.http.NotFoundResponse;
 //import io.javalin.json.JavalinJackson;
 //import io.javalin.validation.BodyValidator;
-//import io.javalin.validation.Validation;
 //import io.javalin.validation.ValidationError;
 //import io.javalin.validation.ValidationException;
 //import io.javalin.validation.Validator;
+//import umm3601.todo.TodoController;
+//import umm3601.user.UserController;
+import io.javalin.validation.Validation;
+import io.javalin.validation.Validator;
+//import umm3601.user.UserController;
 
 /**
  * Tests the logic of the UserController
@@ -69,7 +75,7 @@ import io.javalin.http.HttpStatus;
 // also a lot of "magic strings" that Checkstyle doesn't actually
 // flag as a problem) make more sense.
 @SuppressWarnings({ "MagicNumber" })
-class UserControllerSpec {
+class TodoControllerSpec {
 
   // An instance of the controller we're testing that is prepared in
   // `setupEach()`, and then exercised in the various tests below.
@@ -79,7 +85,7 @@ class UserControllerSpec {
   // in a few of the tests. It isn't used all that often, though,
   // which suggests that maybe we should extract the tests that
   // care about it into their own spec file?
-  //private ObjectId samsId;
+  private ObjectId testID;
 
   // The client and database that will be used
   // for all the tests in this spec file.
@@ -93,10 +99,10 @@ class UserControllerSpec {
   private Context ctx;
 
   @Captor
-  private ArgumentCaptor<ArrayList<Todo>> userArrayListCaptor;
+  private ArgumentCaptor<ArrayList<Todo>> todoArrayListCaptor;
 
   @Captor
-  private ArgumentCaptor<Todo> userCaptor;
+  private ArgumentCaptor<Todo> todoCaptor;
 
   @Captor
   private ArgumentCaptor<Map<String, String>> mapCaptor;
@@ -137,63 +143,40 @@ class UserControllerSpec {
     // Setup database
     MongoCollection<Document> todoDocuments = db.getCollection("todos");
     todoDocuments.drop();
+
     List<Document> testTodos = new ArrayList<>();
     testTodos.add(
         new Document()
           .append("owner", "Alfred")
           .append("status", false)
           .append("body", "Do the first thing")
-          .append("category", "Things")
-            // .append("name", "Chris")
-            // .append("age", 25)
-            // .append("company", "UMM")
-            // .append("email", "chris@this.that")
-            // .append("role", "admin")
-            // .append("avatar", "https://gravatar.com/avatar/8c9616d6cc5de638ea6920fb5d65fc6c?d=identicon")
+          .append("category", "homework")
           );
     testTodos.add(
         new Document()
          .append("owner", "Bob")
           .append("status", false)
           .append("body", "Do the second thing")
-          .append("category", "Things")
-            // .append("name", "Pat")
-            // .append("age", 37)
-            // .append("company", "IBM")
-            // .append("email", "pat@something.com")
-            // .append("role", "editor")
-            // .append("avatar", "https://gravatar.com/avatar/b42a11826c3bde672bce7e06ad729d44?d=identicon")
+          .append("category", "homework")
           );
     testTodos.add(
         new Document()
          .append("owner", "Clide")
-          .append("status", false)
+          .append("status", true)
           .append("body", "Do the third thing")
-          .append("category", "Things")
-            // .append("name", "Jamie")
-            // .append("age", 37)
-            // .append("company", "OHMNET")
-            // .append("email", "jamie@frogs.com")
-            // .append("role", "viewer")
-            // .append("avatar", "https://gravatar.com/avatar/d4a6c71dd9470ad4cf58f78c100258bf?d=identicon")
+          .append("category", "games")
           );
 
-    //samsId = new ObjectId();
-    Document sam = new Document()
+    testID = new ObjectId();
+    Document fourth = new Document()
+        .append("_id", testID)//This will be used later for testing purposes.
         .append("owner", "Dave")
-        .append("status", false)
+        .append("status", true)
         .append("body", "Do the fourth thing")
-        .append("category", "Things");
-        // .append("_id", samsId)
-        // .append("name", "Sam")
-        // .append("age", 45)
-        // .append("company", "OHMNET")
-        // .append("email", "sam@frogs.com")
-        // .append("role", "viewer")
-        // .append("avatar", "https://gravatar.com/avatar/08b7610b558a4cbbd20ae99072801f4d?d=identicon");
+        .append("category", "alphabetizing");
 
     todoDocuments.insertMany(testTodos);
-    todoDocuments.insertOne(sam);
+    todoDocuments.insertOne(fourth);
 
     todoController = new TodoController(db);
   }
@@ -214,993 +197,207 @@ class UserControllerSpec {
     // this case where we want all users).
     when(ctx.queryParamMap()).thenReturn(Collections.emptyMap());
 
-    // Now, go ahead and ask the userController to getUsers
+    // Now, go ahead and ask the todoController to getTodos
     // (which will, indeed, ask the context for its queryParamMap)
     todoController.getTodos(ctx);
 
-    // We are going to capture an argument to a function, and the type of
-    // that argument will be of type ArrayList<User> (we said so earlier
-    // using a Mockito annotation like this):
-    // @Captor
-    // private ArgumentCaptor<ArrayList<User>> userArrayListCaptor;
-    // We only want to declare that captor once and let the annotation
-    // help us accomplish reassignment of the value for the captor
-    // We reset the values of our annotated declarations using the command
-    // `MockitoAnnotations.openMocks(this);` in our @BeforeEach
-
-    // Specifically, we want to pay attention to the ArrayList<User> that
-    // is passed as input when ctx.json is called --- what is the argument
-    // that was passed? We capture it and can refer to it later.
-    verify(ctx).json(userArrayListCaptor.capture());
+    verify(ctx).json(todoArrayListCaptor.capture());
     verify(ctx).status(HttpStatus.OK);
 
     // Check that the database collection holds the same number of documents
-    // as the size of the captured List<User>
+    // as the size of the captured List<Todos>
     assertEquals(
         db.getCollection("todos").countDocuments(),
-        userArrayListCaptor.getValue().size());
+        todoArrayListCaptor.getValue().size());
   }
-} //Remove this!
-
-  /**
-   * Confirm that if we process a request for users with age 37,
-   * that all returned users have that age, and we get the correct
-   * number of users.
-   *
-   * The structure of this test is:
-   *
-   *    - We create a `Map` for the request's `queryParams`, that
-   *      contains a single entry, mapping the `AGE_KEY` to the
-   *      target value ("37"). This "tells" our `UserController`
-   *      that we want all the `User`s that have age 37.
-   *    - We create a validator that confirms that the code
-   *      we're testing calls `ctx.queryParamsAsClass("age", Integer.class)`,
-   *      i.e., it asks for the value in the query param map
-   *      associated with the key `"age"`, interpreted as an Integer.
-   *      That call needs to return a value of type `Validator<Integer>`
-   *      that will succeed and return the (integer) value `37` associated
-   *      with the (`String`) parameter value `"37"`.
-   *    - We then call `userController.getUsers(ctx)` to run the code
-   *      being tested with the constructed context `ctx`.
-   *    - We also use the `userListArrayCaptor` (defined above)
-   *      to capture the `ArrayList<User>` that the code under test
-   *      passes to `ctx.json(…)`. We can then confirm that the
-   *      correct list of users (i.e., all the users with age 37)
-   *      is passed in to be returned in the context.
-   *    - Now we can use a variety of assertions to confirm that
-   *      the code under test did the "right" thing:
-   *       - Confirm that the list of users has length 2
-   *       - Confirm that each user in the list has age 37
-   *       - Confirm that their names are "Jamie" and "Pat"
-   *
-   * @throws IOException
-   */
-  // @Test
-  // void canGetUsersWithAge37() throws IOException {
-  //   // We'll need both `String` and `Integer` representations of
-  //   // the target age, so I'm defining both here.
-  //   Integer targetAge = 37;
-  //   String targetAgeString = targetAge.toString();
-
-  //   // Create a `Map` for the `queryParams` that will "return" the string
-  //   // "37" if you ask for the value associated with the `AGE_KEY`.
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-
-  //   queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {targetAgeString}));
-  //   // When the code being tested calls `ctx.queryParamMap()` return the
-  //   // the `queryParams` map we just built.
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   // When the code being tested calls `ctx.queryParam(AGE_KEY)` return the
-  //   // `targetAgeString`.
-  //   when(ctx.queryParam(UserController.AGE_KEY)).thenReturn(targetAgeString);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `AGE_KEY` _as an integer_, we get back the integer value 37.
-  //   Validation validation = new Validation();
-  //   // The `AGE_KEY` should be name of the key whose value is being validated.
-  //   // You can actually put whatever you want here, because it's only used in the generation
-  //   // of testing error reports, but using the actually key value will make those reports more informative.
-  //   Validator<Integer> validator = validation.validator(UserController.AGE_KEY, Integer.class, targetAgeString);
-  //   // When the code being tested calls `ctx.queryParamAsClass("age", Integer.class)`
-  //   // we'll return the `Validator` we just constructed.
-  //   when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class))
-  //       .thenReturn(validator);
-
-  //   userController.getUsers(ctx);
-
-  //   // Confirm that the code being tested calls `ctx.json(…)`, and capture whatever
-  //   // is passed in as the argument when `ctx.json()` is called.
-  //   verify(ctx).json(userArrayListCaptor.capture());
-  //   // Confirm that the code under test calls `ctx.status(HttpStatus.OK)` is called.
-  //   verify(ctx).status(HttpStatus.OK);
-
-  //   // Confirm that we get back two users.
-  //   assertEquals(2, userArrayListCaptor.getValue().size());
-  //   // Confirm that both users have age 37.
-  //   for (User user : userArrayListCaptor.getValue()) {
-  //     assertEquals(targetAge, user.age);
-  //   }
-  //   // Generate a list of the names of the returned users.
-  //   List<String> names = userArrayListCaptor.getValue().stream().map(user -> user.name).collect(Collectors.toList());
-  //   // Confirm that the returned `names` contain the two names of the
-  //   // 37-year-olds.
-  //   assertTrue(names.contains("Jamie"));
-  //   assertTrue(names.contains("Pat"));
-  // }
-
-  /**
-   * Confirm that if we process a request for users with age 37,
-   * that all returned users have that age, and we get the correct
-   * number of users.
-   *
-   * Instead of using the Captor like in many other tests, in this test
-   * we use an ArgumentMatcher just to show how that can be used, illustrating
-   * another way to test the same thing.
-   *
-   * An `ArgumentMatcher` has a method `matches` that returns `true`
-   * if the argument passed to `ctx.json(…)` (a `List<User>` in this case)
-   * has the desired properties.
-   *
-   * This is probably overkill here, but it does illustrate a different
-   * approach to writing tests.
-   *
-   * @throws JsonMappingException
-   * @throws JsonProcessingException
-   */
-  // @Test
-  // void canGetUsersWithAge37Redux() throws JsonMappingException, JsonProcessingException {
-  //   // We'll need both `String` and `Integer` representations of
-  //   // the target age, so I'm defining both here.
-  //   Integer targetAge = 37;
-  //   String targetAgeString = targetAge.toString();
-
-  //   // When the controller calls `ctx.queryParamMap`, return the expected map for an
-  //   // "?age=37" query.
-  //   when(ctx.queryParamMap()).thenReturn(Map.of(UserController.AGE_KEY, List.of(targetAgeString)));
-  //   // When the code being tested calls `ctx.queryParam(AGE_KEY)` return the
-  //   // `targetAgeString`.
-  //   when(ctx.queryParam(UserController.AGE_KEY)).thenReturn(targetAgeString);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `AGE_KEY` _as an integer_, we get back the integer value 37.
-  //   Validation validation = new Validation();
-  //   // The `AGE_KEY` should be name of the key whose value is being validated.
-  //   // You can actually put whatever you want here, because it's only used in the generation
-  //   // of testing error reports, but using the actually key value will make those reports more informative.
-  //   Validator<Integer> validator = validation.validator(UserController.AGE_KEY, Integer.class, targetAgeString);
-  //   when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class)).thenReturn(validator);
-
-  //   // Call the method under test.
-  //   userController.getUsers(ctx);
-
-  //   // Verify that `getUsers` included a call to `ctx.status(HttpStatus.OK)` at some
-  //   // point.
-  //   verify(ctx).status(HttpStatus.OK);
-
-  //   // Verify that `ctx.json()` is called with a `List` of `User`s.
-  //   // Each of those `User`s should have age 37.
-  //   verify(ctx).json(argThat(new ArgumentMatcher<List<User>>() {
-  //     @Override
-  //     public boolean matches(List<User> users) {
-  //       for (User user : users) {
-  //         assertEquals(targetAge, user.age);
-  //       }
-  //       assertEquals(2, users.size());
-  //       return true;
-  //     }
-  //   }));
-  // }
-
-  /**
-   * Test that if the user sends a request with an illegal value in
-   * the age field (i.e., something that can't be parsed to a number)
-   * we get a reasonable error back.
-   */
-  // @Test
-  // void respondsAppropriatelyToNonNumericAge() {
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   String illegalIntegerString = "bad integer string";
-  //   queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {illegalIntegerString}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   // When the code being tested calls `ctx.queryParam(AGE_KEY)` return the
-  //   // `illegalIntegerString`.
-  //   when(ctx.queryParam(UserController.AGE_KEY)).thenReturn(illegalIntegerString);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `AGE_KEY` _as an integer_, we get back the `illegalIntegerString`.
-  //   Validation validation = new Validation();
-  //   // The `AGE_KEY` should be name of the key whose value is being validated.
-  //   // You can actually put whatever you want here, because it's only used in the generation
-  //   // of testing error reports, but using the actually key value will make those reports more informative.
-  //   Validator<Integer> validator = validation.validator(UserController.AGE_KEY, Integer.class, illegalIntegerString);
-  //   when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class)).thenReturn(validator);
-
-  //   // This should now throw a `ValidationException` because
-  //   // our request has an age that can't be parsed to a number.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.getUsers(ctx);
-  //   });
-  //   // This digs into the returned `ValidationException` to get the underlying `Exception` that caused
-  //   // the validation to fail:
-  //   //   - `exception.getErrors` returns a `Map` that maps keys (like `AGE_KEY`) to lists of
-  //   //      validation errors for that key
-  //   //   - `.get(AGE_KEY)` returns a list of all the validation errors associated with `AGE_KEY`
-  //   //   - `.get(0)` assumes that the root cause is the first error in the list. In our case there
-  //   //     is only one root cause,
-  //   //     so that's safe, but you might be careful about that assumption in other contexts.
-  //   //   - `.exception()` gets the actually `Exception` value that was the underlying cause
-  //   Exception exceptionCause = exception.getErrors().get(UserController.AGE_KEY).get(0).exception();
-  //The cause should have been a `NumberFormatException` (what is thrown when we try to parse "bad" as an integer).
-  //   assertEquals(NumberFormatException.class, exceptionCause.getClass());
-  //   // The message for that `NumberFOrmatException` should include the text it tried to parse as an integer,
-  //   // i.e., `"bad integer string"`.
-  //   assertTrue(exceptionCause.getMessage().contains(illegalIntegerString));
-  // }
-
-  // /**
-  //  * Test that if the user sends a request with an illegal value in
-  //  * the age field (i.e., too big of a number)
-  //  * we get a reasonable error code back.
-  //  */
-  // @Test
-  // void respondsAppropriatelyToTooLargeNumberAge() {
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   String overlyLargeAgeString = "151";
-  //   queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {overlyLargeAgeString}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   // When the code being tested calls `ctx.queryParam(AGE_KEY)` return the
-  //   // `overlyLargeAgeString`.
-  //   when(ctx.queryParam(UserController.AGE_KEY)).thenReturn(overlyLargeAgeString);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `AGE_KEY` _as an integer_, we get back the integer value 37.
-  //   Validation validation = new Validation();
-  //   // The `AGE_KEY` should be name of the key whose value is being validated.
-  //   // You can actually put whatever you want here, because it's only used in the generation
-  //   // of testing error reports, but using the actually key value will make those reports more informative.
-  //   Validator<Integer> validator = validation.validator(UserController.AGE_KEY, Integer.class, overlyLargeAgeString);
-  //   when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class)).thenReturn(validator);
-
-  //   // This should now throw a `ValidationException` because
-  //   // our request has an age that is larger than 150, which isn't allowed.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.getUsers(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error and confirm that it contains the problematic string, since that would be useful information
-  //   // for someone trying to debug a case where this validation fails.
-  //   String exceptionMessage = exception.getErrors().get(UserController.AGE_KEY).get(0).getMessage();
-  //   // The message should be the message from our code under test, which should include the text we
-  //   // tried to parse as an age, namely "151".
-  //   assertTrue(exceptionMessage.contains(overlyLargeAgeString));
-  // }
-
-  /**
-   * Test that if the user sends a request with an illegal value in
-   * the age field (i.e., too small of a number)
-   * we get a reasonable error code back.
-   */
-  // @Test
-  // void respondsAppropriatelyToTooSmallNumberAge() {
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   String negativeAgeString = "-1";
-  //   queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {negativeAgeString}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   // When the code being tested calls `ctx.queryParam(AGE_KEY)` return the
-  //   // `negativeAgeString`.
-  //   when(ctx.queryParam(UserController.AGE_KEY)).thenReturn(negativeAgeString);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `AGE_KEY` _as an integer_, we get back the string value `negativeAgeString`.
-  //   Validation validation = new Validation();
-  //   // The `AGE_KEY` should be name of the key whose value is being validated.
-  //   // You can actually put whatever you want here, because it's only used in the generation
-  //   // of testing error reports, but using the actually key value will make those reports more informative.
-  //   Validator<Integer> validator = validation.validator(UserController.AGE_KEY, Integer.class, negativeAgeString);
-  //   when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class)).thenReturn(validator);
-
-  //   // This should now throw a `ValidationException` because
-  //   // our request has an age that is larger than 150, which isn't allowed.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.getUsers(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error and confirm that it contains the problematic string, since that would be useful information
-  //   // for someone trying to debug a case where this validation fails.
-  //   String exceptionMessage = exception.getErrors().get(UserController.AGE_KEY).get(0).getMessage();
-  //   // The message should be the message from our code under test, which should include the text we
-  //   // tried to parse as an age, namely "-1".
-  //   assertTrue(exceptionMessage.contains(negativeAgeString));
-  // }
-
-  // @Test
-  // void canGetUsersWithCompany() throws IOException {
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   queryParams.put(UserController.COMPANY_KEY, Arrays.asList(new String[] {"OHMNET"}));
-  //   queryParams.put(UserController.SORT_ORDER_KEY, Arrays.asList(new String[] {"desc"}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   when(ctx.queryParam(UserController.COMPANY_KEY)).thenReturn("OHMNET");
-  //   when(ctx.queryParam(UserController.SORT_ORDER_KEY)).thenReturn("desc");
-
-  //   userController.getUsers(ctx);
-
-  //   verify(ctx).json(userArrayListCaptor.capture());
-  //   verify(ctx).status(HttpStatus.OK);
-
-  //   // Confirm that all the users passed to `json` work for OHMNET.
-  //   for (User user : userArrayListCaptor.getValue()) {
-  //     assertEquals("OHMNET", user.company);
-  //   }
-  // }
-
-  // @Test
-  // void canGetUsersWithCompanyLowercase() throws IOException {
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   queryParams.put(UserController.COMPANY_KEY, Arrays.asList(new String[] {"ohm"}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   when(ctx.queryParam(UserController.COMPANY_KEY)).thenReturn("ohm");
-
-  //   userController.getUsers(ctx);
-
-  //   verify(ctx).json(userArrayListCaptor.capture());
-  //   verify(ctx).status(HttpStatus.OK);
-
-  //   // Confirm that all the users passed to `json` work for OHMNET.
-  //   for (User user : userArrayListCaptor.getValue()) {
-  //     assertEquals("OHMNET", user.company);
-  //   }
-  // }
-
-  // @Test
-  // void getUsersByRole() throws IOException {
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   String roleString = "viewer";
-  //   queryParams.put(UserController.ROLE_KEY, Arrays.asList(new String[] {roleString}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `ROLE_KEY` we get back a string that represents a legal role.
-  //   Validation validation = new Validation();
-  //   Validator<String> validator = validation.validator(UserController.ROLE_KEY, String.class, roleString);
-  //   when(ctx.queryParamAsClass(UserController.ROLE_KEY, String.class)).thenReturn(validator);
-
-  //   userController.getUsers(ctx);
-
-  //   verify(ctx).json(userArrayListCaptor.capture());
-  //   verify(ctx).status(HttpStatus.OK);
-  //   assertEquals(2, userArrayListCaptor.getValue().size());
-  // }
-
-  // @Test
-  // void getUsersByCompanyAndAge() throws IOException {
-  //   String targetCompanyString = "OHMNET";
-  //   Integer targetAge = 37;
-  //   String targetAgeString = targetAge.toString();
-
-  //   Map<String, List<String>> queryParams = new HashMap<>();
-  //   queryParams.put(UserController.COMPANY_KEY, Arrays.asList(new String[] {targetCompanyString}));
-  //   queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {targetAgeString}));
-  //   when(ctx.queryParamMap()).thenReturn(queryParams);
-  //   when(ctx.queryParam(UserController.COMPANY_KEY)).thenReturn(targetCompanyString);
-
-  //   // Create a validator that confirms that when we ask for the value associated with
-  //   // `AGE_KEY` _as an integer_, we get back the integer value 37.
-  //   Validation validation = new Validation();
-  //   Validator<Integer> validator = validation.validator(UserController.AGE_KEY, Integer.class, targetAgeString);
-  //   when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class)).thenReturn(validator);
-  //   when(ctx.queryParam(UserController.AGE_KEY)).thenReturn(targetAgeString);
-
-  //   userController.getUsers(ctx);
-
-  //   verify(ctx).json(userArrayListCaptor.capture());
-  //   verify(ctx).status(HttpStatus.OK);
-  //   assertEquals(1, userArrayListCaptor.getValue().size());
-  //   for (User user : userArrayListCaptor.getValue()) {
-  //     assertEquals(targetCompanyString, user.company);
-  //     assertEquals(targetAge, user.age);
-  //   }
-  // }
-
-  // @Test
-  // void getUserWithExistentId() throws IOException {
-  //   String id = samsId.toHexString();
-  //   when(ctx.pathParam("id")).thenReturn(id);
-
-  //   userController.getUser(ctx);
-
-  //   verify(ctx).json(userCaptor.capture());
-  //   verify(ctx).status(HttpStatus.OK);
-  //   assertEquals("Sam", userCaptor.getValue().name);
-  //   assertEquals(samsId.toHexString(), userCaptor.getValue()._id);
-  // }
-
-  // @Test
-  // void getUserWithBadId() throws IOException {
-  //   when(ctx.pathParam("id")).thenReturn("bad");
-
-  //   Throwable exception = assertThrows(BadRequestResponse.class, () -> {
-  //     userController.getUser(ctx);
-  //   });
-
-  //   assertEquals("The requested user id wasn't a legal Mongo Object ID.", exception.getMessage());
-  // }
-
-  // @Test
-  // void getUserWithNonexistentId() throws IOException {
-  //   String id = "588935f5c668650dc77df581";
-  //   when(ctx.pathParam("id")).thenReturn(id);
-
-  //   Throwable exception = assertThrows(NotFoundResponse.class, () -> {
-  //     userController.getUser(ctx);
-  //   });
-
-  //   assertEquals("The requested user was not found", exception.getMessage());
-  // }
-
-  // @Captor
-  // private ArgumentCaptor<ArrayList<UserByCompany>> userByCompanyListCaptor;
-
-  // @Test
-  // void testGetUsersGroupedByCompany() {
-  //   when(ctx.queryParam("sortBy")).thenReturn("company");
-  //   when(ctx.queryParam("sortOrder")).thenReturn("asc");
-  //   userController.getUsersGroupedByCompany(ctx);
-
-  //   // Capture the argument to `ctx.json()`
-  //   verify(ctx).json(userByCompanyListCaptor.capture());
-
-  //   // Get the value that was passed to `ctx.json()`
-  //   ArrayList<UserByCompany> result = userByCompanyListCaptor.getValue();
-
-  //   // There are 3 companies in the test data, so we should have 3 entries in the
-  //   // result.
-  //   assertEquals(3, result.size());
-
-  //   // The companies should be in alphabetical order by company name,
-  //   // and with user counts of 1, 2, and 1, respectively.
-  //   UserByCompany ibm = result.get(0);
-  //   assertEquals("IBM", ibm._id);
-  //   assertEquals(1, ibm.count);
-  //   UserByCompany ohmnet = result.get(1);
-  //   assertEquals("OHMNET", ohmnet._id);
-  //   assertEquals(2, ohmnet.count);
-  //   UserByCompany umm = result.get(2);
-  //   assertEquals("UMM", umm._id);
-  //   assertEquals(1, umm.count);
-
-  //   // The users for OHMNET should be Jamie and Sam, although we don't
-  //   // know what order they'll be in.
-  //   assertEquals(2, ohmnet.users.size());
-  //   assertTrue(ohmnet.users.get(0).name.equals("Jamie") || ohmnet.users.get(0).name.equals("Sam"),
-  //       "First user should have name 'Jamie' or 'Sam'");
-  //   assertTrue(ohmnet.users.get(1).name.equals("Jamie") || ohmnet.users.get(1).name.equals("Sam"),
-  //       "Second user should have name 'Jamie' or 'Sam'");
-  // }
-
-  // @Test
-  // void testGetUsersGroupedByCompanyDescending() {
-  //   when(ctx.queryParam("sortBy")).thenReturn("company");
-  //   when(ctx.queryParam("sortOrder")).thenReturn("desc");
-  //   userController.getUsersGroupedByCompany(ctx);
-
-  //   // Capture the argument to `ctx.json()`
-  //   verify(ctx).json(userByCompanyListCaptor.capture());
-
-  //   // Get the value that was passed to `ctx.json()`
-  //   ArrayList<UserByCompany> result = userByCompanyListCaptor.getValue();
-
-  //   // There are 3 companies in the test data, so we should have 3 entries in the
-  //   // result.
-  //   assertEquals(3, result.size());
-
-  //   // The companies should be in reverse alphabetical order by company name,
-  //   // and with user counts of 1, 2, and 1, respectively.
-  //   UserByCompany umm = result.get(0);
-  //   assertEquals("UMM", umm._id);
-  //   assertEquals(1, umm.count);
-  //   UserByCompany ohmnet = result.get(1);
-  //   assertEquals("OHMNET", ohmnet._id);
-  //   assertEquals(2, ohmnet.count);
-  //   UserByCompany ibm = result.get(2);
-  //   assertEquals("IBM", ibm._id);
-  //   assertEquals(1, ibm.count);
-  // }
-
-  // @Test
-  // void testGetUsersGroupedByCompanyOrderedByCount() {
-  //   when(ctx.queryParam("sortBy")).thenReturn("count");
-  //   when(ctx.queryParam("sortOrder")).thenReturn("asc");
-  //   userController.getUsersGroupedByCompany(ctx);
-
-  //   // Capture the argument to `ctx.json()`
-  //   verify(ctx).json(userByCompanyListCaptor.capture());
-
-  //   // Get the value that was passed to `ctx.json()`
-  //   ArrayList<UserByCompany> result = userByCompanyListCaptor.getValue();
-
-  //   // There are 3 companies in the test data, so we should have 3 entries in the
-  //   // result.
-  //   assertEquals(3, result.size());
-
-  //   // The companies should be in order by user count, and with counts of 1, 1, and
-  //   // 2,
-  //   // respectively. We don't know which order "IBM" and "UMM" will be in, since
-  //   // they
-  //   // both have a count of 1. So we'll get them both and then swap them if
-  //   // necessary.
-  //   UserByCompany ibm = result.get(0);
-  //   UserByCompany umm = result.get(1);
-  //   if (ibm._id.equals("UMM")) {
-  //     umm = result.get(0);
-  //     ibm = result.get(1);
-  //   }
-  //   UserByCompany ohmnet = result.get(2);
-  //   assertEquals("IBM", ibm._id);
-  //   assertEquals(1, ibm.count);
-  //   assertEquals("UMM", umm._id);
-  //   assertEquals(1, umm.count);
-  //   assertEquals("OHMNET", ohmnet._id);
-  //   assertEquals(2, ohmnet.count);
-  // }
-
-  // @Test
-  // void addUser() throws IOException {
-  //   // Create a new user to add
-  //   User newUser = new User();
-  //   newUser.name = "Test User";
-  //   newUser.age = 25;
-  //   newUser.company = "testers";
-  //   newUser.email = "test@example.com";
-  //   newUser.role = "viewer";
-
-  //   // Use `javalinJackson` to convert the `User` object to a JSON string representing that user.
-  //   // This would be equivalent to:
-  //   //   String testNewUser = """
-  //   //       {
-  //   //         "name": "Test User",
-  //   //         "age": 25,
-  //   //         "company": "testers",
-  //   //         "email": "test@example.com",
-  //   //         "role": "viewer"
-  //   //       }
-  //   //       """;
-  //   // but using `javalinJackson` to generate the JSON avoids repeating all the field values,
-  //   // which is then less error prone.
-  //   String newUserJson = javalinJackson.toJsonString(newUser, User.class);
-
-  //   // A `BodyValidator` needs
-  //   //   - The string (`newUserJson`) being validated
-  //   //   - The class (`User.class) it's trying to generate from that string
-  //   //   - A function (`() -> User`) which "shows" the validator how to convert
-  //   //     the JSON string to a `User` object. We'll again use `javalinJackson`,
-  //   //     but in the other direction.
-  //   when(ctx.bodyValidator(User.class))
-  //     .thenReturn(new BodyValidator<User>(newUserJson, User.class,
-  //                   () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   userController.addNewUser(ctx);
-  //   verify(ctx).json(mapCaptor.capture());
-
-  //   // Our status should be 201, i.e., our new user was successfully created.
-  //   verify(ctx).status(HttpStatus.CREATED);
-
-  //   // Verify that the user was added to the database with the correct ID
-  //   Document addedUser = db.getCollection("users")
-  //       .find(eq("_id", new ObjectId(mapCaptor.getValue().get("id")))).first();
-
-  //   // Successfully adding the user should return the newly generated, non-empty
-  //   // MongoDB ID for that user.
-  //   assertNotEquals("", addedUser.get("_id"));
-  //   // The new user in the database (`addedUser`) should have the same
-  //   // field values as the user we asked it to add (`newUser`).
-  //   assertEquals(newUser.name, addedUser.get("name"));
-  //   assertEquals(newUser.age, addedUser.get(UserController.AGE_KEY));
-  //   assertEquals(newUser.company, addedUser.get(UserController.COMPANY_KEY));
-  //   assertEquals(newUser.email, addedUser.get("email"));
-  //   assertEquals(newUser.role, addedUser.get(UserController.ROLE_KEY));
-  //   assertNotNull(addedUser.get("avatar"));
-  // }
-
-  // @Test
-  // void addInvalidEmailUser() throws IOException {
-  //   // Create a new user JSON string to add.
-  //   // Note that it has an invalid string for the email address, which is
-  //   // why we're using a `String` here instead of a `User` object
-  //   // like we did in the previous tests.
-  //   String newUserJson = """
-  //     {
-  //       "name": "Test User",
-  //       "age": 25,
-  //       "company": "testers",
-  //       "email": "invalidemail",
-  //       "role": "viewer"
-  //     }
-  //     """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //     .thenReturn(new BodyValidator<User>(newUserJson, User.class,
-  //                   () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an invalid email address.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include the text
-  //   // we tried to parse as an email, namely "invalidemail".
-  //   assertTrue(exceptionMessage.contains("invalidemail"));
-  // }
-
-  // @Test
-  // void addInvalidAgeUser() throws IOException {
-  //   // Create a new user JSON string to add.
-  //   // Note that it has a string for the age that can't be parsed to a number.
-  //   String newUserJson = """
-  //     {
-  //       "name": "Test User",
-  //       "age": "notanumber",
-  //       "company": "testers",
-  //       "email": "test@example.com",
-  //       "role": "viewer"
-  //     }
-  //     """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .thenReturn(new BodyValidator<User>(newUserJson, User.class,
-  //                     () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an invalid email address.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include the text
-  //   // we tried to parse as an email, namely "notanumber".
-  //   assertTrue(exceptionMessage.contains("notanumber"));
-  // }
-
-  // @Test
-  // void addNegativeAgeUser() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "name": "Test User",
-  //         "age": -17,
-  //         "company": "testers",
-  //         "email": "test@example.com",
-  //         "role": "viewer"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .thenReturn(new BodyValidator<User>(newUserJson, User.class,
-  //                     () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an age that's too large.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include the text
-  //   // we tried to use as an age, namely "-17".
-  //   assertTrue(exceptionMessage.contains("-17"));
-  // }
-
-  // @Test
-  // void add150AgeUser() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "name": "Test User",
-  //         "age": 150,
-  //         "company": "testers",
-  //         "email": "test@example.com",
-  //         "role": "viewer"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .then(value -> new BodyValidator<User>(newUserJson, User.class,
-  //                       () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an invalid email address.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include the text
-  //   // we tried to use as an age, namely "150".
-  //   assertTrue(exceptionMessage.contains("150"));
-  // }
-
-  // @Test
-  // void addUserWithoutName() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "age": 25,
-  //         "company": "testers",
-  //         "email": "test@example.com",
-  //         "role": "viewer"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .then(value -> new BodyValidator<User>(newUserJson, User.class,
-  //                       () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has no name.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include some text
-  //   // indicating that there was a missing user name.
-  //   assertTrue(exceptionMessage.contains("non-empty user name"));
-  // }
-
-  // @Test
-  // void addEmptyNameUser() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "name": "",
-  //         "age": 25,
-  //         "company": "testers",
-  //         "email": "test@example.com",
-  //         "role": "viewer"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .then(value -> new BodyValidator<User>(newUserJson, User.class,
-  //                       () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an invalid email address.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include some text
-  //   // indicating that there was an empty string for the user name.
-  //   assertTrue(exceptionMessage.contains("non-empty user name"));
-  // }
-
-  // @Test
-  // void addInvalidRoleUser() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "name": "Test User",
-  //         "age": 25,
-  //         "company": "testers",
-  //         "email": "test@example.com",
-  //         "role": "invalidrole"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .then(value -> new BodyValidator<User>(newUserJson, User.class,
-  //                       () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an invalid user role.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include the text
-  //   // we tried to use as a role, namely "invalidrole".
-  //   assertTrue(exceptionMessage.contains("invalidrole"));
-  // }
-
-  // @Test
-  // void addUserWithoutCompany() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "name": "Test User",
-  //         "age": 25,
-  //         "email": "test@example.com",
-  //         "role": "viewer"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .then(value -> new BodyValidator<User>(newUserJson, User.class,
-  //                       () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has no company.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // This `ValidationException` was caused by a custom check, so we just get the message from the first
-  //   // error (which is a `"REQUEST_BODY"` error) and convert that to a string with `toString()`. This gives
-  //   // a `String` that has all the details of the exception, which we can make sure contains information
-  //   // that would help a developer sort out validation errors.
-  //   String exceptionMessage = exception.getErrors().get("REQUEST_BODY").get(0).toString();
-
-  //   // The message should be the message from our code under test, which should also include some text
-  //   // indicating that there was a missing company name.
-  //   assertTrue(exceptionMessage.contains("non-empty company name"));
-  // }
-
-  // @Test
-  // void addUserWithNeitherCompanyNorName() throws IOException {
-  //   String newUserJson = """
-  //       {
-  //         "name": "",
-  //         "age": 25,
-  //         "company": "",
-  //         "email": "test@example.com",
-  //         "role": "viewer"
-  //       }
-  //       """;
-
-  //   when(ctx.body()).thenReturn(newUserJson);
-  //   when(ctx.bodyValidator(User.class))
-  //       .then(value -> new BodyValidator<User>(newUserJson, User.class,
-  //                       () -> javalinJackson.fromJsonString(newUserJson, User.class)));
-
-  //   // This should now throw a `ValidationException` because
-  //   // the JSON for our new user has an invalid email address.
-  //   ValidationException exception = assertThrows(ValidationException.class, () -> {
-  //     userController.addNewUser(ctx);
-  //   });
-  //   // We should have _two_ errors here both of type `REQUEST_BODY`. The first should be for the
-  //   // missing name and the second for the missing company.
-  //   List<ValidationError<Object>> errors = exception.getErrors().get("REQUEST_BODY");
-
-  //   // Check the user name error
-  //   // It's a little fragile to have the tests assume the user error is first and the
-  //   // company error is second.
-  //   String nameExceptionMessage = errors.get(0).toString();
-  //   assertTrue(nameExceptionMessage.contains("non-empty user name"));
-
-  //   // Check the company name error
-  //   String companyExceptionMessage = errors.get(1).toString();
-  //   assertTrue(companyExceptionMessage.contains("non-empty company name"));
-  // }
-
-  // @Test
-  // void deleteFoundUser() throws IOException {
-  //   String testID = samsId.toHexString();
-  //   when(ctx.pathParam("id")).thenReturn(testID);
-
-  //   // User exists before deletion
-  //   assertEquals(1, db.getCollection("users").countDocuments(eq("_id", new ObjectId(testID))));
-
-  //   userController.deleteUser(ctx);
-
-  //   verify(ctx).status(HttpStatus.OK);
-
-  //   // User is no longer in the database
-  //   assertEquals(0, db.getCollection("users").countDocuments(eq("_id", new ObjectId(testID))));
-  // }
-
-  // @Test
-  // void tryToDeleteNotFoundUser() throws IOException {
-  //   String testID = samsId.toHexString();
-  //   when(ctx.pathParam("id")).thenReturn(testID);
-
-  //   userController.deleteUser(ctx);
-  //   // User is no longer in the database
-  //   assertEquals(0, db.getCollection("users").countDocuments(eq("_id", new ObjectId(testID))));
-
-  //   assertThrows(NotFoundResponse.class, () -> {
-  //     userController.deleteUser(ctx);
-  //   });
-
-  //   verify(ctx).status(HttpStatus.NOT_FOUND);
-
-  //   // User is still not in the database
-  //   assertEquals(0, db.getCollection("users").countDocuments(eq("_id", new ObjectId(testID))));
-  // }
-
-  /**
-   * Test that the `generateAvatar` method works as expected.
-   *
-   * To test this code, we need to mock out the `md5()` method so we
-   * can control what it returns. This way we don't have to figure
-   * out what the actual md5 hash of a particular email address is.
-   *
-   * The use of `Mockito.spy()` essentially allows us to override
-   * the `md5()` method, while leaving the rest of the user controller
-   * "as is". This is a nice way to test a method that depends on
-   * an internal method that we don't want to test (`md5()` in this case).
-   *
-   * This code was suggested by GitHub CoPilot.
-   *
-   * @throws NoSuchAlgorithmException
-   */
-  // @Test
-  // void testGenerateAvatar() throws NoSuchAlgorithmException {
-  //   // Arrange
-  //   String email = "test@example.com";
-  //   UserController controller = Mockito.spy(userController);
-  //   when(controller.md5(email)).thenReturn("md5hash");
-
-  //   // Act
-  //   String avatar = controller.generateAvatar(email);
-
-  //   // Assert
-  //   assertEquals("https://gravatar.com/avatar/md5hash?d=identicon", avatar);
-  // }
-
-  /**
-   * Test that the `generateAvatar` throws a `NoSuchAlgorithmException`
-   * if it can't find the `md5` hashing algorithm.
-   *
-   * To test this code, we need to mock out the `md5()` method so we
-   * can control what it returns. In particular, we want `.md5()` to
-   * throw a `NoSuchAlgorithmException`, which we can't do without
-   * mocking `.md5()` (since the algorithm does actually exist).
-   *
-   * The use of `Mockito.spy()` essentially allows us to override
-   * the `md5()` method, while leaving the rest of the user controller
-   * "as is". This is a nice way to test a method that depends on
-   * an internal method that we don't want to test (`md5()` in this case).
-   *
-   * This code was suggested by GitHub CoPilot.
-   *
-   * @throws NoSuchAlgorithmException
-   */
-//   @Test
-//   void testGenerateAvatarWithException() throws NoSuchAlgorithmException {
-//     // Arrange
-//     String email = "test@example.com";
-//     UserController controller = Mockito.spy(userController);
-//     when(controller.md5(email)).thenThrow(NoSuchAlgorithmException.class);
-
-//     // Act
-//     String avatar = controller.generateAvatar(email);
-
-//     // Assert
-//     assertEquals("https://gravatar.com/avatar/?d=mp", avatar);
-//   }
-// }
+
+  @Test
+  void getTodoWithExistentId() throws IOException {
+    String id = testID.toHexString();
+    when(ctx.pathParam("id")).thenReturn(id);
+
+    todoController.getTodo(ctx);
+
+    //The todoCaptor only captures a single Todo.
+    verify(ctx).json(todoCaptor.capture());
+    verify(ctx).status(HttpStatus.OK);
+    assertEquals("Dave", todoCaptor.getValue().owner);
+    assertEquals(id, todoCaptor.getValue()._id);
+  }
+
+  @Test
+  void getTodoWithBadId() throws IOException {
+    when(ctx.pathParam("id")).thenReturn("bad");
+
+    Throwable exception = assertThrows(BadRequestResponse.class, () -> {
+      todoController.getTodo(ctx);
+    });
+
+    assertEquals("The requested todo id wasn't a legal Mongo Object ID.", exception.getMessage());
+  }
+
+  @Test
+  void listTodosByCategory() throws IOException {
+     Map<String, List<String>> queryParams = new HashMap<>();
+      queryParams.put(TodoController.CATEGORY_KEY, Arrays.asList(new String[] {"homework"}));
+      //Whenever the TodoController would use queryParamMap; provide the tests's queryParams instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use queryParam; provide the string "homework" instead.
+      when(ctx.queryParam(TodoController.CATEGORY_KEY)).thenReturn("homework");
+
+      //Validator is only necessary if we're using 'queryParamAsClass.' In this case, we're just expecting a raw string.
+      // Validation validation = new Validation();
+      // Validator<String> validator = validation.validator(TodoController.CATEGORY_KEY, String.class, "homework");
+      // when(ctx.queryParamAsClass(TodoController.CATEGORY_KEY, String.class)).thenReturn(validator);
+
+      todoController.getTodos(ctx);
+    //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+      // Confirm that all the todos passed to `json` have the requested category.
+      for (Todo todo : todoArrayListCaptor.getValue()) {
+        assertEquals("homework", todo.category);
+      }
+  }
+
+  @Test
+  void testLimitTodos() throws IOException {
+      //Integer targetLimit = 67;
+      String targetLimitString = "3"; //targetLimit.toString();
+
+     Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put(TodoController.LIMIT_KEY, Arrays.asList(new String[] {targetLimitString}));
+      //Whenever the TodoController would use queryParamMap; provide the desired limit instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use queryParam; provide the desired limit instead.
+      when(ctx.queryParam(TodoController.LIMIT_KEY)).thenReturn(targetLimitString);
+
+      todoController.getTodos(ctx);
+      //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+      // Confirm we get back 3 of the 4 todos.
+      assertEquals(3, todoArrayListCaptor.getValue().size());
+  }
+
+  @Test
+  void testCompleteTodos() throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+      queryParams.put(TodoController.STATUS_KEY, Arrays.asList(new String[] {"complete"}));
+      //Whenever the TodoController would use queryParamMap; provide the tests's queryParams instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use queryParam; provide the string "complete" instead.
+      when(ctx.queryParam(TodoController.STATUS_KEY)).thenReturn("complete");
+
+      //Validator is only necessary if we're using 'queryParamAsClass.' In this case, we're just expecting a raw string.
+      Validation validation = new Validation();
+      Validator<String> validator = validation.validator(TodoController.STATUS_KEY, String.class, "complete");
+      when(ctx.queryParamAsClass(TodoController.STATUS_KEY, String.class)).thenReturn(validator);
+
+      todoController.getTodos(ctx);
+    //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+      // Confirm that all the todos passed to `json` are in fact complete
+      for (Todo todo : todoArrayListCaptor.getValue()) {
+        assertEquals("true", todo.status); //Weird the database doesn't consider this a boolean.
+      }
+  }
+
+  @Test
+  void testIncompleteTodos() throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+      queryParams.put(TodoController.STATUS_KEY, Arrays.asList(new String[] {"incomplete"}));
+      //Whenever the TodoController would use queryParamMap; provide the tests's queryParams instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use queryParam; provide the string "incomplete" instead.
+      when(ctx.queryParam(TodoController.STATUS_KEY)).thenReturn("incomplete");
+
+      //Validator is only necessary if we're using 'queryParamAsClass.' In this case, we're just expecting a raw string.
+      Validation validation = new Validation();
+      Validator<String> validator = validation.validator(TodoController.STATUS_KEY, String.class, "incomplete");
+      when(ctx.queryParamAsClass(TodoController.STATUS_KEY, String.class)).thenReturn(validator);
+
+      todoController.getTodos(ctx);
+    //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+      // Confirm that all the todos passed to `json` are in fact complete
+      for (Todo todo : todoArrayListCaptor.getValue()) {
+        assertEquals("false", todo.status);
+      }
+  }
+
+  @Test
+  void listTodosByBody() throws IOException {
+     Map<String, List<String>> queryParams = new HashMap<>();
+      queryParams.put(TodoController.BODY_KEY, Arrays.asList(new String[] {"thing"}));
+      //Whenever the TodoController would use queryParamMap; provide the tests's queryParams instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use queryParam; provide the string "homework" instead.
+      when(ctx.queryParam(TodoController.BODY_KEY)).thenReturn("thing");
+
+      todoController.getTodos(ctx);
+    //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+      // All four provided todos have 'things' in their body.
+     assertEquals(4, todoArrayListCaptor.getValue().size());
+  }
+
+  @Test
+  void orderTodosByCategory() throws IOException {
+     Map<String, List<String>> queryParams = new HashMap<>();
+      queryParams.put(TodoController.ORDER_KEY, Arrays.asList(new String[] {TodoController.CATEGORY_KEY}));
+      //Whenever the TodoController would use queryParamMap; provide the tests's queryParams instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use queryParam; provide the string desired order method instead.
+      when(ctx.queryParam(TodoController.ORDER_KEY)).thenReturn(TodoController.CATEGORY_KEY);
+
+    Validation validation = new Validation();
+    Validator<String> validator =
+        validation.validator(TodoController.ORDER_KEY, String.class, TodoController.CATEGORY_KEY);
+    when(ctx.queryParamAsClass(TodoController.ORDER_KEY, String.class)).thenReturn(validator);
+
+      todoController.getTodos(ctx);
+    //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+    // The category 'alphabetizing' is alphabetically first. Therefore the first element
+     assertEquals("alphabetizing", todoArrayListCaptor.getValue().getFirst().category);
+  }
+
+  @Test
+  void categoryCombination() throws IOException {
+    Map<String, List<String>> queryParams = new HashMap<>();
+      queryParams.put(TodoController.CATEGORY_KEY, Arrays.asList(new String[] {"homework"}));
+      queryParams.put(TodoController.OWNER_KEY, Arrays.asList(new String[] {"Alfred"}));
+      queryParams.put(TodoController.STATUS_KEY, Arrays.asList(new String[] {"incomplete"}));
+      //Whenever the TodoController would use queryParamMap; provide the tests's queryParams instead.
+      when(ctx.queryParamMap()).thenReturn(queryParams);
+      //Whenever the TodoController would use just queryParam; provide the string desired order method instead.
+      when(ctx.queryParam(TodoController.CATEGORY_KEY)).thenReturn("homework");
+      when(ctx.queryParam(TodoController.OWNER_KEY)).thenReturn("Alfred");
+      when(ctx.queryParam(TodoController.STATUS_KEY)).thenReturn("incomplete");
+
+    //Status uses queryParamAsClass, and therefore needs a validator.
+    Validation validation = new Validation();
+    Validator<String> validator = validation.validator(TodoController.STATUS_KEY, String.class, "incomplete");
+    when(ctx.queryParamAsClass(TodoController.STATUS_KEY, String.class)).thenReturn(validator);
+
+
+      todoController.getTodos(ctx);
+    //Make sure we're capturing the results as an array.
+      verify(ctx).json(todoArrayListCaptor.capture());
+      verify(ctx).status(HttpStatus.OK);
+
+    // Only Alfred's Todo should fit all three filters.
+     assertEquals("Do the first thing", todoArrayListCaptor.getValue().getFirst().body);
+  }
+}


### PR DESCRIPTION
Added tests for each of TodoController's filters, as well as for combined filters and ordering. Modified todoController to use queryParam instead of queryParamAsClass where appropriate, and removed various unnecessary comments. Changed ORDER_KEY and BODY_KEY to match intended strings, and updated TodoController's body filter to account for the new discrepancy between property and key names.